### PR TITLE
feat(E4-S5): MCP annotation tools — real implementations

### DIFF
--- a/packages/api/src/mcp/__tests__/annotation-tools.test.ts
+++ b/packages/api/src/mcp/__tests__/annotation-tools.test.ts
@@ -1,0 +1,256 @@
+import { beforeEach, afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { getDb, closeDb } from '../../db.js';
+import { 
+  listAnnotations, 
+  createAnnotation, 
+  resolveAnnotation, 
+  submitReview 
+} from '../tools/annotations.js';
+
+// Mock the db module to use a test database
+let testDbPath: string;
+
+beforeEach(() => {
+  // Create a temporary directory for test database
+  const tempDir = mkdtempSync(join(tmpdir(), 'foundry-test-'));
+  testDbPath = join(tempDir, 'test.db');
+  process.env.FOUNDRY_DB_PATH = testDbPath;
+  
+  // Initialize the test database
+  const db = getDb();
+  
+  // Create tables
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS annotations (
+      id TEXT PRIMARY KEY,
+      doc_path TEXT NOT NULL,
+      heading_path TEXT,
+      content_hash TEXT,
+      quoted_text TEXT,
+      content TEXT NOT NULL,
+      parent_id TEXT,
+      review_id TEXT,
+      user_id TEXT NOT NULL,
+      author_type TEXT NOT NULL CHECK (author_type IN ('human', 'ai')),
+      status TEXT NOT NULL CHECK (status IN ('draft', 'submitted', 'replied', 'resolved', 'orphaned')),
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS reviews (
+      id TEXT PRIMARY KEY,
+      doc_path TEXT NOT NULL,
+      user_id TEXT NOT NULL,
+      status TEXT NOT NULL CHECK (status IN ('draft', 'submitted', 'approved', 'rejected')),
+      submitted_at TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+  `);
+});
+
+afterEach(() => {
+  // Clean up test database
+  closeDb();
+  if (testDbPath) {
+    try {
+      rmSync(testDbPath, { recursive: true, force: true });
+    } catch (error) {
+      // Ignore cleanup errors
+    }
+  }
+  delete process.env.FOUNDRY_DB_PATH;
+});
+
+describe('listAnnotations', () => {
+  it('should list annotations for a doc_path', () => {
+    const annotation = createAnnotation({
+      doc_path: 'test-doc.md',
+      section: 'intro',
+      content: 'Test annotation'
+    });
+
+    const results = listAnnotations('test-doc.md');
+    expect(results).toHaveLength(1);
+    expect(results[0].id).toBe(annotation.id);
+    expect(results[0].content).toBe('Test annotation');
+  });
+
+  it('should filter by section', () => {
+    createAnnotation({
+      doc_path: 'test-doc.md',
+      section: 'intro',
+      content: 'Intro annotation'
+    });
+    createAnnotation({
+      doc_path: 'test-doc.md',
+      section: 'conclusion',
+      content: 'Conclusion annotation'
+    });
+
+    const results = listAnnotations('test-doc.md', 'intro');
+    expect(results).toHaveLength(1);
+    expect(results[0].content).toBe('Intro annotation');
+  });
+
+  it('should filter by status', () => {
+    createAnnotation({
+      doc_path: 'test-doc.md',
+      section: 'intro',
+      content: 'Draft annotation'
+    });
+    const resolved = createAnnotation({
+      doc_path: 'test-doc.md',
+      section: 'intro',
+      content: 'Resolved annotation'
+    });
+    resolveAnnotation(resolved.id);
+
+    const submittedResults = listAnnotations('test-doc.md', undefined, 'submitted');
+    expect(submittedResults).toHaveLength(1);
+    expect(submittedResults[0].content).toBe('Draft annotation');
+
+    const resolvedResults = listAnnotations('test-doc.md', undefined, 'resolved');
+    expect(resolvedResults).toHaveLength(1);
+    expect(resolvedResults[0].content).toBe('Resolved annotation');
+  });
+});
+
+describe('createAnnotation', () => {
+  it('should create annotation with default values', () => {
+    const annotation = createAnnotation({
+      doc_path: 'test-doc.md',
+      section: 'intro',
+      content: 'Test annotation'
+    });
+
+    expect(annotation.id).toBeTruthy();
+    expect(annotation.doc_path).toBe('test-doc.md');
+    expect(annotation.heading_path).toBe('intro');
+    expect(annotation.content).toBe('Test annotation');
+    expect(annotation.user_id).toBe('clay');
+    expect(annotation.author_type).toBe('ai');
+    expect(annotation.status).toBe('submitted');
+    expect(annotation.parent_id).toBeNull();
+    expect(annotation.created_at).toBeTruthy();
+    expect(annotation.updated_at).toBeTruthy();
+  });
+
+  it('should create reply annotation when parent_id provided', () => {
+    const parent = createAnnotation({
+      doc_path: 'test-doc.md',
+      section: 'intro',
+      content: 'Parent annotation'
+    });
+
+    const reply = createAnnotation({
+      doc_path: 'test-doc.md',
+      section: 'intro',
+      content: 'Reply annotation',
+      parent_id: parent.id
+    });
+
+    expect(reply.parent_id).toBe(parent.id);
+    expect(reply.status).toBe('replied');
+  });
+
+  it('should use custom author_type when provided', () => {
+    const annotation = createAnnotation({
+      doc_path: 'test-doc.md',
+      section: 'intro',
+      content: 'Human annotation',
+      author_type: 'human'
+    });
+
+    expect(annotation.author_type).toBe('human');
+  });
+});
+
+describe('resolveAnnotation', () => {
+  it('should resolve existing annotation', () => {
+    const annotation = createAnnotation({
+      doc_path: 'test-doc.md',
+      section: 'intro',
+      content: 'Test annotation'
+    });
+
+    const result = resolveAnnotation(annotation.id);
+
+    expect(result.status).toBe('resolved');
+    expect(result.annotation_id).toBe(annotation.id);
+
+    // Verify annotation is actually resolved in database
+    const resolved = listAnnotations('test-doc.md', undefined, 'resolved');
+    expect(resolved).toHaveLength(1);
+    expect(resolved[0].id).toBe(annotation.id);
+  });
+
+  it('should return error for non-existent annotation', () => {
+    const result = resolveAnnotation('non-existent-id');
+
+    expect(result.status).toBe('error');
+    expect(result.message).toBe('Annotation not found');
+  });
+});
+
+describe('submitReview', () => {
+  it('should create review with specified annotation IDs', () => {
+    const annotation1 = createAnnotation({
+      doc_path: 'test-doc.md',
+      section: 'intro',
+      content: 'First annotation'
+    });
+    const annotation2 = createAnnotation({
+      doc_path: 'test-doc.md',
+      section: 'conclusion',
+      content: 'Second annotation'
+    });
+
+    const result = submitReview('test-doc.md', [annotation1.id, annotation2.id]);
+
+    expect(result).toMatchObject({
+      status: 'review_submitted',
+      doc_path: 'test-doc.md',
+      comment_count: 2
+    });
+
+    expect((result as any).review_id).toBeTruthy();
+    expect((result as any).submitted_at).toBeTruthy();
+    expect((result as any).comments).toHaveLength(2);
+  });
+
+  it('should include all draft/submitted annotations when no IDs specified', () => {
+    createAnnotation({
+      doc_path: 'test-doc.md',
+      section: 'intro',
+      content: 'First annotation'
+    });
+    createAnnotation({
+      doc_path: 'test-doc.md',
+      section: 'conclusion',
+      content: 'Second annotation'
+    });
+
+    const result = submitReview('test-doc.md');
+
+    expect((result as any).comment_count).toBe(2);
+  });
+
+  it('should update annotation statuses to submitted', () => {
+    const annotation = createAnnotation({
+      doc_path: 'test-doc.md',
+      section: 'intro',
+      content: 'Test annotation'
+    });
+
+    submitReview('test-doc.md', [annotation.id]);
+
+    // Verify annotation status was updated
+    const updated = listAnnotations('test-doc.md', undefined, 'submitted');
+    expect(updated).toHaveLength(1);
+    expect(updated[0].id).toBe(annotation.id);
+  });
+});

--- a/packages/api/src/mcp/tools/annotations.ts
+++ b/packages/api/src/mcp/tools/annotations.ts
@@ -1,20 +1,129 @@
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import { getDb } from '../../db.js';
+import { createId } from '@paralleldrive/cuid2';
+import type { Annotation } from '../../types/annotations.js';
+
+/**
+ * Core annotation functions that can be tested
+ */
+export function listAnnotations(docPath: string, section?: string, status?: string): Annotation[] {
+  const db = getDb();
+  let query = 'SELECT * FROM annotations WHERE doc_path = ?';
+  const params: any[] = [docPath];
+
+  if (section) {
+    query += ' AND heading_path LIKE ?';
+    params.push(`%${section}%`);
+  }
+  if (status) {
+    query += ' AND status = ?';
+    params.push(status);
+  }
+
+  query += ' ORDER BY created_at DESC';
+  const rows = db.prepare(query).all(...params);
+  return rows as Annotation[];
+}
+
+export function createAnnotation(params: {
+  doc_path: string;
+  section: string;
+  content: string;
+  parent_id?: string;
+  author_type?: string
+}): Annotation {
+  const db = getDb();
+  const id = createId();
+  const now = new Date().toISOString();
+
+  const annotation = {
+    id,
+    doc_path: params.doc_path,
+    heading_path: params.section,
+    content_hash: '', // MCP callers don't need to provide this
+    quoted_text: null,
+    content: params.content,
+    parent_id: params.parent_id || null,
+    review_id: null,
+    user_id: 'clay',
+    author_type: params.author_type || 'ai',
+    status: params.parent_id ? 'replied' : 'submitted',
+    created_at: now,
+    updated_at: now,
+  } as Annotation;
+
+  // INSERT into annotations table
+  db.prepare(`INSERT INTO annotations (id, doc_path, heading_path, content_hash, quoted_text, content, parent_id, review_id, user_id, author_type, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`).run(
+    annotation.id, annotation.doc_path, annotation.heading_path, annotation.content_hash,
+    annotation.quoted_text, annotation.content, annotation.parent_id, annotation.review_id,
+    annotation.user_id, annotation.author_type, annotation.status, annotation.created_at, annotation.updated_at
+  );
+
+  return annotation;
+}
+
+export function resolveAnnotation(annotationId: string): { status: string; annotation_id?: string; message?: string } {
+  const db = getDb();
+
+  const existing = db.prepare('SELECT * FROM annotations WHERE id = ?').get(annotationId);
+  if (!existing) {
+    return { status: "error", message: "Annotation not found" };
+  }
+
+  const now = new Date().toISOString();
+  db.prepare('UPDATE annotations SET status = ?, updated_at = ? WHERE id = ?').run('resolved', now, annotationId);
+
+  return { status: "resolved", annotation_id: annotationId };
+}
+
+export function submitReview(docPath: string, annotationIds?: string[]): object {
+  const db = getDb();
+
+  // Create review record
+  const reviewId = createId();
+  const now = new Date().toISOString();
+  db.prepare('INSERT INTO reviews (id, doc_path, user_id, status, submitted_at, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)').run(
+    reviewId, docPath, 'dan', 'submitted', now, now, now
+  );
+
+  // Get annotations to include
+  let annotations: Annotation[];
+  if (annotationIds && annotationIds.length > 0) {
+    const placeholders = annotationIds.map(() => '?').join(',');
+    annotations = db.prepare(`SELECT * FROM annotations WHERE id IN (${placeholders})`).all(...annotationIds) as Annotation[];
+  } else {
+    // Default: all draft/submitted annotations for this doc
+    annotations = db.prepare('SELECT * FROM annotations WHERE doc_path = ? AND status IN (?, ?)').all(docPath, 'draft', 'submitted') as Annotation[];
+  }
+
+  // Update annotations with review_id and status
+  for (const ann of annotations) {
+    db.prepare('UPDATE annotations SET review_id = ?, status = ?, updated_at = ? WHERE id = ?').run(reviewId, 'submitted', now, ann.id);
+  }
+
+  // Build structured payload for OpenClaw
+  const payload = {
+    status: "review_submitted",
+    review_id: reviewId,
+    doc_path: docPath,
+    submitted_at: now,
+    comment_count: annotations.length,
+    comments: annotations.map(a => ({
+      id: a.id,
+      heading_path: a.heading_path,
+      quoted_text: a.quoted_text,
+      content: a.content,
+    })),
+  };
+
+  return payload;
+}
 
 /**
  * Register annotation tools with the MCP server
  */
 export function registerAnnotationTools(server: Server): void {
-  // Not implemented response helper
-  const notImplementedResponse = {
-    content: [{
-      type: "text" as const,
-      text: JSON.stringify({
-        status: "not_implemented",
-        message: "Annotation tools will be available in E4."
-      })
-    }]
-  };
 
   // Handle list tools request
   server.setRequestHandler(ListToolsRequestSchema, async () => {
@@ -33,6 +142,10 @@ export function registerAnnotationTools(server: Server): void {
               section: {
                 type: 'string',
                 description: 'Optional section filter'
+              },
+              status: {
+                type: 'string',
+                description: 'Optional status filter (draft, submitted, replied, resolved, orphaned)'
               }
             },
             required: ['doc_path']
@@ -59,6 +172,10 @@ export function registerAnnotationTools(server: Server): void {
               parent_id: {
                 type: 'string',
                 description: 'Optional parent annotation ID for threading'
+              },
+              author_type: {
+                type: 'string',
+                description: 'Optional author type (human or ai), defaults to ai for MCP callers'
               }
             },
             required: ['doc_path', 'section', 'content']
@@ -105,14 +222,45 @@ export function registerAnnotationTools(server: Server): void {
 
   // Handle tool calls
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
-    const { name } = request.params;
+    const { name, arguments: args } = request.params;
+    
+    if (!args) {
+      throw new Error('Tool arguments are required');
+    }
 
     switch (name) {
-      case 'list_annotations':
-      case 'create_annotation':
-      case 'resolve_annotation':
-      case 'submit_review':
-        return notImplementedResponse;
+      case 'list_annotations': {
+        const result = listAnnotations(
+          args.doc_path as string, 
+          args.section as string | undefined, 
+          args.status as string | undefined
+        );
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case 'create_annotation': {
+        const result = createAnnotation({
+          doc_path: args.doc_path as string,
+          section: args.section as string,
+          content: args.content as string,
+          parent_id: args.parent_id as string | undefined,
+          author_type: args.author_type as string | undefined
+        });
+        return { content: [{ type: "text", text: JSON.stringify({ status: "created", annotation: result }) }] };
+      }
+
+      case 'resolve_annotation': {
+        const result = resolveAnnotation(args.annotation_id as string);
+        return { content: [{ type: "text", text: JSON.stringify(result) }] };
+      }
+
+      case 'submit_review': {
+        const result = submitReview(
+          args.doc_path as string, 
+          args.annotation_ids as string[] | undefined
+        );
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
 
       default:
         throw new Error(`Unknown tool: ${name}`);


### PR DESCRIPTION
## What

Replaces E2 stub MCP tools with real SQLite-backed implementations:
- list_annotations: query with doc_path/section/status filters
- create_annotation: creates comments/replies (defaults to AI author for MCP callers)
- resolve_annotation: marks annotations as resolved
- submit_review: creates review batch, updates annotations, returns structured payload
- Core logic extracted into testable functions
- Test suite for all MCP tool operations
- E2 stub code removed

## Stories
- E4-S5: MCP Tool Implementation (Batch 4 — final E4 story)

## Testing
- npm run build ✅
- MCP tool tests ✅ (11 tests passing)
- Existing annotation/review tests still passing ✅ (34 tests)