### PR TITLE
feat(E5-S1): Auth middleware + protected routes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# Foundry Environment Variables
+# Copy to .env and fill in values
+
+# GitHub token for fetching private repos during build
+GITHUB_TOKEN=
+
+# Bearer token for API write protection (annotations/reviews)
+# Generate with: openssl rand -hex 32
+# If unset, auth is disabled (dev mode)
+FOUNDRY_WRITE_TOKEN=
+
+# Server port (default: 3001)
+# PORT=3001
+
+# Database path (default: ./foundry.db)
+# FOUNDRY_DB_PATH=./foundry.db

--- a/fix_auth_headers.py
+++ b/fix_auth_headers.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+import re
+
+# Read the file
+with open('packages/api/src/routes/__tests__/annotations.test.ts', 'r') as f:
+    content = f.read()
+
+# Pattern to match request(app).post|get|patch and add auth header
+# Look for: request(app) followed by .post|.get|.patch, then add .set() before .send() or .query() or .expect()
+pattern = r'(request\(app\)\s*\.(post|get|patch)\([^)]+\))(\s*)(\.(?:send|query|expect))'
+replacement = r'\1\3.set("Authorization", "Bearer test-token")\3\4'
+
+# Apply the replacement
+new_content = re.sub(pattern, replacement, content, flags=re.MULTILINE)
+
+# Write back
+with open('packages/api/src/routes/__tests__/annotations.test.ts', 'w') as f:
+    f.write(new_content)
+
+print("Updated auth headers in annotations.test.ts")

--- a/fix_reviews_auth.py
+++ b/fix_reviews_auth.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+
+import re
+
+# Read the file
+with open('packages/api/src/routes/__tests__/reviews.test.ts', 'r') as f:
+    content = f.read()
+
+# Pattern to match request(app).post|get|patch and add auth header
+pattern = r'(request\(app\)\s*\.(post|get|patch)\([^)]+\))(\s*)(\.(?:send|query|expect))'
+replacement = r'\1\3.set("Authorization", "Bearer test-token")\3\4'
+
+# Apply the replacement
+new_content = re.sub(pattern, replacement, content, flags=re.MULTILINE)
+
+# Write back
+with open('packages/api/src/routes/__tests__/reviews.test.ts', 'w') as f:
+    f.write(new_content)
+
+print("Updated auth headers in reviews.test.ts")

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -9,6 +9,7 @@ import { createDocsRouter } from './routes/docs.js';
 import { createSearchRouter } from './routes/search.js';
 import { createAnnotationsRouter } from './routes/annotations.js';
 import { createReviewsRouter } from './routes/reviews.js';
+import { requireAuth, logAuthStatus } from './middleware/auth.js';
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
 import { createMcpServer } from './mcp/server.js';
 
@@ -152,11 +153,16 @@ async function startServer(): Promise<void> {
       app.get('/api/search', (req, res) => res.status(503).json({ error: 'Search service unavailable (Anvil disabled)' }));
     }
 
-    // Mount annotations router
-    app.use('/api', createAnnotationsRouter());
+    // Create protected routers by wrapping with auth middleware
+    const protectedAnnotationsRouter = express.Router();
+    protectedAnnotationsRouter.use('/annotations', requireAuth);
+    protectedAnnotationsRouter.use(createAnnotationsRouter());
+    app.use('/api', protectedAnnotationsRouter);
 
-    // Mount reviews router
-    app.use('/api', createReviewsRouter());
+    const protectedReviewsRouter = express.Router();
+    protectedReviewsRouter.use('/reviews', requireAuth);
+    protectedReviewsRouter.use(createReviewsRouter());
+    app.use('/api', protectedReviewsRouter);
 
     // Static file serving — serve the Astro build output
     app.use(express.static(STATIC_PATH));
@@ -185,6 +191,7 @@ async function startServer(): Promise<void> {
         console.log(`🔌 MCP endpoints disabled (Anvil unavailable)`);
       }
       console.log(`🌐 CORS enabled for GitHub Pages and localhost`);
+      logAuthStatus();
     });
   } catch (error) {
     console.error('❌ Failed to start server:', error);

--- a/packages/api/src/middleware/__tests__/auth.test.ts
+++ b/packages/api/src/middleware/__tests__/auth.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { requireAuth } from '../auth.js';
+
+describe('requireAuth middleware', () => {
+  let app: express.Express;
+  let originalEnv: string | undefined;
+
+  beforeEach(() => {
+    // Save original env
+    originalEnv = process.env.FOUNDRY_WRITE_TOKEN;
+    
+    // Create fresh app for each test
+    app = express();
+    app.use(express.json());
+  });
+
+  afterEach(() => {
+    // Restore original env
+    if (originalEnv === undefined) {
+      delete process.env.FOUNDRY_WRITE_TOKEN;
+    } else {
+      process.env.FOUNDRY_WRITE_TOKEN = originalEnv;
+    }
+  });
+
+  it('should allow requests when FOUNDRY_WRITE_TOKEN is not set (dev mode)', async () => {
+    delete process.env.FOUNDRY_WRITE_TOKEN;
+    
+    app.use('/protected', requireAuth);
+    app.get('/protected', (req, res) => res.json({ success: true }));
+
+    const res = await request(app)
+      .get('/protected')
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+  });
+
+  it('should return 401 when no Authorization header is provided and token is set', async () => {
+    process.env.FOUNDRY_WRITE_TOKEN = 'test-token';
+    
+    app.use('/protected', requireAuth);
+    app.get('/protected', (req, res) => res.json({ success: true }));
+
+    const res = await request(app)
+      .get('/protected')
+      .expect(401);
+
+    expect(res.body.error).toBe('Unauthorized');
+  });
+
+  it('should return 401 when wrong token is provided', async () => {
+    process.env.FOUNDRY_WRITE_TOKEN = 'correct-token';
+    
+    app.use('/protected', requireAuth);
+    app.get('/protected', (req, res) => res.json({ success: true }));
+
+    const res = await request(app)
+      .get('/protected')
+      .set('Authorization', 'Bearer wrong-token')
+      .expect(401);
+
+    expect(res.body.error).toBe('Unauthorized');
+  });
+
+  it('should allow request when valid Bearer token is provided', async () => {
+    process.env.FOUNDRY_WRITE_TOKEN = 'correct-token';
+    
+    app.use('/protected', requireAuth);
+    app.get('/protected', (req, res) => res.json({ success: true }));
+
+    const res = await request(app)
+      .get('/protected')
+      .set('Authorization', 'Bearer correct-token')
+      .expect(200);
+
+    expect(res.body.success).toBe(true);
+  });
+
+  it('should return 401 when Authorization header has malformed format', async () => {
+    process.env.FOUNDRY_WRITE_TOKEN = 'test-token';
+    
+    app.use('/protected', requireAuth);
+    app.get('/protected', (req, res) => res.json({ success: true }));
+
+    // Test various malformed headers
+    const malformedHeaders = [
+      'Basic test-token',           // Wrong auth type
+      'Bearer',                     // Missing token
+      'test-token',                 // No "Bearer " prefix  
+      'Bearer  test-token',         // Double space
+    ];
+
+    for (const header of malformedHeaders) {
+      const res = await request(app)
+        .get('/protected')
+        .set('Authorization', header)
+        .expect(401);
+
+      expect(res.body.error).toBe('Unauthorized');
+    }
+  });
+});

--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -1,0 +1,58 @@
+import { Request, Response, NextFunction } from 'express';
+
+/**
+ * Check if authentication is enabled (FOUNDRY_WRITE_TOKEN is set)
+ */
+function isAuthEnabled(): boolean {
+  return !!process.env.FOUNDRY_WRITE_TOKEN;
+}
+
+/**
+ * Bearer token authentication middleware
+ *
+ * Protects routes by requiring a valid Authorization: Bearer <token> header
+ * that matches the FOUNDRY_WRITE_TOKEN environment variable.
+ *
+ * If FOUNDRY_WRITE_TOKEN is not set, all requests are allowed through (dev mode).
+ */
+export function requireAuth(req: Request, res: Response, next: NextFunction): void {
+  // If auth token is not configured, allow all requests (dev mode)
+  if (!isAuthEnabled()) {
+    return next();
+  }
+
+  const authHeader = req.headers.authorization;
+
+  // Check if Authorization header exists
+  if (!authHeader) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  // Check if header follows Bearer token format
+  if (!authHeader.startsWith('Bearer ')) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  // Extract token from "Bearer <token>" format
+  const token = authHeader.slice(7);
+  const expectedToken = process.env.FOUNDRY_WRITE_TOKEN;
+
+  // Verify token matches expected value
+  if (token !== expectedToken) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  // Token is valid, proceed to next middleware/route handler
+  next();
+}
+
+/**
+ * Log authentication status on server startup
+ */
+export function logAuthStatus(): void {
+  if (isAuthEnabled()) {
+    console.log('🔒 Authentication enabled for write operations');
+  } else {
+    console.log('⚠️ Authentication disabled (dev mode) - set FOUNDRY_WRITE_TOKEN to enable');
+  }
+}

--- a/packages/api/src/routes/__tests__/annotations.test.ts
+++ b/packages/api/src/routes/__tests__/annotations.test.ts
@@ -5,6 +5,7 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 import { unlinkSync } from 'fs';
 import { createAnnotationsRouter } from '../annotations.js';
+import { requireAuth } from '../../middleware/auth.js';
 import { getDb, closeDb } from '../../db.js';
 
 const ISO_8601_REGEX = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
@@ -15,10 +16,16 @@ const testDbPath = join(tmpdir(), `foundry-test-annotations-${Date.now()}.db`);
 
 beforeAll(() => {
   process.env.FOUNDRY_DB_PATH = testDbPath;
+  process.env.FOUNDRY_WRITE_TOKEN = 'test-token';
 
   app = express();
   app.use(express.json());
-  app.use('/api', createAnnotationsRouter());
+  
+  // Create protected annotations router
+  const protectedAnnotationsRouter = express.Router();
+  protectedAnnotationsRouter.use('/annotations', requireAuth);
+  protectedAnnotationsRouter.use(createAnnotationsRouter());
+  app.use('/api', protectedAnnotationsRouter);
 });
 
 afterAll(() => {
@@ -43,6 +50,58 @@ function validBody(overrides: Record<string, unknown> = {}) {
 }
 
 describe('Annotations Router', () => {
+  // ─── Authentication Tests ─────────────────────────────────────────
+  
+  describe('Authentication', () => {
+    it('should return 401 when POST /annotations without token', async () => {
+      const res = await request(app)
+        .post('/api/annotations')
+        .send(validBody())
+        .expect(401);
+
+      expect(res.body.error).toBe('Unauthorized');
+    });
+
+    it('should return 401 when GET /annotations without token', async () => {
+      const res = await request(app)
+        .get('/api/annotations')
+        .query({ doc_path: 'test/doc.md' })
+        .expect(401);
+
+      expect(res.body.error).toBe('Unauthorized');
+    });
+
+    it('should return 401 when POST /annotations with wrong token', async () => {
+      const res = await request(app)
+        .post('/api/annotations')
+        .set('Authorization', 'Bearer wrong-token')
+        .send(validBody())
+        .expect(401);
+
+      expect(res.body.error).toBe('Unauthorized');
+    });
+
+    it('should succeed when POST /annotations with valid token', async () => {
+      const res = await request(app)
+        .post('/api/annotations')
+        .set('Authorization', 'Bearer test-token')
+        .send(validBody())
+        .expect(201);
+
+      expect(res.body.id).toMatch(CUID2_REGEX);
+    });
+
+    it('should succeed when GET /annotations with valid token', async () => {
+      const res = await request(app)
+        .get('/api/annotations')
+        .set('Authorization', 'Bearer test-token')
+        .query({ doc_path: 'test/doc.md' })
+        .expect(200);
+
+      expect(Array.isArray(res.body)).toBe(true);
+    });
+  });
+
   // ─── POST /annotations ─────────────────────────────────────────────
 
   describe('POST /annotations', () => {
@@ -50,6 +109,7 @@ describe('Annotations Router', () => {
       const body = validBody();
       const res = await request(app)
         .post('/api/annotations')
+        .set("Authorization", "Bearer test-token")
         .send(body)
         .expect(201);
 
@@ -71,6 +131,7 @@ describe('Annotations Router', () => {
     it('should accept optional quoted_text', async () => {
       const res = await request(app)
         .post('/api/annotations')
+        .set("Authorization", "Bearer test-token")
         .send(validBody({ quoted_text: 'some quoted text' }))
         .expect(201);
 
@@ -80,6 +141,7 @@ describe('Annotations Router', () => {
     it('should accept optional author_type of ai', async () => {
       const res = await request(app)
         .post('/api/annotations')
+        .set("Authorization", "Bearer test-token")
         .send(validBody({ author_type: 'ai' }))
         .expect(201);
 
@@ -89,6 +151,7 @@ describe('Annotations Router', () => {
     it('should return 400 when doc_path is missing', async () => {
       const res = await request(app)
         .post('/api/annotations')
+        .set("Authorization", "Bearer test-token")
         .send(validBody({ doc_path: '' }))
         .expect(400);
 
@@ -98,6 +161,7 @@ describe('Annotations Router', () => {
     it('should return 400 when heading_path is missing', async () => {
       const res = await request(app)
         .post('/api/annotations')
+        .set("Authorization", "Bearer test-token")
         .send(validBody({ heading_path: '' }))
         .expect(400);
 
@@ -107,6 +171,7 @@ describe('Annotations Router', () => {
     it('should return 400 when content_hash is missing', async () => {
       const res = await request(app)
         .post('/api/annotations')
+        .set("Authorization", "Bearer test-token")
         .send(validBody({ content_hash: '' }))
         .expect(400);
 
@@ -116,6 +181,7 @@ describe('Annotations Router', () => {
     it('should return 400 when content is missing', async () => {
       const res = await request(app)
         .post('/api/annotations')
+        .set("Authorization", "Bearer test-token")
         .send(validBody({ content: '' }))
         .expect(400);
 
@@ -125,6 +191,7 @@ describe('Annotations Router', () => {
     it('should return 400 with descriptive error message', async () => {
       const res = await request(app)
         .post('/api/annotations')
+        .set("Authorization", "Bearer test-token")
         .send({})
         .expect(400);
 
@@ -135,11 +202,13 @@ describe('Annotations Router', () => {
     it('should generate unique IDs for each annotation', async () => {
       const res1 = await request(app)
         .post('/api/annotations')
+        .set("Authorization", "Bearer test-token")
         .send(validBody())
         .expect(201);
 
       const res2 = await request(app)
         .post('/api/annotations')
+        .set("Authorization", "Bearer test-token")
         .send(validBody())
         .expect(201);
 
@@ -163,19 +232,21 @@ describe('Annotations Router', () => {
 
       seededIds = [];
       for (const body of bodies) {
-        const res = await request(app).post('/api/annotations').send(body).expect(201);
+        const res = await request(app).post('/api/annotations').set("Authorization", "Bearer test-token").send(body).expect(201);
         seededIds.push(res.body.id);
       }
 
       // Update one annotation status to 'submitted' for status filter testing
       await request(app)
         .patch(`/api/annotations/${seededIds[0]}`)
+        .set("Authorization", "Bearer test-token")
         .send({ status: 'submitted' });
     });
 
     it('should return 400 when doc_path is missing', async () => {
       const res = await request(app)
         .get('/api/annotations')
+        .set("Authorization", "Bearer test-token")
         .expect(400);
 
       expect(res.body.error).toContain('doc_path');
@@ -184,6 +255,7 @@ describe('Annotations Router', () => {
     it('should return annotations filtered by doc_path', async () => {
       const res = await request(app)
         .get('/api/annotations')
+        .set("Authorization", "Bearer test-token")
         .query({ doc_path: 'get-test/doc.md' })
         .expect(200);
 
@@ -196,6 +268,7 @@ describe('Annotations Router', () => {
     it('should return empty array for unknown doc_path', async () => {
       const res = await request(app)
         .get('/api/annotations')
+        .set("Authorization", "Bearer test-token")
         .query({ doc_path: 'non-existent/path.md' })
         .expect(200);
 
@@ -205,6 +278,7 @@ describe('Annotations Router', () => {
     it('should filter by section (heading_path LIKE match)', async () => {
       const res = await request(app)
         .get('/api/annotations')
+        .set("Authorization", "Bearer test-token")
         .query({ doc_path: 'get-test/doc.md', section: 'Section A' })
         .expect(200);
 
@@ -217,6 +291,7 @@ describe('Annotations Router', () => {
     it('should filter by status', async () => {
       const res = await request(app)
         .get('/api/annotations')
+        .set("Authorization", "Bearer test-token")
         .query({ doc_path: 'get-test/doc.md', status: 'submitted' })
         .expect(200);
 
@@ -227,6 +302,7 @@ describe('Annotations Router', () => {
     it('should combine section and status filters', async () => {
       const res = await request(app)
         .get('/api/annotations')
+        .set("Authorization", "Bearer test-token")
         .query({ doc_path: 'get-test/doc.md', section: 'Section A', status: 'submitted' })
         .expect(200);
 
@@ -238,6 +314,7 @@ describe('Annotations Router', () => {
     it('should return results ordered by created_at DESC', async () => {
       const res = await request(app)
         .get('/api/annotations')
+        .set("Authorization", "Bearer test-token")
         .query({ doc_path: 'get-test/doc.md' })
         .expect(200);
 
@@ -255,6 +332,7 @@ describe('Annotations Router', () => {
     beforeAll(async () => {
       const res = await request(app)
         .post('/api/annotations')
+        .set("Authorization", "Bearer test-token")
         .send(validBody({ doc_path: 'patch-test/doc.md', content: 'original content' }))
         .expect(201);
       annotationId = res.body.id;
@@ -263,6 +341,7 @@ describe('Annotations Router', () => {
     it('should update status', async () => {
       const res = await request(app)
         .patch(`/api/annotations/${annotationId}`)
+        .set("Authorization", "Bearer test-token")
         .send({ status: 'submitted' })
         .expect(200);
 
@@ -273,6 +352,7 @@ describe('Annotations Router', () => {
     it('should update content', async () => {
       const res = await request(app)
         .patch(`/api/annotations/${annotationId}`)
+        .set("Authorization", "Bearer test-token")
         .send({ content: 'updated content' })
         .expect(200);
 
@@ -282,6 +362,7 @@ describe('Annotations Router', () => {
     it('should update both status and content', async () => {
       const res = await request(app)
         .patch(`/api/annotations/${annotationId}`)
+        .set("Authorization", "Bearer test-token")
         .send({ status: 'resolved', content: 'final content' })
         .expect(200);
 
@@ -292,6 +373,7 @@ describe('Annotations Router', () => {
     it('should update updated_at timestamp', async () => {
       const before = await request(app)
         .get('/api/annotations')
+        .set("Authorization", "Bearer test-token")
         .query({ doc_path: 'patch-test/doc.md' })
         .expect(200);
 
@@ -302,11 +384,13 @@ describe('Annotations Router', () => {
 
       await request(app)
         .patch(`/api/annotations/${annotationId}`)
+        .set("Authorization", "Bearer test-token")
         .send({ content: 'timestamp check' })
         .expect(200);
 
       const after = await request(app)
         .get('/api/annotations')
+        .set("Authorization", "Bearer test-token")
         .query({ doc_path: 'patch-test/doc.md' })
         .expect(200);
 
@@ -317,6 +401,7 @@ describe('Annotations Router', () => {
     it('should return 400 when neither status nor content is provided', async () => {
       const res = await request(app)
         .patch(`/api/annotations/${annotationId}`)
+        .set("Authorization", "Bearer test-token")
         .send({})
         .expect(400);
 
@@ -326,6 +411,7 @@ describe('Annotations Router', () => {
     it('should return 404 for non-existent annotation ID', async () => {
       const res = await request(app)
         .patch('/api/annotations/nonexistent-id-12345')
+        .set("Authorization", "Bearer test-token")
         .send({ status: 'submitted' })
         .expect(404);
 

--- a/packages/api/src/routes/__tests__/reviews.test.ts
+++ b/packages/api/src/routes/__tests__/reviews.test.ts
@@ -5,6 +5,7 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 import { unlinkSync } from 'fs';
 import { createReviewsRouter } from '../reviews.js';
+import { requireAuth } from '../../middleware/auth.js';
 import { getDb, closeDb } from '../../db.js';
 
 const ISO_8601_REGEX = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
@@ -15,10 +16,16 @@ const testDbPath = join(tmpdir(), `foundry-test-reviews-${Date.now()}.db`);
 
 beforeAll(() => {
   process.env.FOUNDRY_DB_PATH = testDbPath;
+  process.env.FOUNDRY_WRITE_TOKEN = 'test-token';
 
   app = express();
   app.use(express.json());
-  app.use('/api', createReviewsRouter());
+  
+  // Create protected reviews router
+  const protectedReviewsRouter = express.Router();
+  protectedReviewsRouter.use('/reviews', requireAuth);
+  protectedReviewsRouter.use(createReviewsRouter());
+  app.use('/api', protectedReviewsRouter);
 });
 
 afterAll(() => {
@@ -32,12 +39,46 @@ afterAll(() => {
 });
 
 describe('Reviews Router', () => {
+  // ─── Authentication Tests ─────────────────────────────────────────
+  
+  describe('Authentication', () => {
+    it('should return 401 when POST /reviews without token', async () => {
+      const res = await request(app)
+        .post('/api/reviews')
+        .send({ doc_path: 'test/doc.md' })
+        .expect(401);
+
+      expect(res.body.error).toBe('Unauthorized');
+    });
+
+    it('should return 401 when POST /reviews with wrong token', async () => {
+      const res = await request(app)
+        .post('/api/reviews')
+        .set('Authorization', 'Bearer wrong-token')
+        .send({ doc_path: 'test/doc.md' })
+        .expect(401);
+
+      expect(res.body.error).toBe('Unauthorized');
+    });
+
+    it('should succeed when POST /reviews with valid token', async () => {
+      const res = await request(app)
+        .post('/api/reviews')
+        .set('Authorization', 'Bearer test-token')
+        .send({ doc_path: 'test/doc.md' })
+        .expect(201);
+
+      expect(res.body.id).toMatch(CUID2_REGEX);
+    });
+  });
+
   // ─── POST /reviews ─────────────────────────────────────────────────
 
   describe('POST /reviews', () => {
     it('should create a review with defaults', async () => {
       const res = await request(app)
         .post('/api/reviews')
+        .set("Authorization", "Bearer test-token")
         .send({ doc_path: 'docs/process.md' })
         .expect(201);
 
@@ -54,6 +95,7 @@ describe('Reviews Router', () => {
     it('should return 400 when doc_path is missing', async () => {
       const res = await request(app)
         .post('/api/reviews')
+        .set("Authorization", "Bearer test-token")
         .send({})
         .expect(400);
 
@@ -63,6 +105,7 @@ describe('Reviews Router', () => {
     it('should return 400 when doc_path is empty string', async () => {
       const res = await request(app)
         .post('/api/reviews')
+        .set("Authorization", "Bearer test-token")
         .send({ doc_path: '' })
         .expect(400);
 
@@ -72,11 +115,13 @@ describe('Reviews Router', () => {
     it('should generate unique IDs for each review', async () => {
       const res1 = await request(app)
         .post('/api/reviews')
+        .set("Authorization", "Bearer test-token")
         .send({ doc_path: 'docs/a.md' })
         .expect(201);
 
       const res2 = await request(app)
         .post('/api/reviews')
+        .set("Authorization", "Bearer test-token")
         .send({ doc_path: 'docs/b.md' })
         .expect(201);
 
@@ -86,11 +131,13 @@ describe('Reviews Router', () => {
     it('should allow multiple reviews for the same doc_path', async () => {
       const res1 = await request(app)
         .post('/api/reviews')
+        .set("Authorization", "Bearer test-token")
         .send({ doc_path: 'docs/same.md' })
         .expect(201);
 
       const res2 = await request(app)
         .post('/api/reviews')
+        .set("Authorization", "Bearer test-token")
         .send({ doc_path: 'docs/same.md' })
         .expect(201);
 
@@ -101,6 +148,7 @@ describe('Reviews Router', () => {
     it('should set created_at and updated_at to the same value', async () => {
       const res = await request(app)
         .post('/api/reviews')
+        .set("Authorization", "Bearer test-token")
         .send({ doc_path: 'docs/timestamps.md' })
         .expect(201);
 
@@ -113,14 +161,15 @@ describe('Reviews Router', () => {
   describe('GET /reviews', () => {
     beforeAll(async () => {
       // Seed reviews for GET tests
-      await request(app).post('/api/reviews').send({ doc_path: 'get-test/doc.md' }).expect(201);
-      await request(app).post('/api/reviews').send({ doc_path: 'get-test/doc.md' }).expect(201);
-      await request(app).post('/api/reviews').send({ doc_path: 'get-test/other.md' }).expect(201);
+      await request(app).post('/api/reviews').set("Authorization", "Bearer test-token").send({ doc_path: 'get-test/doc.md' }).expect(201);
+      await request(app).post('/api/reviews').set("Authorization", "Bearer test-token").send({ doc_path: 'get-test/doc.md' }).expect(201);
+      await request(app).post('/api/reviews').set("Authorization", "Bearer test-token").send({ doc_path: 'get-test/other.md' }).expect(201);
     });
 
     it('should return 400 when doc_path is missing', async () => {
       const res = await request(app)
         .get('/api/reviews')
+        .set("Authorization", "Bearer test-token")
         .expect(400);
 
       expect(res.body.error).toContain('doc_path');
@@ -129,6 +178,7 @@ describe('Reviews Router', () => {
     it('should return reviews filtered by doc_path', async () => {
       const res = await request(app)
         .get('/api/reviews')
+        .set("Authorization", "Bearer test-token")
         .query({ doc_path: 'get-test/doc.md' })
         .expect(200);
 
@@ -141,6 +191,7 @@ describe('Reviews Router', () => {
     it('should return empty array for unknown doc_path', async () => {
       const res = await request(app)
         .get('/api/reviews')
+        .set("Authorization", "Bearer test-token")
         .query({ doc_path: 'non-existent/path.md' })
         .expect(200);
 
@@ -150,6 +201,7 @@ describe('Reviews Router', () => {
     it('should return results ordered by created_at DESC', async () => {
       const res = await request(app)
         .get('/api/reviews')
+        .set("Authorization", "Bearer test-token")
         .query({ doc_path: 'get-test/doc.md' })
         .expect(200);
 
@@ -161,6 +213,7 @@ describe('Reviews Router', () => {
     it('should return all review fields', async () => {
       const res = await request(app)
         .get('/api/reviews')
+        .set("Authorization", "Bearer test-token")
         .query({ doc_path: 'get-test/doc.md' })
         .expect(200);
 
@@ -178,6 +231,7 @@ describe('Reviews Router', () => {
     it('should only return reviews for the requested doc_path', async () => {
       const res = await request(app)
         .get('/api/reviews')
+        .set("Authorization", "Bearer test-token")
         .query({ doc_path: 'get-test/other.md' })
         .expect(200);
 


### PR DESCRIPTION
## E5-S1: Auth Middleware + Protected Routes

### What
- Bearer token auth middleware (`requireAuth`)
- All annotation/review endpoints (GET + POST/PATCH/DELETE) require valid token
- Dev mode: no token env var = auth disabled (permissive)
- `.env.example` with all config documented

### Auth Matrix
| Endpoint | Auth Required |
|----------|--------------|
| /api/health | ❌ |
| /api/docs/* | ❌ |
| /api/search | ❌ |
| /api/annotations* | ✅ |
| /api/reviews* | ✅ |
| Static files | ❌ |

### Tests
- Auth middleware unit tests (5 cases)
- Annotation route auth tests (5 cases)
- Review route auth tests (3 cases)
- All existing tests updated with auth headers

Part of E5: Authentication + Write Protection