### PR TITLE
feat(E4-S4): Submit Review + orphan detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ Thumbs.db
 .idea/
 *.swp
 *.swo
+*.db

--- a/packages/api/src/routes/annotations.ts
+++ b/packages/api/src/routes/annotations.ts
@@ -70,6 +70,7 @@ export function createAnnotationsRouter(): Router {
         quoted_text,
         content,
         parent_id,
+        review_id,
         author_type = 'human'
       } = req.body;
 
@@ -92,7 +93,7 @@ export function createAnnotationsRouter(): Router {
         quoted_text: quoted_text || null,
         content,
         parent_id: parent_id || null,
-        review_id: null,
+        review_id: review_id || null,
         user_id: 'dan',
         author_type,
         status: 'draft',
@@ -133,14 +134,14 @@ export function createAnnotationsRouter(): Router {
   });
 
   // PATCH /annotations/:id - Update annotation
-  router.patch('/annotations/:id', async (req: Request<{ id: string }, Annotation, Partial<Pick<Annotation, 'status' | 'content'>>>, res: Response<Annotation>) => {
+  router.patch('/annotations/:id', async (req: Request<{ id: string }, Annotation, Partial<Pick<Annotation, 'status' | 'content' | 'review_id'>>>, res: Response<Annotation>) => {
     try {
       const { id } = req.params;
-      const { status, content } = req.body;
+      const { status, content, review_id } = req.body;
 
-      if (!status && !content) {
+      if (!status && !content && review_id === undefined) {
         return res.status(400).json({
-          error: 'status or content must be provided',
+          error: 'status, content, or review_id must be provided',
         } as any);
       }
 
@@ -168,6 +169,11 @@ export function createAnnotationsRouter(): Router {
       if (content !== undefined) {
         updates.push('content = ?');
         params.push(content);
+      }
+
+      if (review_id !== undefined) {
+        updates.push('review_id = ?');
+        params.push(review_id);
       }
 
       updates.push('updated_at = ?');

--- a/packages/api/src/routes/reviews.ts
+++ b/packages/api/src/routes/reviews.ts
@@ -94,5 +94,71 @@ export function createReviewsRouter(): Router {
     }
   });
 
+  // PATCH /reviews/:id - Update review
+  router.patch('/reviews/:id', async (req: Request<{ id: string }, Review, Partial<Pick<Review, 'status' | 'submitted_at' | 'completed_at'>>>, res: Response<Review>) => {
+    try {
+      const { id } = req.params;
+      const { status, submitted_at, completed_at } = req.body;
+
+      if (!status && !submitted_at && !completed_at) {
+        return res.status(400).json({
+          error: 'status, submitted_at, or completed_at must be provided',
+        } as any);
+      }
+
+      const db = getDb();
+
+      // First check if review exists
+      const existingStmt = db.prepare('SELECT * FROM reviews WHERE id = ?');
+      const existing = existingStmt.get(id) as Review | undefined;
+
+      if (!existing) {
+        return res.status(404).json({
+          error: 'Review not found',
+        } as any);
+      }
+
+      const now = new Date().toISOString();
+      const updates: string[] = [];
+      const params: any[] = [];
+
+      if (status !== undefined) {
+        updates.push('status = ?');
+        params.push(status);
+      }
+
+      if (submitted_at !== undefined) {
+        updates.push('submitted_at = ?');
+        params.push(submitted_at);
+      }
+
+      if (completed_at !== undefined) {
+        updates.push('completed_at = ?');
+        params.push(completed_at);
+      }
+
+      updates.push('updated_at = ?');
+      params.push(now);
+      params.push(id);
+
+      const updateStmt = db.prepare(`
+        UPDATE reviews
+        SET ${updates.join(', ')}
+        WHERE id = ?
+      `);
+
+      updateStmt.run(...params);
+
+      // Fetch updated review
+      const updatedReview = existingStmt.get(id) as Review;
+      res.json(updatedReview);
+    } catch (error) {
+      console.error('Error updating review:', error);
+      res.status(500).json({
+        error: 'Failed to update review',
+      } as any);
+    }
+  });
+
   return router;
 }

--- a/packages/api/src/types/annotations.ts
+++ b/packages/api/src/types/annotations.ts
@@ -36,6 +36,7 @@ export interface CreateAnnotationBody {
   quoted_text?: string;
   content: string;
   parent_id?: string;
+  review_id?: string;
   author_type?: AuthorType;
 }
 

--- a/packages/site/src/components/AnnotationThread.tsx
+++ b/packages/site/src/components/AnnotationThread.tsx
@@ -92,6 +92,105 @@ function jumpToSection(headingPath: string) {
   }
 }
 
+// Get current document heading paths (same format as CommentDraft uses)
+function getDocumentHeadings(): Set<string> {
+  const contentElement = document.querySelector('article.content');
+  if (!contentElement) return new Set();
+
+  const allHeadings = Array.from(contentElement.querySelectorAll('h1, h2, h3, h4, h5, h6'));
+  const headingPaths = new Set<string>();
+
+  for (const heading of allHeadings) {
+    const level = parseInt(heading.tagName.charAt(1));
+    const text = heading.textContent?.trim() || '';
+
+    // Build hierarchy - find all previous headings to build the path
+    const hierarchy: { level: number; text: string; prefix: string }[] = [];
+
+    for (const prevHeading of allHeadings) {
+      // Stop when we reach the current heading
+      if (prevHeading === heading) break;
+
+      // Only include headings that come before this one in document order
+      if (prevHeading.compareDocumentPosition(heading) & Node.DOCUMENT_POSITION_FOLLOWING) {
+        const prevLevel = parseInt(prevHeading.tagName.charAt(1));
+        const prevText = prevHeading.textContent?.trim() || '';
+        const prevPrefix = '#'.repeat(prevLevel);
+
+        // Build hierarchy - keep only headings that form a proper hierarchy
+        while (hierarchy.length > 0 && hierarchy[hierarchy.length - 1].level >= prevLevel) {
+          hierarchy.pop();
+        }
+
+        hierarchy.push({ level: prevLevel, text: prevText, prefix: prevPrefix });
+      }
+    }
+
+    // Add current heading to hierarchy
+    const prefix = '#'.repeat(level);
+    hierarchy.push({ level, text, prefix });
+
+    // Build the full path
+    const fullPath = hierarchy.map(h => `${h.prefix} ${h.text}`).join(' > ');
+    headingPaths.add(fullPath);
+  }
+
+  return headingPaths;
+}
+
+// Generate content hash for a section (similar to CommentDraft)
+async function getSectionContentHash(headingPath: string): Promise<string> {
+  const contentElement = document.querySelector('article.content');
+  if (!contentElement) return '';
+
+  // Parse the last segment to find the heading
+  const segments = headingPath.split(' > ');
+  const lastSegment = segments[segments.length - 1];
+  const headingText = lastSegment.replace(/^#+\s*/, '').trim();
+
+  // Find the heading element
+  const allHeadings = Array.from(contentElement.querySelectorAll('h1, h2, h3, h4, h5, h6'));
+  let currentHeading: Element | null = null;
+
+  for (const heading of allHeadings) {
+    if (heading.textContent?.trim() === headingText) {
+      currentHeading = heading;
+      break;
+    }
+  }
+
+  if (!currentHeading) return '';
+
+  // Get all content from this heading until the next heading of equal or higher level
+  const currentLevel = parseInt(currentHeading.tagName.charAt(1));
+  let sectionText = currentHeading.textContent || '';
+  let nextElement = currentHeading.nextElementSibling;
+
+  while (nextElement) {
+    const tagName = nextElement.tagName?.toLowerCase();
+    if (tagName && tagName.match(/^h[1-6]$/)) {
+      const nextLevel = parseInt(tagName.charAt(1));
+      if (nextLevel <= currentLevel) {
+        break; // Found next section
+      }
+    }
+
+    sectionText += nextElement.textContent || '';
+    nextElement = nextElement.nextElementSibling;
+  }
+
+  // Generate SHA-256 hash
+  try {
+    const encoder = new TextEncoder();
+    const data = encoder.encode(sectionText.trim());
+    const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+    const hashArray = Array.from(new Uint8Array(hashBuffer));
+    return hashArray.map(b => b.toString(16).padStart(2, '0')).join('');
+  } catch {
+    return '';
+  }
+}
+
 export default function AnnotationThread({ docPath, apiBaseUrl = 'http://localhost:3001' }: Props) {
   const [annotations, setAnnotations] = useState<Annotation[]>([]);
   const [loading, setLoading] = useState(true);
@@ -100,6 +199,67 @@ export default function AnnotationThread({ docPath, apiBaseUrl = 'http://localho
   const [expandedReviews, setExpandedReviews] = useState<Set<string>>(new Set());
   const [expandedResolved, setExpandedResolved] = useState<Set<string>>(new Set());
   const [showOrphaned, setShowOrphaned] = useState(false);
+
+  // Helper to update annotation status via API
+  const patchAnnotation = useCallback(async (id: string, updates: Partial<Pick<Annotation, 'status'>>) => {
+    try {
+      const response = await fetch(`${apiBaseUrl}/annotations/${id}`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(updates)
+      });
+
+      if (!response.ok) {
+        console.warn(`Failed to update annotation ${id}:`, response.status);
+        return false;
+      }
+
+      return true;
+    } catch (err) {
+      console.warn(`Error updating annotation ${id}:`, err);
+      return false;
+    }
+  }, [apiBaseUrl]);
+
+  // Detect orphaned annotations and content drift
+  const detectOrphansAndDrift = useCallback(async (annotations: Annotation[]): Promise<Annotation[]> => {
+    const headings = getDocumentHeadings();
+    const updatedAnnotations: Annotation[] = [];
+
+    for (const annotation of annotations) {
+      let updatedAnnotation = { ...annotation };
+
+      // Check if heading path exists in current document
+      const pathExists = headings.has(annotation.heading_path);
+
+      if (!pathExists && annotation.status !== 'orphaned') {
+        // Mark as orphaned
+        const success = await patchAnnotation(annotation.id, { status: 'orphaned' });
+        if (success) {
+          updatedAnnotation.status = 'orphaned';
+        }
+      }
+
+      // Content drift detection: heading exists but hash changed
+      if (pathExists && annotation.status !== 'orphaned') {
+        try {
+          const currentHash = await getSectionContentHash(annotation.heading_path);
+          if (currentHash && currentHash !== annotation.content_hash) {
+            // Add a flag for UI display (the UI already handles ⚠️ display)
+            updatedAnnotation = { ...updatedAnnotation, drifted: true } as Annotation & { drifted?: boolean };
+          }
+        } catch (err) {
+          console.warn('Error calculating content hash for drift detection:', err);
+        }
+      }
+
+      updatedAnnotations.push(updatedAnnotation);
+    }
+
+    return updatedAnnotations;
+  }, [patchAnnotation]);
 
   // Load panel visibility from localStorage
   useEffect(() => {
@@ -120,33 +280,49 @@ export default function AnnotationThread({ docPath, apiBaseUrl = 'http://localho
   }, [isVisible]);
 
   // Fetch annotations
-  useEffect(() => {
-    async function fetchAnnotations() {
-      setLoading(true);
-      setError(null);
+  const fetchAnnotations = useCallback(async () => {
+    setLoading(true);
+    setError(null);
 
-      try {
-        const response = await fetch(`${apiBaseUrl}/annotations?doc_path=${encodeURIComponent(docPath)}`);
+    try {
+      const response = await fetch(`${apiBaseUrl}/annotations?doc_path=${encodeURIComponent(docPath)}`);
 
-        if (!response.ok) {
-          throw new Error(`HTTP ${response.status}`);
-        }
-
-        const data = await response.json();
-        setAnnotations(data);
-      } catch (err) {
-        console.warn('Failed to fetch annotations:', err);
-        setError('Unable to load comments');
-        setAnnotations([]);
-      } finally {
-        setLoading(false);
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
       }
-    }
 
+      const data = await response.json();
+
+      // Run orphan detection and content drift detection
+      const processedAnnotations = await detectOrphansAndDrift(data);
+      setAnnotations(processedAnnotations);
+    } catch (err) {
+      console.warn('Failed to fetch annotations:', err);
+      setError('Unable to load comments');
+      setAnnotations([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [docPath, apiBaseUrl, detectOrphansAndDrift]);
+
+  useEffect(() => {
     if (docPath) {
       fetchAnnotations();
     }
-  }, [docPath, apiBaseUrl]);
+  }, [docPath, fetchAnnotations]);
+
+  // Listen for review submission events to refetch annotations
+  useEffect(() => {
+    const handleReviewSubmitted = () => {
+      fetchAnnotations();
+    };
+
+    window.addEventListener('foundry-review-submitted', handleReviewSubmitted);
+
+    return () => {
+      window.removeEventListener('foundry-review-submitted', handleReviewSubmitted);
+    };
+  }, [fetchAnnotations]);
 
   // Add section margin indicators
   useEffect(() => {
@@ -267,9 +443,11 @@ export default function AnnotationThread({ docPath, apiBaseUrl = 'http://localho
     return topLevel.map(addReplies);
   };
 
-  const renderAnnotation = (annotation: Annotation & { replies?: Annotation[] }, isReply = false) => {
+  const renderAnnotation = (annotation: Annotation & { replies?: Annotation[]; drifted?: boolean }, isReply = false) => {
     const isResolved = annotation.status === 'resolved';
     const isDraft = annotation.status === 'draft';
+    const isOrphaned = annotation.status === 'orphaned';
+    const isDrifted = annotation.drifted || false;
     const expanded = expandedResolved.has(annotation.id);
 
     return (
@@ -290,6 +468,7 @@ export default function AnnotationThread({ docPath, apiBaseUrl = 'http://localho
             <div className="thread-comment-header">
               <span className={`thread-comment-status ${isDraft ? 'thread-comment-status--dimmed' : ''}`}>
                 {getStatusIcon(annotation.status, !!annotation.replies?.length)}
+                {isDrifted && <span className="thread-comment-drift" title="Content has changed since this comment was made">⚠️</span>}
               </span>
               <span className="thread-comment-author">
                 {getAuthorBadge(annotation.author_type, annotation.user_id)}
@@ -312,6 +491,12 @@ export default function AnnotationThread({ docPath, apiBaseUrl = 'http://localho
                 </button>
               )}
             </div>
+
+            {isOrphaned && (
+              <div className="thread-comment-orphan-context">
+                <strong>Original section:</strong> {annotation.heading_path}
+              </div>
+            )}
 
             {annotation.quoted_text && (
               <blockquote className="thread-comment-quote">

--- a/packages/site/src/components/CommentDraft.tsx
+++ b/packages/site/src/components/CommentDraft.tsx
@@ -1,14 +1,11 @@
 import { useState, useEffect, useRef } from 'react';
-
-interface DraftComment {
-  id: string;
-  doc_path: string;
-  heading_path: string;
-  content_hash: string;
-  quoted_text: string;
-  content: string;
-  created_at: string;
-}
+import {
+  type DraftComment,
+  getDrafts,
+  saveDraft,
+  updateDraft,
+  deleteDraft
+} from '../utils/draft-storage.js';
 
 interface Props {
   docPath: string;
@@ -382,57 +379,3 @@ export default function CommentDraft({ docPath }: Props) {
   );
 }
 
-// localStorage utility functions
-function getDrafts(docPath: string): DraftComment[] {
-  try {
-    const key = `foundry-drafts-${docPath}`;
-    const stored = localStorage.getItem(key);
-    return stored ? JSON.parse(stored) : [];
-  } catch {
-    return [];
-  }
-}
-
-function saveDraft(docPath: string, draft: DraftComment): void {
-  try {
-    const key = `foundry-drafts-${docPath}`;
-    const existing = getDrafts(docPath);
-    const updated = [...existing, draft];
-    localStorage.setItem(key, JSON.stringify(updated));
-  } catch {
-    // Silently fail if localStorage is unavailable
-  }
-}
-
-function updateDraft(docPath: string, draftId: string, content: string): void {
-  try {
-    const key = `foundry-drafts-${docPath}`;
-    const existing = getDrafts(docPath);
-    const updated = existing.map(draft => 
-      draft.id === draftId ? { ...draft, content } : draft
-    );
-    localStorage.setItem(key, JSON.stringify(updated));
-  } catch {
-    // Silently fail if localStorage is unavailable
-  }
-}
-
-function deleteDraft(docPath: string, draftId: string): void {
-  try {
-    const key = `foundry-drafts-${docPath}`;
-    const existing = getDrafts(docPath);
-    const updated = existing.filter(draft => draft.id !== draftId);
-    localStorage.setItem(key, JSON.stringify(updated));
-  } catch {
-    // Silently fail if localStorage is unavailable
-  }
-}
-
-function clearDrafts(docPath: string): void {
-  try {
-    const key = `foundry-drafts-${docPath}`;
-    localStorage.removeItem(key);
-  } catch {
-    // Silently fail if localStorage is unavailable
-  }
-}

--- a/packages/site/src/components/SubmitReview.tsx
+++ b/packages/site/src/components/SubmitReview.tsx
@@ -1,0 +1,202 @@
+import { useState, useEffect } from 'react';
+import { getDrafts, clearDrafts, type DraftComment } from '../utils/draft-storage.js';
+
+interface Props {
+  docPath: string;
+  apiBaseUrl?: string;
+}
+
+interface SubmissionState {
+  isSubmitting: boolean;
+  error: string | null;
+  success: boolean;
+}
+
+export default function SubmitReview({ docPath, apiBaseUrl = 'http://localhost:3001' }: Props) {
+  const [drafts, setDrafts] = useState<DraftComment[]>([]);
+  const [submissionState, setSubmissionState] = useState<SubmissionState>({
+    isSubmitting: false,
+    error: null,
+    success: false
+  });
+
+  // Load drafts on mount and when docPath changes
+  useEffect(() => {
+    const loadedDrafts = getDrafts(docPath);
+    setDrafts(loadedDrafts);
+  }, [docPath]);
+
+  // Listen for localStorage changes to keep drafts in sync
+  useEffect(() => {
+    const handleStorageChange = () => {
+      const loadedDrafts = getDrafts(docPath);
+      setDrafts(loadedDrafts);
+    };
+
+    window.addEventListener('storage', handleStorageChange);
+    // Also listen for custom events from CommentDraft operations
+    window.addEventListener('foundry-draft-updated', handleStorageChange);
+
+    return () => {
+      window.removeEventListener('storage', handleStorageChange);
+      window.removeEventListener('foundry-draft-updated', handleStorageChange);
+    };
+  }, [docPath]);
+
+  const handleSubmit = async () => {
+    if (drafts.length === 0) return;
+
+    const confirmMessage = `Submit ${drafts.length} comment${drafts.length > 1 ? 's' : ''} for review?`;
+    if (!window.confirm(confirmMessage)) {
+      return;
+    }
+
+    setSubmissionState({
+      isSubmitting: true,
+      error: null,
+      success: false
+    });
+
+    try {
+      // Step 1: Create the review
+      const reviewResponse = await fetch(`${apiBaseUrl}/reviews`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          doc_path: docPath
+        })
+      });
+
+      if (!reviewResponse.ok) {
+        throw new Error(`Failed to create review: HTTP ${reviewResponse.status}`);
+      }
+
+      const review = await reviewResponse.json();
+      const reviewId = review.id;
+
+      // Step 2: Submit each draft as an annotation
+      const annotationPromises = drafts.map(async (draft) => {
+        // Create annotation
+        const annotationResponse = await fetch(`${apiBaseUrl}/annotations`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            doc_path: draft.doc_path,
+            heading_path: draft.heading_path,
+            content_hash: draft.content_hash,
+            quoted_text: draft.quoted_text,
+            content: draft.content,
+            author_type: 'human',
+            review_id: reviewId
+          })
+        });
+
+        if (!annotationResponse.ok) {
+          throw new Error(`Failed to create annotation: HTTP ${annotationResponse.status}`);
+        }
+
+        const annotation = await annotationResponse.json();
+
+        // Update status to submitted
+        const patchResponse = await fetch(`${apiBaseUrl}/annotations/${annotation.id}`, {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            status: 'submitted'
+          })
+        });
+
+        if (!patchResponse.ok) {
+          throw new Error(`Failed to update annotation status: HTTP ${patchResponse.status}`);
+        }
+
+        return annotation;
+      });
+
+      await Promise.all(annotationPromises);
+
+      // Step 3: Update review status to submitted
+      const reviewPatchResponse = await fetch(`${apiBaseUrl}/reviews/${reviewId}`, {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          status: 'submitted',
+          submitted_at: new Date().toISOString()
+        })
+      });
+
+      if (!reviewPatchResponse.ok) {
+        throw new Error(`Failed to update review status: HTTP ${reviewPatchResponse.status}`);
+      }
+
+      // Step 4: Clear localStorage drafts
+      clearDrafts(docPath);
+      setDrafts([]);
+
+      // Step 5: Show success and trigger refetch
+      setSubmissionState({
+        isSubmitting: false,
+        error: null,
+        success: true
+      });
+
+      // Dispatch custom event to trigger AnnotationThread refetch
+      window.dispatchEvent(new CustomEvent('foundry-review-submitted'));
+
+      // Clear success message after 3 seconds
+      setTimeout(() => {
+        setSubmissionState(prev => ({ ...prev, success: false }));
+      }, 3000);
+
+    } catch (error) {
+      console.error('Error submitting review:', error);
+      setSubmissionState({
+        isSubmitting: false,
+        error: error instanceof Error ? error.message : 'Failed to submit review',
+        success: false
+      });
+    }
+  };
+
+  // Don't render if no drafts
+  if (drafts.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="submit-review">
+      <button
+        className={`submit-review__button ${submissionState.isSubmitting ? 'submit-review__button--loading' : ''}`}
+        onClick={handleSubmit}
+        disabled={submissionState.isSubmitting}
+        title={`Submit ${drafts.length} comment${drafts.length > 1 ? 's' : ''} for review`}
+      >
+        {submissionState.isSubmitting ? (
+          <>🔄 Submitting...</>
+        ) : (
+          <>📤 Submit Review ({drafts.length})</>
+        )}
+      </button>
+
+      {submissionState.success && (
+        <div className="submit-review__success">
+          ✅ Review submitted!
+        </div>
+      )}
+
+      {submissionState.error && (
+        <div className="submit-review__error">
+          ❌ {submissionState.error}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/site/src/layouts/DocLayout.astro
+++ b/packages/site/src/layouts/DocLayout.astro
@@ -8,6 +8,7 @@ import PlayAllManager from '../components/PlayAllManager.tsx';
 import TtsControlsBar from '../components/TtsControlsBar.tsx';
 import AnnotationThread from '../components/AnnotationThread.tsx';
 import CommentDraft from '../components/CommentDraft.tsx';
+import SubmitReview from '../components/SubmitReview.tsx';
 
 interface Props {
   title?: string;
@@ -72,6 +73,12 @@ const apiBaseUrl = import.meta.env.API_BASE_URL || 'http://localhost:3001';
         <CommentDraft docPath={currentPath} client:load />
       </article>
     </main>
+
+    <SubmitReview
+      docPath={currentPath}
+      apiBaseUrl={apiBaseUrl}
+      client:load
+    />
 
     <AnnotationThread
       docPath={currentPath}

--- a/packages/site/src/styles/global.css
+++ b/packages/site/src/styles/global.css
@@ -1447,3 +1447,123 @@ pre.mermaid {
   }
 }
 
+/* ============================================
+   Submit Review Component Styles
+   ============================================ */
+
+.submit-review {
+  position: fixed;
+  top: calc(var(--header-height) + var(--spacing-md));
+  right: calc(var(--thread-panel-width) + var(--spacing-md));
+  z-index: 20;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-xs);
+}
+
+.submit-review__button {
+  background: var(--color-accent);
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: var(--spacing-sm) var(--spacing-md);
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+  cursor: pointer;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  transition: all var(--transition-fast);
+  white-space: nowrap;
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+}
+
+.submit-review__button:hover:not(:disabled) {
+  background: var(--color-accent-hover);
+  transform: translateY(-1px);
+  box-shadow: 0 3px 12px rgba(0, 0, 0, 0.2);
+}
+
+.submit-review__button:disabled {
+  background: var(--color-text-muted);
+  cursor: not-allowed;
+  transform: none;
+}
+
+.submit-review__button--loading {
+  animation: submitPulse 1.5s infinite;
+}
+
+@keyframes submitPulse {
+  0%, 100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.7;
+  }
+}
+
+.submit-review__success {
+  background: var(--color-tip-bg);
+  color: var(--color-tip-border);
+  border: 1px solid var(--color-tip-border);
+  border-radius: 6px;
+  padding: var(--spacing-xs) var(--spacing-sm);
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+  animation: fadeIn 0.3s ease-out;
+}
+
+.submit-review__error {
+  background: var(--color-danger-bg);
+  color: var(--color-danger-border);
+  border: 1px solid var(--color-danger-border);
+  border-radius: 6px;
+  padding: var(--spacing-xs) var(--spacing-sm);
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+  animation: fadeIn 0.3s ease-out;
+}
+
+/* Content drift indicator */
+.thread-comment-drift {
+  margin-left: var(--spacing-xs);
+  font-size: 0.8em;
+  opacity: 0.8;
+}
+
+/* Orphaned comment context */
+.thread-comment-orphan-context {
+  background: var(--color-warning-bg);
+  border: 1px solid var(--color-warning-border);
+  border-radius: 4px;
+  padding: var(--spacing-xs) var(--spacing-sm);
+  margin-bottom: var(--spacing-sm);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+}
+
+/* Mobile adjustments */
+@media (max-width: 1024px) {
+  .submit-review {
+    position: static;
+    padding: var(--spacing-md);
+    background: var(--color-bg-secondary);
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  .submit-review__button {
+    width: 100%;
+    justify-content: center;
+  }
+}
+
+/* Dark theme adjustments */
+[data-theme="dark"] .submit-review__button {
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+}
+
+[data-theme="dark"] .submit-review__button:hover:not(:disabled) {
+  box-shadow: 0 3px 12px rgba(0, 0, 0, 0.4);
+}
+

--- a/packages/site/src/utils/draft-storage.ts
+++ b/packages/site/src/utils/draft-storage.ts
@@ -1,0 +1,78 @@
+export interface DraftComment {
+  id: string;
+  doc_path: string;
+  heading_path: string;
+  content_hash: string;
+  quoted_text: string;
+  content: string;
+  created_at: string;
+}
+
+/**
+ * Get all drafts for a specific document path from localStorage
+ */
+export function getDrafts(docPath: string): DraftComment[] {
+  try {
+    const key = `foundry-drafts-${docPath}`;
+    const stored = localStorage.getItem(key);
+    return stored ? JSON.parse(stored) : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Save a new draft to localStorage
+ */
+export function saveDraft(docPath: string, draft: DraftComment): void {
+  try {
+    const key = `foundry-drafts-${docPath}`;
+    const existing = getDrafts(docPath);
+    const updated = [...existing, draft];
+    localStorage.setItem(key, JSON.stringify(updated));
+  } catch {
+    // Silently fail if localStorage is unavailable
+  }
+}
+
+/**
+ * Update the content of an existing draft
+ */
+export function updateDraft(docPath: string, draftId: string, content: string): void {
+  try {
+    const key = `foundry-drafts-${docPath}`;
+    const existing = getDrafts(docPath);
+    const updated = existing.map(draft =>
+      draft.id === draftId ? { ...draft, content } : draft
+    );
+    localStorage.setItem(key, JSON.stringify(updated));
+  } catch {
+    // Silently fail if localStorage is unavailable
+  }
+}
+
+/**
+ * Delete a specific draft
+ */
+export function deleteDraft(docPath: string, draftId: string): void {
+  try {
+    const key = `foundry-drafts-${docPath}`;
+    const existing = getDrafts(docPath);
+    const updated = existing.filter(draft => draft.id !== draftId);
+    localStorage.setItem(key, JSON.stringify(updated));
+  } catch {
+    // Silently fail if localStorage is unavailable
+  }
+}
+
+/**
+ * Clear all drafts for a document path
+ */
+export function clearDrafts(docPath: string): void {
+  try {
+    const key = `foundry-drafts-${docPath}`;
+    localStorage.removeItem(key);
+  } catch {
+    // Silently fail if localStorage is unavailable
+  }
+}


### PR DESCRIPTION
## What

Bridges draft creation (S3) and thread display (S2):
- Submit Review button: collects localStorage drafts → creates review batch → persists to SQLite → clears drafts
- Thread panel auto-refreshes via custom event after submission
- Orphan detection on page load (heading path comparison)
- Content drift detection (hash comparison with ⚠️ indicator)
- PATCH /reviews/:id endpoint for review status tracking
- review_id support in POST/PATCH /annotations
- Shared draft-storage module extracted from CommentDraft
- Error handling preserves drafts on API failure

## Stories
- E4-S4: Submit Review + Orphan Detection (Batch 3)

## Testing
- npm run build (site + api) ✅
- Annotation + review tests ✅