### PR TITLE
feat(E4.5-S1): API route prefixing + relative URLs

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -116,19 +116,19 @@ async function startServer(): Promise<void> {
     });
 
     // Mount health router
-    app.use('/', createHealthRouter(anvil));
+    app.use('/api', createHealthRouter(anvil));
 
     // Mount docs router
-    app.use('/', createDocsRouter(anvil));
+    app.use('/api', createDocsRouter(anvil));
 
     // Mount search router
-    app.use('/', createSearchRouter(anvil));
+    app.use('/api', createSearchRouter(anvil));
 
     // Mount annotations router
-    app.use('/', createAnnotationsRouter());
+    app.use('/api', createAnnotationsRouter());
 
     // Mount reviews router
-    app.use('/', createReviewsRouter());
+    app.use('/api', createReviewsRouter());
 
     // Global error handler (must be last)
     app.use(errorHandler);
@@ -136,7 +136,7 @@ async function startServer(): Promise<void> {
     // Start the server
     app.listen(PORT, () => {
       console.log(`🚀 Foundry API server running on port ${PORT}`);
-      console.log(`📊 Health endpoint: http://localhost:${PORT}/health`);
+      console.log(`📊 Health endpoint: http://localhost:${PORT}/api/health`);
       console.log(`🔌 MCP SSE endpoint: http://localhost:${PORT}/mcp/sse`);
       console.log(`📨 MCP message endpoint: http://localhost:${PORT}/mcp/message`);
       console.log(`🌐 CORS enabled for GitHub Pages and localhost`);

--- a/packages/api/src/routes/__tests__/annotations.test.ts
+++ b/packages/api/src/routes/__tests__/annotations.test.ts
@@ -18,7 +18,7 @@ beforeAll(() => {
 
   app = express();
   app.use(express.json());
-  app.use('/', createAnnotationsRouter());
+  app.use('/api', createAnnotationsRouter());
 });
 
 afterAll(() => {
@@ -49,7 +49,7 @@ describe('Annotations Router', () => {
     it('should create an annotation with defaults', async () => {
       const body = validBody();
       const res = await request(app)
-        .post('/annotations')
+        .post('/api/annotations')
         .send(body)
         .expect(201);
 
@@ -70,7 +70,7 @@ describe('Annotations Router', () => {
 
     it('should accept optional quoted_text', async () => {
       const res = await request(app)
-        .post('/annotations')
+        .post('/api/annotations')
         .send(validBody({ quoted_text: 'some quoted text' }))
         .expect(201);
 
@@ -79,7 +79,7 @@ describe('Annotations Router', () => {
 
     it('should accept optional author_type of ai', async () => {
       const res = await request(app)
-        .post('/annotations')
+        .post('/api/annotations')
         .send(validBody({ author_type: 'ai' }))
         .expect(201);
 
@@ -88,7 +88,7 @@ describe('Annotations Router', () => {
 
     it('should return 400 when doc_path is missing', async () => {
       const res = await request(app)
-        .post('/annotations')
+        .post('/api/annotations')
         .send(validBody({ doc_path: '' }))
         .expect(400);
 
@@ -97,7 +97,7 @@ describe('Annotations Router', () => {
 
     it('should return 400 when heading_path is missing', async () => {
       const res = await request(app)
-        .post('/annotations')
+        .post('/api/annotations')
         .send(validBody({ heading_path: '' }))
         .expect(400);
 
@@ -106,7 +106,7 @@ describe('Annotations Router', () => {
 
     it('should return 400 when content_hash is missing', async () => {
       const res = await request(app)
-        .post('/annotations')
+        .post('/api/annotations')
         .send(validBody({ content_hash: '' }))
         .expect(400);
 
@@ -115,7 +115,7 @@ describe('Annotations Router', () => {
 
     it('should return 400 when content is missing', async () => {
       const res = await request(app)
-        .post('/annotations')
+        .post('/api/annotations')
         .send(validBody({ content: '' }))
         .expect(400);
 
@@ -124,7 +124,7 @@ describe('Annotations Router', () => {
 
     it('should return 400 with descriptive error message', async () => {
       const res = await request(app)
-        .post('/annotations')
+        .post('/api/annotations')
         .send({})
         .expect(400);
 
@@ -134,12 +134,12 @@ describe('Annotations Router', () => {
 
     it('should generate unique IDs for each annotation', async () => {
       const res1 = await request(app)
-        .post('/annotations')
+        .post('/api/annotations')
         .send(validBody())
         .expect(201);
 
       const res2 = await request(app)
-        .post('/annotations')
+        .post('/api/annotations')
         .send(validBody())
         .expect(201);
 
@@ -163,19 +163,19 @@ describe('Annotations Router', () => {
 
       seededIds = [];
       for (const body of bodies) {
-        const res = await request(app).post('/annotations').send(body).expect(201);
+        const res = await request(app).post('/api/annotations').send(body).expect(201);
         seededIds.push(res.body.id);
       }
 
       // Update one annotation status to 'submitted' for status filter testing
       await request(app)
-        .patch(`/annotations/${seededIds[0]}`)
+        .patch(`/api/annotations/${seededIds[0]}`)
         .send({ status: 'submitted' });
     });
 
     it('should return 400 when doc_path is missing', async () => {
       const res = await request(app)
-        .get('/annotations')
+        .get('/api/annotations')
         .expect(400);
 
       expect(res.body.error).toContain('doc_path');
@@ -183,7 +183,7 @@ describe('Annotations Router', () => {
 
     it('should return annotations filtered by doc_path', async () => {
       const res = await request(app)
-        .get('/annotations')
+        .get('/api/annotations')
         .query({ doc_path: 'get-test/doc.md' })
         .expect(200);
 
@@ -195,7 +195,7 @@ describe('Annotations Router', () => {
 
     it('should return empty array for unknown doc_path', async () => {
       const res = await request(app)
-        .get('/annotations')
+        .get('/api/annotations')
         .query({ doc_path: 'non-existent/path.md' })
         .expect(200);
 
@@ -204,7 +204,7 @@ describe('Annotations Router', () => {
 
     it('should filter by section (heading_path LIKE match)', async () => {
       const res = await request(app)
-        .get('/annotations')
+        .get('/api/annotations')
         .query({ doc_path: 'get-test/doc.md', section: 'Section A' })
         .expect(200);
 
@@ -216,7 +216,7 @@ describe('Annotations Router', () => {
 
     it('should filter by status', async () => {
       const res = await request(app)
-        .get('/annotations')
+        .get('/api/annotations')
         .query({ doc_path: 'get-test/doc.md', status: 'submitted' })
         .expect(200);
 
@@ -226,7 +226,7 @@ describe('Annotations Router', () => {
 
     it('should combine section and status filters', async () => {
       const res = await request(app)
-        .get('/annotations')
+        .get('/api/annotations')
         .query({ doc_path: 'get-test/doc.md', section: 'Section A', status: 'submitted' })
         .expect(200);
 
@@ -237,7 +237,7 @@ describe('Annotations Router', () => {
 
     it('should return results ordered by created_at DESC', async () => {
       const res = await request(app)
-        .get('/annotations')
+        .get('/api/annotations')
         .query({ doc_path: 'get-test/doc.md' })
         .expect(200);
 
@@ -254,7 +254,7 @@ describe('Annotations Router', () => {
 
     beforeAll(async () => {
       const res = await request(app)
-        .post('/annotations')
+        .post('/api/annotations')
         .send(validBody({ doc_path: 'patch-test/doc.md', content: 'original content' }))
         .expect(201);
       annotationId = res.body.id;
@@ -262,7 +262,7 @@ describe('Annotations Router', () => {
 
     it('should update status', async () => {
       const res = await request(app)
-        .patch(`/annotations/${annotationId}`)
+        .patch(`/api/annotations/${annotationId}`)
         .send({ status: 'submitted' })
         .expect(200);
 
@@ -272,7 +272,7 @@ describe('Annotations Router', () => {
 
     it('should update content', async () => {
       const res = await request(app)
-        .patch(`/annotations/${annotationId}`)
+        .patch(`/api/annotations/${annotationId}`)
         .send({ content: 'updated content' })
         .expect(200);
 
@@ -281,7 +281,7 @@ describe('Annotations Router', () => {
 
     it('should update both status and content', async () => {
       const res = await request(app)
-        .patch(`/annotations/${annotationId}`)
+        .patch(`/api/annotations/${annotationId}`)
         .send({ status: 'resolved', content: 'final content' })
         .expect(200);
 
@@ -291,7 +291,7 @@ describe('Annotations Router', () => {
 
     it('should update updated_at timestamp', async () => {
       const before = await request(app)
-        .get('/annotations')
+        .get('/api/annotations')
         .query({ doc_path: 'patch-test/doc.md' })
         .expect(200);
 
@@ -301,12 +301,12 @@ describe('Annotations Router', () => {
       await new Promise((r) => setTimeout(r, 10));
 
       await request(app)
-        .patch(`/annotations/${annotationId}`)
+        .patch(`/api/annotations/${annotationId}`)
         .send({ content: 'timestamp check' })
         .expect(200);
 
       const after = await request(app)
-        .get('/annotations')
+        .get('/api/annotations')
         .query({ doc_path: 'patch-test/doc.md' })
         .expect(200);
 
@@ -316,7 +316,7 @@ describe('Annotations Router', () => {
 
     it('should return 400 when neither status nor content is provided', async () => {
       const res = await request(app)
-        .patch(`/annotations/${annotationId}`)
+        .patch(`/api/annotations/${annotationId}`)
         .send({})
         .expect(400);
 
@@ -325,7 +325,7 @@ describe('Annotations Router', () => {
 
     it('should return 404 for non-existent annotation ID', async () => {
       const res = await request(app)
-        .patch('/annotations/nonexistent-id-12345')
+        .patch('/api/annotations/nonexistent-id-12345')
         .send({ status: 'submitted' })
         .expect(404);
 

--- a/packages/api/src/routes/__tests__/docs.test.ts
+++ b/packages/api/src/routes/__tests__/docs.test.ts
@@ -41,10 +41,10 @@ describe('Docs Router', () => {
 
     const app = express();
     app.use(express.json());
-    app.use('/', createDocsRouter(mockAnvil));
+    app.use('/api', createDocsRouter(mockAnvil));
 
     const response = await request(app)
-      .get('/docs')
+      .get('/api/docs')
       .expect(200);
 
     expect(response.body).toEqual([
@@ -101,10 +101,10 @@ describe('Docs Router', () => {
 
     const app = express();
     app.use(express.json());
-    app.use('/', createDocsRouter(mockAnvil));
+    app.use('/api', createDocsRouter(mockAnvil));
 
     const response = await request(app)
-      .get('/docs/methodology/process.md')
+      .get('/api/docs/methodology/process.md')
       .expect(200);
 
     expect(response.body).toEqual({
@@ -136,10 +136,10 @@ describe('Docs Router', () => {
 
     const app = express();
     app.use(express.json());
-    app.use('/', createDocsRouter(mockAnvil));
+    app.use('/api', createDocsRouter(mockAnvil));
 
     const response = await request(app)
-      .get('/docs/non-existent.md')
+      .get('/api/docs/non-existent.md')
       .expect(404);
 
     expect(response.body).toEqual({
@@ -157,10 +157,10 @@ describe('Docs Router', () => {
 
     const app = express();
     app.use(express.json());
-    app.use('/', createDocsRouter(mockAnvil));
+    app.use('/api', createDocsRouter(mockAnvil));
 
     const response = await request(app)
-      .get('/docs')
+      .get('/api/docs')
       .expect(500);
 
     expect(response.body).toEqual({
@@ -176,10 +176,10 @@ describe('Docs Router', () => {
 
     const app = express();
     app.use(express.json());
-    app.use('/', createDocsRouter(mockAnvil));
+    app.use('/api', createDocsRouter(mockAnvil));
 
     const response = await request(app)
-      .get('/docs/some-file.md')
+      .get('/api/docs/some-file.md')
       .expect(500);
 
     expect(response.body).toEqual({

--- a/packages/api/src/routes/__tests__/reviews.test.ts
+++ b/packages/api/src/routes/__tests__/reviews.test.ts
@@ -18,7 +18,7 @@ beforeAll(() => {
 
   app = express();
   app.use(express.json());
-  app.use('/', createReviewsRouter());
+  app.use('/api', createReviewsRouter());
 });
 
 afterAll(() => {
@@ -37,7 +37,7 @@ describe('Reviews Router', () => {
   describe('POST /reviews', () => {
     it('should create a review with defaults', async () => {
       const res = await request(app)
-        .post('/reviews')
+        .post('/api/reviews')
         .send({ doc_path: 'docs/process.md' })
         .expect(201);
 
@@ -53,7 +53,7 @@ describe('Reviews Router', () => {
 
     it('should return 400 when doc_path is missing', async () => {
       const res = await request(app)
-        .post('/reviews')
+        .post('/api/reviews')
         .send({})
         .expect(400);
 
@@ -62,7 +62,7 @@ describe('Reviews Router', () => {
 
     it('should return 400 when doc_path is empty string', async () => {
       const res = await request(app)
-        .post('/reviews')
+        .post('/api/reviews')
         .send({ doc_path: '' })
         .expect(400);
 
@@ -71,12 +71,12 @@ describe('Reviews Router', () => {
 
     it('should generate unique IDs for each review', async () => {
       const res1 = await request(app)
-        .post('/reviews')
+        .post('/api/reviews')
         .send({ doc_path: 'docs/a.md' })
         .expect(201);
 
       const res2 = await request(app)
-        .post('/reviews')
+        .post('/api/reviews')
         .send({ doc_path: 'docs/b.md' })
         .expect(201);
 
@@ -85,12 +85,12 @@ describe('Reviews Router', () => {
 
     it('should allow multiple reviews for the same doc_path', async () => {
       const res1 = await request(app)
-        .post('/reviews')
+        .post('/api/reviews')
         .send({ doc_path: 'docs/same.md' })
         .expect(201);
 
       const res2 = await request(app)
-        .post('/reviews')
+        .post('/api/reviews')
         .send({ doc_path: 'docs/same.md' })
         .expect(201);
 
@@ -100,7 +100,7 @@ describe('Reviews Router', () => {
 
     it('should set created_at and updated_at to the same value', async () => {
       const res = await request(app)
-        .post('/reviews')
+        .post('/api/reviews')
         .send({ doc_path: 'docs/timestamps.md' })
         .expect(201);
 
@@ -113,14 +113,14 @@ describe('Reviews Router', () => {
   describe('GET /reviews', () => {
     beforeAll(async () => {
       // Seed reviews for GET tests
-      await request(app).post('/reviews').send({ doc_path: 'get-test/doc.md' }).expect(201);
-      await request(app).post('/reviews').send({ doc_path: 'get-test/doc.md' }).expect(201);
-      await request(app).post('/reviews').send({ doc_path: 'get-test/other.md' }).expect(201);
+      await request(app).post('/api/reviews').send({ doc_path: 'get-test/doc.md' }).expect(201);
+      await request(app).post('/api/reviews').send({ doc_path: 'get-test/doc.md' }).expect(201);
+      await request(app).post('/api/reviews').send({ doc_path: 'get-test/other.md' }).expect(201);
     });
 
     it('should return 400 when doc_path is missing', async () => {
       const res = await request(app)
-        .get('/reviews')
+        .get('/api/reviews')
         .expect(400);
 
       expect(res.body.error).toContain('doc_path');
@@ -128,7 +128,7 @@ describe('Reviews Router', () => {
 
     it('should return reviews filtered by doc_path', async () => {
       const res = await request(app)
-        .get('/reviews')
+        .get('/api/reviews')
         .query({ doc_path: 'get-test/doc.md' })
         .expect(200);
 
@@ -140,7 +140,7 @@ describe('Reviews Router', () => {
 
     it('should return empty array for unknown doc_path', async () => {
       const res = await request(app)
-        .get('/reviews')
+        .get('/api/reviews')
         .query({ doc_path: 'non-existent/path.md' })
         .expect(200);
 
@@ -149,7 +149,7 @@ describe('Reviews Router', () => {
 
     it('should return results ordered by created_at DESC', async () => {
       const res = await request(app)
-        .get('/reviews')
+        .get('/api/reviews')
         .query({ doc_path: 'get-test/doc.md' })
         .expect(200);
 
@@ -160,7 +160,7 @@ describe('Reviews Router', () => {
 
     it('should return all review fields', async () => {
       const res = await request(app)
-        .get('/reviews')
+        .get('/api/reviews')
         .query({ doc_path: 'get-test/doc.md' })
         .expect(200);
 
@@ -177,7 +177,7 @@ describe('Reviews Router', () => {
 
     it('should only return reviews for the requested doc_path', async () => {
       const res = await request(app)
-        .get('/reviews')
+        .get('/api/reviews')
         .query({ doc_path: 'get-test/other.md' })
         .expect(200);
 

--- a/packages/api/src/routes/__tests__/search.test.ts
+++ b/packages/api/src/routes/__tests__/search.test.ts
@@ -12,7 +12,7 @@ const mockAnvil = {
 // Create test app
 const app = express();
 app.use(express.json());
-app.use('/', createSearchRouter(mockAnvil));
+app.use('/api', createSearchRouter(mockAnvil));
 
 describe('POST /search', () => {
   beforeEach(() => {
@@ -48,7 +48,7 @@ describe('POST /search', () => {
     mockAnvil.search.mockResolvedValue(mockResults);
 
     const response = await request(app)
-      .post('/search')
+      .post('/api/search')
       .send({ query: 'test query' })
       .expect(200);
 
@@ -77,7 +77,7 @@ describe('POST /search', () => {
 
   it('should return 400 when query is missing', async () => {
     const response = await request(app)
-      .post('/search')
+      .post('/api/search')
       .send({})
       .expect(400);
 
@@ -90,7 +90,7 @@ describe('POST /search', () => {
 
   it('should return 400 when query is empty string', async () => {
     const response = await request(app)
-      .post('/search')
+      .post('/api/search')
       .send({ query: '' })
       .expect(400);
 
@@ -103,7 +103,7 @@ describe('POST /search', () => {
 
   it('should return 400 when query is whitespace only', async () => {
     const response = await request(app)
-      .post('/search')
+      .post('/api/search')
       .send({ query: '   ' })
       .expect(400);
 
@@ -119,7 +119,7 @@ describe('POST /search', () => {
     mockAnvil.search.mockResolvedValue(mockResults);
 
     await request(app)
-      .post('/search')
+      .post('/api/search')
       .send({ query: 'test query', topK: 5 })
       .expect(200);
 
@@ -130,7 +130,7 @@ describe('POST /search', () => {
     mockAnvil.search.mockResolvedValue([]);
 
     const response = await request(app)
-      .post('/search')
+      .post('/api/search')
       .send({ query: 'no matches query' })
       .expect(200);
 
@@ -146,7 +146,7 @@ describe('POST /search', () => {
     mockAnvil.search.mockResolvedValue([]);
 
     const response = await request(app)
-      .post('/search')
+      .post('/api/search')
       .send({ query: 'test query', topK: 0 })
       .expect(200);
 
@@ -178,7 +178,7 @@ describe('POST /search', () => {
     mockAnvil.search.mockResolvedValue(mockResults);
 
     const response = await request(app)
-      .post('/search')
+      .post('/api/search')
       .send({ query: 'test' })
       .expect(200);
 

--- a/packages/site/src/components/AnnotationThread.tsx
+++ b/packages/site/src/components/AnnotationThread.tsx
@@ -27,7 +27,6 @@ interface ReviewGroup {
 
 interface Props {
   docPath: string;
-  apiBaseUrl?: string;
 }
 
 const STORAGE_KEY = 'foundry-thread-panel';
@@ -191,7 +190,7 @@ async function getSectionContentHash(headingPath: string): Promise<string> {
   }
 }
 
-export default function AnnotationThread({ docPath, apiBaseUrl = 'http://localhost:3001' }: Props) {
+export default function AnnotationThread({ docPath }: Props) {
   const [annotations, setAnnotations] = useState<Annotation[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -203,7 +202,7 @@ export default function AnnotationThread({ docPath, apiBaseUrl = 'http://localho
   // Helper to update annotation status via API
   const patchAnnotation = useCallback(async (id: string, updates: Partial<Pick<Annotation, 'status'>>) => {
     try {
-      const response = await fetch(`${apiBaseUrl}/annotations/${id}`, {
+      const response = await fetch(`/api/annotations/${id}`, {
         method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',
@@ -221,7 +220,7 @@ export default function AnnotationThread({ docPath, apiBaseUrl = 'http://localho
       console.warn(`Error updating annotation ${id}:`, err);
       return false;
     }
-  }, [apiBaseUrl]);
+  }, []);
 
   // Detect orphaned annotations and content drift
   const detectOrphansAndDrift = useCallback(async (annotations: Annotation[]): Promise<Annotation[]> => {
@@ -285,7 +284,7 @@ export default function AnnotationThread({ docPath, apiBaseUrl = 'http://localho
     setError(null);
 
     try {
-      const response = await fetch(`${apiBaseUrl}/annotations?doc_path=${encodeURIComponent(docPath)}`);
+      const response = await fetch(`/api/annotations?doc_path=${encodeURIComponent(docPath)}`);
 
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}`);
@@ -303,7 +302,7 @@ export default function AnnotationThread({ docPath, apiBaseUrl = 'http://localho
     } finally {
       setLoading(false);
     }
-  }, [docPath, apiBaseUrl, detectOrphansAndDrift]);
+  }, [docPath, detectOrphansAndDrift]);
 
   useEffect(() => {
     if (docPath) {

--- a/packages/site/src/components/SubmitReview.tsx
+++ b/packages/site/src/components/SubmitReview.tsx
@@ -3,7 +3,6 @@ import { getDrafts, clearDrafts, type DraftComment } from '../utils/draft-storag
 
 interface Props {
   docPath: string;
-  apiBaseUrl?: string;
 }
 
 interface SubmissionState {
@@ -12,7 +11,7 @@ interface SubmissionState {
   success: boolean;
 }
 
-export default function SubmitReview({ docPath, apiBaseUrl = 'http://localhost:3001' }: Props) {
+export default function SubmitReview({ docPath }: Props) {
   const [drafts, setDrafts] = useState<DraftComment[]>([]);
   const [submissionState, setSubmissionState] = useState<SubmissionState>({
     isSubmitting: false,
@@ -59,7 +58,7 @@ export default function SubmitReview({ docPath, apiBaseUrl = 'http://localhost:3
 
     try {
       // Step 1: Create the review
-      const reviewResponse = await fetch(`${apiBaseUrl}/reviews`, {
+      const reviewResponse = await fetch(`/api/reviews`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -79,7 +78,7 @@ export default function SubmitReview({ docPath, apiBaseUrl = 'http://localhost:3
       // Step 2: Submit each draft as an annotation
       const annotationPromises = drafts.map(async (draft) => {
         // Create annotation
-        const annotationResponse = await fetch(`${apiBaseUrl}/annotations`, {
+        const annotationResponse = await fetch(`/api/annotations`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -102,7 +101,7 @@ export default function SubmitReview({ docPath, apiBaseUrl = 'http://localhost:3
         const annotation = await annotationResponse.json();
 
         // Update status to submitted
-        const patchResponse = await fetch(`${apiBaseUrl}/annotations/${annotation.id}`, {
+        const patchResponse = await fetch(`/api/annotations/${annotation.id}`, {
           method: 'PATCH',
           headers: {
             'Content-Type': 'application/json',
@@ -122,7 +121,7 @@ export default function SubmitReview({ docPath, apiBaseUrl = 'http://localhost:3
       await Promise.all(annotationPromises);
 
       // Step 3: Update review status to submitted
-      const reviewPatchResponse = await fetch(`${apiBaseUrl}/reviews/${reviewId}`, {
+      const reviewPatchResponse = await fetch(`/api/reviews/${reviewId}`, {
         method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',

--- a/packages/site/src/layouts/DocLayout.astro
+++ b/packages/site/src/layouts/DocLayout.astro
@@ -19,7 +19,6 @@ interface Props {
 const { title = 'Foundry', description = 'Documentation platform for human-AI collaborative workflows', currentPath = '/' } = Astro.props;
 const pageTitle = title === 'Foundry' ? title : `${title} — Foundry`;
 const base = import.meta.env.BASE_URL;
-const apiBaseUrl = import.meta.env.API_BASE_URL || 'http://localhost:3001';
 ---
 
 <!DOCTYPE html>
@@ -76,13 +75,11 @@ const apiBaseUrl = import.meta.env.API_BASE_URL || 'http://localhost:3001';
 
     <SubmitReview
       docPath={currentPath}
-      apiBaseUrl={apiBaseUrl}
       client:load
     />
 
     <AnnotationThread
       docPath={currentPath}
-      apiBaseUrl={apiBaseUrl}
       client:load
     />
   </div>


### PR DESCRIPTION
## What

Prepares for single-origin serving:
- All REST endpoints moved to /api/* prefix
- MCP stays at /mcp/*
- Frontend components use relative /api/* URLs
- Removed apiBaseUrl prop from components and layout
- All tests updated for new route paths

## Stories
- E4.5-S1: Route Prefixing (Batch 1)

## Testing
- npm run build (api + site) ✅
- Tests passing ✅