### PR TITLE
feat(E5-S2): Frontend token modal + auth headers

### DIFF
--- a/packages/site/src/components/AnnotationThread.tsx
+++ b/packages/site/src/components/AnnotationThread.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
+import { authFetch, isAuthenticated } from '../utils/api.js';
 
 // Types (copied from API package)
 type AnnotationStatus = "draft" | "submitted" | "replied" | "resolved" | "orphaned";
@@ -198,11 +199,12 @@ export default function AnnotationThread({ docPath }: Props) {
   const [expandedReviews, setExpandedReviews] = useState<Set<string>>(new Set());
   const [expandedResolved, setExpandedResolved] = useState<Set<string>>(new Set());
   const [showOrphaned, setShowOrphaned] = useState(false);
+  const [authenticated, setAuthenticated] = useState(false);
 
   // Helper to update annotation status via API
   const patchAnnotation = useCallback(async (id: string, updates: Partial<Pick<Annotation, 'status'>>) => {
     try {
-      const response = await fetch(`/api/annotations/${id}`, {
+      const response = await authFetch(`/api/annotations/${id}`, {
         method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',
@@ -280,11 +282,18 @@ export default function AnnotationThread({ docPath }: Props) {
 
   // Fetch annotations
   const fetchAnnotations = useCallback(async () => {
+    if (!isAuthenticated()) {
+      setLoading(false);
+      setAnnotations([]);
+      setError(null);
+      return;
+    }
+
     setLoading(true);
     setError(null);
 
     try {
-      const response = await fetch(`/api/annotations?doc_path=${encodeURIComponent(docPath)}`);
+      const response = await authFetch(`/api/annotations?doc_path=${encodeURIComponent(docPath)}`);
 
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}`);
@@ -320,6 +329,27 @@ export default function AnnotationThread({ docPath }: Props) {
 
     return () => {
       window.removeEventListener('foundry-review-submitted', handleReviewSubmitted);
+    };
+  }, [fetchAnnotations]);
+
+  // Check auth status and listen for auth events
+  useEffect(() => {
+    const checkAuth = () => {
+      setAuthenticated(isAuthenticated());
+    };
+
+    const handleAuthUnlocked = () => {
+      setAuthenticated(true);
+      fetchAnnotations();
+    };
+
+    // Initial check
+    checkAuth();
+
+    window.addEventListener('foundry-auth-unlocked', handleAuthUnlocked);
+
+    return () => {
+      window.removeEventListener('foundry-auth-unlocked', handleAuthUnlocked);
     };
   }, [fetchAnnotations]);
 
@@ -524,6 +554,27 @@ export default function AnnotationThread({ docPath }: Props) {
     </div>
   );
 
+  const handleRequestAuth = () => {
+    window.dispatchEvent(new CustomEvent('foundry-auth-required'));
+  };
+
+  const renderAuthPrompt = () => (
+    <div className="thread-auth-prompt">
+      <div className="thread-auth-prompt__content">
+        <div className="thread-auth-prompt__icon">🔒</div>
+        <div className="thread-auth-prompt__text">
+          <p>Enter your access token to view annotations</p>
+          <button
+            className="thread-auth-prompt__button"
+            onClick={handleRequestAuth}
+          >
+            Unlock
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+
   const { reviewGroups, ungrouped, orphaned } = groupedAnnotations();
 
   return (
@@ -540,7 +591,9 @@ export default function AnnotationThread({ docPath }: Props) {
       </div>
 
       <div className="thread-content">
-        {loading ? (
+        {!authenticated ? (
+          renderAuthPrompt()
+        ) : loading ? (
           <div className="thread-loading">Loading comments...</div>
         ) : error ? (
           <div className="thread-error">{error}</div>

--- a/packages/site/src/components/AuthIndicator.tsx
+++ b/packages/site/src/components/AuthIndicator.tsx
@@ -1,0 +1,55 @@
+import { useState, useEffect } from 'react';
+import { isAuthenticated, clearToken } from '../utils/api.js';
+
+export default function AuthIndicator() {
+  const [authenticated, setAuthenticated] = useState(false);
+
+  useEffect(() => {
+    const checkAuth = () => {
+      setAuthenticated(isAuthenticated());
+    };
+
+    const handleAuthUnlocked = () => {
+      setAuthenticated(true);
+    };
+
+    const handleAuthRequired = () => {
+      setAuthenticated(false);
+    };
+
+    // Initial check
+    checkAuth();
+
+    window.addEventListener('foundry-auth-unlocked', handleAuthUnlocked);
+    window.addEventListener('foundry-auth-required', handleAuthRequired);
+
+    return () => {
+      window.removeEventListener('foundry-auth-unlocked', handleAuthUnlocked);
+      window.removeEventListener('foundry-auth-required', handleAuthRequired);
+    };
+  }, []);
+
+  const handleClick = () => {
+    if (authenticated) {
+      if (confirm('Clear access token?')) {
+        clearToken();
+        setAuthenticated(false);
+        // Optionally dispatch event to trigger UI updates
+        window.dispatchEvent(new CustomEvent('foundry-auth-required'));
+      }
+    } else {
+      window.dispatchEvent(new CustomEvent('foundry-auth-required'));
+    }
+  };
+
+  return (
+    <button
+      className="auth-indicator"
+      onClick={handleClick}
+      title={authenticated ? 'Click to logout' : 'Click to login'}
+      aria-label={authenticated ? 'Logged in - click to logout' : 'Not logged in - click to login'}
+    >
+      {authenticated ? '🔓' : '🔒'}
+    </button>
+  );
+}

--- a/packages/site/src/components/CommentDraft.tsx
+++ b/packages/site/src/components/CommentDraft.tsx
@@ -6,6 +6,7 @@ import {
   updateDraft,
   deleteDraft
 } from '../utils/draft-storage.js';
+import { isAuthenticated } from '../utils/api.js';
 
 interface Props {
   docPath: string;
@@ -62,6 +63,12 @@ export default function CommentDraft({ docPath }: Props) {
 
       const selectedText = selection.toString().trim();
       if (selectedText.length === 0) {
+        setFloatingButton({ show: false, x: 0, y: 0, selectedText: '', headingPath: '', contentHash: '' });
+        return;
+      }
+
+      // Only show comment button if user is authenticated
+      if (!isAuthenticated()) {
         setFloatingButton({ show: false, x: 0, y: 0, selectedText: '', headingPath: '', contentHash: '' });
         return;
       }

--- a/packages/site/src/components/SubmitReview.tsx
+++ b/packages/site/src/components/SubmitReview.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { getDrafts, clearDrafts, type DraftComment } from '../utils/draft-storage.js';
+import { authFetch } from '../utils/api.js';
 
 interface Props {
   docPath: string;
@@ -58,7 +59,7 @@ export default function SubmitReview({ docPath }: Props) {
 
     try {
       // Step 1: Create the review
-      const reviewResponse = await fetch(`/api/reviews`, {
+      const reviewResponse = await authFetch(`/api/reviews`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -78,7 +79,7 @@ export default function SubmitReview({ docPath }: Props) {
       // Step 2: Submit each draft as an annotation
       const annotationPromises = drafts.map(async (draft) => {
         // Create annotation
-        const annotationResponse = await fetch(`/api/annotations`, {
+        const annotationResponse = await authFetch(`/api/annotations`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -101,7 +102,7 @@ export default function SubmitReview({ docPath }: Props) {
         const annotation = await annotationResponse.json();
 
         // Update status to submitted
-        const patchResponse = await fetch(`/api/annotations/${annotation.id}`, {
+        const patchResponse = await authFetch(`/api/annotations/${annotation.id}`, {
           method: 'PATCH',
           headers: {
             'Content-Type': 'application/json',
@@ -121,7 +122,7 @@ export default function SubmitReview({ docPath }: Props) {
       await Promise.all(annotationPromises);
 
       // Step 3: Update review status to submitted
-      const reviewPatchResponse = await fetch(`/api/reviews/${reviewId}`, {
+      const reviewPatchResponse = await authFetch(`/api/reviews/${reviewId}`, {
         method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',

--- a/packages/site/src/components/TokenModal.tsx
+++ b/packages/site/src/components/TokenModal.tsx
@@ -1,0 +1,331 @@
+import { useState, useEffect } from 'react';
+import { setToken, clearToken, getToken } from '../utils/api.js';
+
+export default function TokenModal() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [token, setTokenInput] = useState('');
+  const [error, setError] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    const handleAuthRequired = () => {
+      setIsOpen(true);
+      setError('Token expired or invalid — please re-enter');
+    };
+
+    const handleAuthUnlocked = () => {
+      setIsOpen(false);
+      setError('');
+      setTokenInput('');
+    };
+
+    window.addEventListener('foundry-auth-required', handleAuthRequired);
+    window.addEventListener('foundry-auth-unlocked', handleAuthUnlocked);
+
+    return () => {
+      window.removeEventListener('foundry-auth-required', handleAuthRequired);
+      window.removeEventListener('foundry-auth-unlocked', handleAuthUnlocked);
+    };
+  }, []);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!token.trim()) {
+      setError('Please enter a token');
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError('');
+
+    try {
+      // Store the token and test it by making a simple request
+      setToken(token.trim());
+
+      // Test the token with a simple API call
+      const response = await fetch('/api/annotations?doc_path=test&test=true', {
+        headers: {
+          'Authorization': `Bearer ${token.trim()}`
+        }
+      });
+
+      if (response.ok || response.status === 404) {
+        // 404 is fine for testing - means token is valid but no annotations for test path
+        window.dispatchEvent(new CustomEvent('foundry-auth-unlocked'));
+        setIsOpen(false);
+        setError('');
+        setTokenInput('');
+      } else if (response.status === 401) {
+        // Invalid token
+        clearToken();
+        setError('Invalid token — please check and try again');
+      } else {
+        // Other error
+        setError('Unable to validate token — please try again');
+      }
+    } catch (err) {
+      setError('Network error — please try again');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleClose = () => {
+    setIsOpen(false);
+    setError('');
+    setTokenInput('');
+  };
+
+  const handleBackdropClick = (e: React.MouseEvent) => {
+    if (e.target === e.currentTarget) {
+      handleClose();
+    }
+  };
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className="token-modal-backdrop" onClick={handleBackdropClick}>
+      <div className="token-modal">
+        <div className="token-modal__content">
+          <div className="token-modal__header">
+            <h3>🔒 Access Token Required</h3>
+            <button
+              className="token-modal__close"
+              onClick={handleClose}
+              aria-label="Close"
+            >
+              ×
+            </button>
+          </div>
+
+          <p className="token-modal__description">
+            Enter your access token to view and create annotations.
+          </p>
+
+          {error && (
+            <div className="token-modal__error">
+              {error}
+            </div>
+          )}
+
+          <form onSubmit={handleSubmit}>
+            <input
+              type="password"
+              className="token-modal__input"
+              placeholder="Enter access token"
+              value={token}
+              onChange={(e) => setTokenInput(e.target.value)}
+              disabled={isSubmitting}
+              autoFocus
+            />
+
+            <div className="token-modal__actions">
+              <button
+                type="submit"
+                className="token-modal__submit"
+                disabled={isSubmitting || !token.trim()}
+              >
+                {isSubmitting ? 'Validating...' : 'Unlock'}
+              </button>
+              <button
+                type="button"
+                className="token-modal__cancel"
+                onClick={handleClose}
+                disabled={isSubmitting}
+              >
+                Cancel
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+
+      <style jsx>{`
+        .token-modal-backdrop {
+          position: fixed;
+          top: 0;
+          left: 0;
+          right: 0;
+          bottom: 0;
+          background: rgba(0, 0, 0, 0.5);
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          z-index: 10000;
+          animation: fadeIn 0.2s ease-out;
+        }
+
+        .token-modal {
+          background: var(--color-bg);
+          border: 1px solid var(--color-border);
+          border-radius: 8px;
+          box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
+          min-width: 400px;
+          max-width: 90vw;
+          animation: slideIn 0.3s ease-out;
+        }
+
+        .token-modal__content {
+          padding: var(--spacing-lg);
+        }
+
+        .token-modal__header {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          margin-bottom: var(--spacing-md);
+        }
+
+        .token-modal__header h3 {
+          margin: 0;
+          color: var(--color-heading);
+          font-size: var(--font-size-lg);
+        }
+
+        .token-modal__close {
+          background: none;
+          border: none;
+          font-size: 1.5rem;
+          cursor: pointer;
+          padding: 4px;
+          color: var(--color-text-secondary);
+          border-radius: 4px;
+          transition: background-color var(--transition-fast), color var(--transition-fast);
+        }
+
+        .token-modal__close:hover {
+          background: var(--color-bg-secondary);
+          color: var(--color-text);
+        }
+
+        .token-modal__description {
+          margin-bottom: var(--spacing-lg);
+          color: var(--color-text-secondary);
+          font-size: var(--font-size-sm);
+        }
+
+        .token-modal__error {
+          background: var(--color-danger-bg);
+          color: var(--color-danger-border);
+          border: 1px solid var(--color-danger-border);
+          border-radius: 6px;
+          padding: var(--spacing-sm);
+          margin-bottom: var(--spacing-md);
+          font-size: var(--font-size-sm);
+        }
+
+        .token-modal__input {
+          width: 100%;
+          padding: var(--spacing-sm) var(--spacing-md);
+          border: 1px solid var(--color-border);
+          border-radius: 6px;
+          font-family: var(--font-body);
+          font-size: var(--font-size-base);
+          background: var(--color-bg);
+          color: var(--color-text);
+          margin-bottom: var(--spacing-md);
+          transition: border-color var(--transition-fast);
+        }
+
+        .token-modal__input:focus {
+          outline: none;
+          border-color: var(--color-accent);
+        }
+
+        .token-modal__input:disabled {
+          opacity: 0.6;
+          cursor: not-allowed;
+        }
+
+        .token-modal__actions {
+          display: flex;
+          gap: var(--spacing-sm);
+        }
+
+        .token-modal__submit {
+          flex: 1;
+          padding: var(--spacing-sm) var(--spacing-lg);
+          background: var(--color-accent);
+          color: #fff;
+          border: none;
+          border-radius: 6px;
+          font-size: var(--font-size-sm);
+          font-weight: 500;
+          cursor: pointer;
+          transition: background-color var(--transition-fast);
+        }
+
+        .token-modal__submit:hover:not(:disabled) {
+          background: var(--color-accent-hover);
+        }
+
+        .token-modal__submit:disabled {
+          opacity: 0.6;
+          cursor: not-allowed;
+        }
+
+        .token-modal__cancel {
+          padding: var(--spacing-sm) var(--spacing-lg);
+          background: none;
+          color: var(--color-text-secondary);
+          border: 1px solid var(--color-border);
+          border-radius: 6px;
+          font-size: var(--font-size-sm);
+          cursor: pointer;
+          transition: all var(--transition-fast);
+        }
+
+        .token-modal__cancel:hover:not(:disabled) {
+          background: var(--color-bg-secondary);
+          color: var(--color-text);
+        }
+
+        .token-modal__cancel:disabled {
+          opacity: 0.6;
+          cursor: not-allowed;
+        }
+
+        @keyframes fadeIn {
+          from {
+            opacity: 0;
+          }
+          to {
+            opacity: 1;
+          }
+        }
+
+        @keyframes slideIn {
+          from {
+            opacity: 0;
+            transform: scale(0.9);
+          }
+          to {
+            opacity: 1;
+            transform: scale(1);
+          }
+        }
+
+        /* Dark theme adjustments */
+        :global([data-theme="dark"]) .token-modal {
+          box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+        }
+
+        /* Mobile responsive */
+        @media (max-width: 768px) {
+          .token-modal {
+            min-width: 320px;
+            max-width: 95vw;
+          }
+
+          .token-modal__content {
+            padding: var(--spacing-md);
+          }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/packages/site/src/layouts/DocLayout.astro
+++ b/packages/site/src/layouts/DocLayout.astro
@@ -9,6 +9,8 @@ import TtsControlsBar from '../components/TtsControlsBar.tsx';
 import AnnotationThread from '../components/AnnotationThread.tsx';
 import CommentDraft from '../components/CommentDraft.tsx';
 import SubmitReview from '../components/SubmitReview.tsx';
+import TokenModal from '../components/TokenModal.tsx';
+import AuthIndicator from '../components/AuthIndicator.tsx';
 
 interface Props {
   title?: string;
@@ -54,6 +56,7 @@ const base = import.meta.env.BASE_URL;
     <a href={`${base}/`} class="header-title" style="text-decoration: none;">🏭 Foundry</a>
     <div class="header-right">
       {/* Sidebar slot — nav goes here (S2) */}
+      <AuthIndicator client:load />
       <ThemeToggle client:load />
       <slot name="header-actions" />
     </div>
@@ -85,6 +88,7 @@ const base = import.meta.env.BASE_URL;
   </div>
 
   <TtsControlsBar client:load />
+  <TokenModal client:load />
 
   <script is:inline>
     // Unified sidebar toggle (works on both desktop and mobile)

--- a/packages/site/src/styles/global.css
+++ b/packages/site/src/styles/global.css
@@ -1594,3 +1594,69 @@ pre.mermaid {
   box-shadow: 0 3px 12px rgba(0, 0, 0, 0.4);
 }
 
+/* --- Thread Auth Prompt --- */
+.thread-auth-prompt {
+  text-align: center;
+  padding: var(--spacing-xl);
+  color: var(--color-text-secondary);
+}
+
+.thread-auth-prompt__content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-md);
+}
+
+.thread-auth-prompt__icon {
+  font-size: 2rem;
+  opacity: 0.6;
+}
+
+.thread-auth-prompt__text {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-sm);
+}
+
+.thread-auth-prompt__text p {
+  margin: 0;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+}
+
+.thread-auth-prompt__button {
+  background: var(--color-accent);
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: var(--spacing-sm) var(--spacing-lg);
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color var(--transition-fast);
+}
+
+.thread-auth-prompt__button:hover {
+  background: var(--color-accent-hover);
+}
+
+/* --- Auth Indicator --- */
+.auth-indicator {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  padding: 6px;
+  font-size: 1.1rem;
+  transition: background-color var(--transition-fast);
+}
+
+.auth-indicator:hover {
+  background: var(--color-bg-secondary);
+}
+

--- a/packages/site/src/utils/api.ts
+++ b/packages/site/src/utils/api.ts
@@ -1,0 +1,37 @@
+const TOKEN_KEY = 'foundry_token';
+
+export function getToken(): string | null {
+  return localStorage.getItem(TOKEN_KEY);
+}
+
+export function setToken(token: string): void {
+  localStorage.setItem(TOKEN_KEY, token);
+}
+
+export function clearToken(): void {
+  localStorage.removeItem(TOKEN_KEY);
+}
+
+export function isAuthenticated(): boolean {
+  return !!getToken();
+}
+
+// Wrapper for fetch that adds auth headers to protected endpoints
+export async function authFetch(url: string, options: RequestInit = {}): Promise<Response> {
+  const token = getToken();
+  const headers = new Headers(options.headers || {});
+
+  if (token) {
+    headers.set('Authorization', `Bearer ${token}`);
+  }
+
+  const response = await fetch(url, { ...options, headers });
+
+  // If we get a 401, clear the stored token and dispatch event
+  if (response.status === 401) {
+    clearToken();
+    window.dispatchEvent(new CustomEvent('foundry-auth-required'));
+  }
+
+  return response;
+}


### PR DESCRIPTION
## E5-S2: Frontend Token Modal + Auth Headers

### What
- TokenModal React island — overlay modal for token entry
- Auth-aware fetch wrapper (`authFetch`) with auto 401 handling
- All annotation/review API calls now include Bearer token
- Lock/unlock indicator in header
- Unauthenticated state: thread panel shows unlock prompt, comment drafting disabled

### Components
- `TokenModal.tsx` — modal overlay, password input, dark/light theme
- `utils/api.ts` — token management + auth-aware fetch
- Updated: AnnotationThread, SubmitReview, CommentDraft
- Updated: DocLayout.astro (TokenModal + lock icon)

### UX Flow
1. Visit site → docs render freely (no auth needed)
2. Open thread panel → see unlock prompt
3. Click unlock → modal appears → enter token
4. Token stored in localStorage → annotations load
5. On 401 → token cleared → modal re-shows with error

Part of E5: Authentication + Write Protection