### PR TITLE
feat(E5-S3): MCP tool auth integration

### DIFF
--- a/packages/api/src/mcp/__tests__/annotations.test.ts
+++ b/packages/api/src/mcp/__tests__/annotations.test.ts
@@ -1,0 +1,637 @@
+import { beforeEach, afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { getDb, closeDb } from '../../db.js';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import {
+  listAnnotations,
+  createAnnotation,
+  resolveAnnotation,
+  submitReview,
+  registerAnnotationTools
+} from '../tools/annotations.js';
+import { registerSearchTool } from '../tools/search.js';
+
+// Mock Anvil for search tool tests
+const mockAnvil = {
+  search: async (query: string, topK: number) => {
+    // Return mock search results for testing
+    return [
+      {
+        content: 'This is test content for the search query',
+        metadata: {
+          file_path: 'test-doc.md',
+          heading_path: 'Test Section'
+        },
+        score: 0.95
+      }
+    ];
+  }
+} as any;
+
+// Mock the db module to use a test database
+let testDbPath: string;
+let originalToken: string | undefined;
+
+beforeEach(() => {
+  // Save original env
+  originalToken = process.env.FOUNDRY_WRITE_TOKEN;
+
+  // Create a temporary directory for test database
+  const tempDir = mkdtempSync(join(tmpdir(), 'foundry-test-'));
+  testDbPath = join(tempDir, 'test.db');
+  process.env.FOUNDRY_DB_PATH = testDbPath;
+
+  // Initialize the test database
+  const db = getDb();
+
+  // Create tables
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS annotations (
+      id TEXT PRIMARY KEY,
+      doc_path TEXT NOT NULL,
+      heading_path TEXT,
+      content_hash TEXT,
+      quoted_text TEXT,
+      content TEXT NOT NULL,
+      parent_id TEXT,
+      review_id TEXT,
+      user_id TEXT NOT NULL,
+      author_type TEXT NOT NULL CHECK (author_type IN ('human', 'ai')),
+      status TEXT NOT NULL CHECK (status IN ('draft', 'submitted', 'replied', 'resolved', 'orphaned')),
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS reviews (
+      id TEXT PRIMARY KEY,
+      doc_path TEXT NOT NULL,
+      user_id TEXT NOT NULL,
+      status TEXT NOT NULL CHECK (status IN ('draft', 'submitted', 'approved', 'rejected')),
+      submitted_at TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+  `);
+});
+
+afterEach(() => {
+  // Restore original env
+  if (originalToken === undefined) {
+    delete process.env.FOUNDRY_WRITE_TOKEN;
+  } else {
+    process.env.FOUNDRY_WRITE_TOKEN = originalToken;
+  }
+
+  // Clean up test database
+  closeDb();
+  if (testDbPath) {
+    try {
+      rmSync(testDbPath, { recursive: true, force: true });
+    } catch (error) {
+      // Ignore cleanup errors
+    }
+  }
+  delete process.env.FOUNDRY_DB_PATH;
+});
+
+/**
+ * Test verifyAuthToken function directly
+ */
+function testVerifyAuthToken(authToken?: string) {
+  // Extract the verifyAuthToken function to test it directly
+  const expectedToken = process.env.FOUNDRY_WRITE_TOKEN;
+
+  // If auth token is not configured, allow all requests (dev mode)
+  if (!expectedToken) {
+    return null;
+  }
+
+  // Check if auth token is provided and matches
+  if (!authToken || authToken !== expectedToken) {
+    return {
+      content: [{ type: "text", text: "Authentication required. Provide a valid auth_token parameter." }],
+      isError: true
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Helper function to simulate MCP tool calls for testing
+ */
+async function callMcpTool(toolName: string, args: any, includeSearchTool = false): Promise<any> {
+  const server = new Server({
+    name: 'foundry-test',
+    version: '0.2.0',
+  }, {
+    capabilities: {
+      tools: {}
+    }
+  });
+
+  // Register annotation tools
+  registerAnnotationTools(server);
+
+  // Register search tool if requested
+  if (includeSearchTool) {
+    registerSearchTool(server, mockAnvil);
+  }
+
+  // Get the call tool request handler by accessing the private _requestHandlers
+  const callHandler = (server as any)._requestHandlers?.get(CallToolRequestSchema.name);
+  if (!callHandler) {
+    // Try alternative access patterns
+    const handlers = (server as any).requestHandlers || (server as any)._handlers;
+    const altHandler = handlers?.get(CallToolRequestSchema.name) || handlers?.get('tools/call');
+    if (!altHandler) {
+      throw new Error('No call handler registered');
+    }
+
+    // Use the alternative handler
+    const request = {
+      method: 'tools/call',
+      params: {
+        name: toolName,
+        arguments: args
+      }
+    };
+
+    try {
+      const result = await altHandler(request);
+      return result;
+    } catch (error) {
+      return {
+        content: [{ type: 'text', text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
+        isError: true
+      };
+    }
+  }
+
+  // Simulate tool call
+  const request = {
+    method: 'tools/call',
+    params: {
+      name: toolName,
+      arguments: args
+    }
+  };
+
+  try {
+    const result = await callHandler(request);
+    return result;
+  } catch (error) {
+    return {
+      content: [{ type: 'text', text: `Error: ${error instanceof Error ? error.message : String(error)}` }],
+      isError: true
+    };
+  }
+}
+
+describe('Core annotation functions (no auth)', () => {
+  describe('listAnnotations', () => {
+    it('should list annotations for a doc_path', () => {
+      const annotation = createAnnotation({
+        doc_path: 'test-doc.md',
+        section: 'intro',
+        content: 'Test annotation'
+      });
+
+      const results = listAnnotations('test-doc.md');
+      expect(results).toHaveLength(1);
+      expect(results[0].id).toBe(annotation.id);
+      expect(results[0].content).toBe('Test annotation');
+    });
+
+    it('should filter by section', () => {
+      createAnnotation({
+        doc_path: 'test-doc.md',
+        section: 'intro',
+        content: 'Intro annotation'
+      });
+      createAnnotation({
+        doc_path: 'test-doc.md',
+        section: 'conclusion',
+        content: 'Conclusion annotation'
+      });
+
+      const results = listAnnotations('test-doc.md', 'intro');
+      expect(results).toHaveLength(1);
+      expect(results[0].content).toBe('Intro annotation');
+    });
+
+    it('should filter by status', () => {
+      createAnnotation({
+        doc_path: 'test-doc.md',
+        section: 'intro',
+        content: 'Draft annotation'
+      });
+      const resolved = createAnnotation({
+        doc_path: 'test-doc.md',
+        section: 'intro',
+        content: 'Resolved annotation'
+      });
+      resolveAnnotation(resolved.id);
+
+      const submittedResults = listAnnotations('test-doc.md', undefined, 'submitted');
+      expect(submittedResults).toHaveLength(1);
+      expect(submittedResults[0].content).toBe('Draft annotation');
+
+      const resolvedResults = listAnnotations('test-doc.md', undefined, 'resolved');
+      expect(resolvedResults).toHaveLength(1);
+      expect(resolvedResults[0].content).toBe('Resolved annotation');
+    });
+  });
+
+  describe('createAnnotation', () => {
+    it('should create annotation with default values', () => {
+      const annotation = createAnnotation({
+        doc_path: 'test-doc.md',
+        section: 'intro',
+        content: 'Test annotation'
+      });
+
+      expect(annotation.id).toBeTruthy();
+      expect(annotation.doc_path).toBe('test-doc.md');
+      expect(annotation.heading_path).toBe('intro');
+      expect(annotation.content).toBe('Test annotation');
+      expect(annotation.user_id).toBe('clay');
+      expect(annotation.author_type).toBe('ai');
+      expect(annotation.status).toBe('submitted');
+      expect(annotation.parent_id).toBeNull();
+      expect(annotation.created_at).toBeTruthy();
+      expect(annotation.updated_at).toBeTruthy();
+    });
+
+    it('should create reply annotation when parent_id provided', () => {
+      const parent = createAnnotation({
+        doc_path: 'test-doc.md',
+        section: 'intro',
+        content: 'Parent annotation'
+      });
+
+      const reply = createAnnotation({
+        doc_path: 'test-doc.md',
+        section: 'intro',
+        content: 'Reply annotation',
+        parent_id: parent.id
+      });
+
+      expect(reply.parent_id).toBe(parent.id);
+      expect(reply.status).toBe('replied');
+    });
+
+    it('should use custom author_type when provided', () => {
+      const annotation = createAnnotation({
+        doc_path: 'test-doc.md',
+        section: 'intro',
+        content: 'Human annotation',
+        author_type: 'human'
+      });
+
+      expect(annotation.author_type).toBe('human');
+    });
+  });
+
+  describe('resolveAnnotation', () => {
+    it('should resolve existing annotation', () => {
+      const annotation = createAnnotation({
+        doc_path: 'test-doc.md',
+        section: 'intro',
+        content: 'Test annotation'
+      });
+
+      const result = resolveAnnotation(annotation.id);
+
+      expect(result.status).toBe('resolved');
+      expect(result.annotation_id).toBe(annotation.id);
+
+      // Verify annotation is actually resolved in database
+      const resolved = listAnnotations('test-doc.md', undefined, 'resolved');
+      expect(resolved).toHaveLength(1);
+      expect(resolved[0].id).toBe(annotation.id);
+    });
+
+    it('should return error for non-existent annotation', () => {
+      const result = resolveAnnotation('non-existent-id');
+
+      expect(result.status).toBe('error');
+      expect(result.message).toBe('Annotation not found');
+    });
+  });
+
+  describe('submitReview', () => {
+    it('should create review with specified annotation IDs', () => {
+      const annotation1 = createAnnotation({
+        doc_path: 'test-doc.md',
+        section: 'intro',
+        content: 'First annotation'
+      });
+      const annotation2 = createAnnotation({
+        doc_path: 'test-doc.md',
+        section: 'conclusion',
+        content: 'Second annotation'
+      });
+
+      const result = submitReview('test-doc.md', [annotation1.id, annotation2.id]);
+
+      expect(result).toMatchObject({
+        status: 'review_submitted',
+        doc_path: 'test-doc.md',
+        comment_count: 2
+      });
+
+      expect((result as any).review_id).toBeTruthy();
+      expect((result as any).submitted_at).toBeTruthy();
+      expect((result as any).comments).toHaveLength(2);
+    });
+
+    it('should include all draft/submitted annotations when no IDs specified', () => {
+      createAnnotation({
+        doc_path: 'test-doc.md',
+        section: 'intro',
+        content: 'First annotation'
+      });
+      createAnnotation({
+        doc_path: 'test-doc.md',
+        section: 'conclusion',
+        content: 'Second annotation'
+      });
+
+      const result = submitReview('test-doc.md');
+
+      expect((result as any).comment_count).toBe(2);
+    });
+
+    it('should update annotation statuses to submitted', () => {
+      const annotation = createAnnotation({
+        doc_path: 'test-doc.md',
+        section: 'intro',
+        content: 'Test annotation'
+      });
+
+      submitReview('test-doc.md', [annotation.id]);
+
+      // Verify annotation status was updated
+      const updated = listAnnotations('test-doc.md', undefined, 'submitted');
+      expect(updated).toHaveLength(1);
+      expect(updated[0].id).toBe(annotation.id);
+    });
+  });
+});
+
+describe('MCP Tool Authentication', () => {
+  describe('Dev mode (no FOUNDRY_WRITE_TOKEN)', () => {
+    beforeEach(() => {
+      delete process.env.FOUNDRY_WRITE_TOKEN;
+    });
+
+    it('should allow list_annotations without auth_token', async () => {
+      createAnnotation({
+        doc_path: 'test-doc.md',
+        section: 'intro',
+        content: 'Test annotation'
+      });
+
+      const result = await callMcpTool('list_annotations', {
+        doc_path: 'test-doc.md'
+      });
+
+      expect(result.content).toBeDefined();
+      expect(result.isError).toBeUndefined();
+      const data = JSON.parse(result.content[0].text);
+      expect(data).toHaveLength(1);
+    });
+
+    it('should allow create_annotation without auth_token', async () => {
+      const result = await callMcpTool('create_annotation', {
+        doc_path: 'test-doc.md',
+        section: 'intro',
+        content: 'Test annotation'
+      });
+
+      expect(result.content).toBeDefined();
+      expect(result.isError).toBeUndefined();
+      const data = JSON.parse(result.content[0].text);
+      expect(data.status).toBe('created');
+      expect(data.annotation).toBeDefined();
+    });
+
+    it('should allow resolve_annotation without auth_token', async () => {
+      const annotation = createAnnotation({
+        doc_path: 'test-doc.md',
+        section: 'intro',
+        content: 'Test annotation'
+      });
+
+      const result = await callMcpTool('resolve_annotation', {
+        annotation_id: annotation.id
+      });
+
+      expect(result.content).toBeDefined();
+      expect(result.isError).toBeUndefined();
+      const data = JSON.parse(result.content[0].text);
+      expect(data.status).toBe('resolved');
+    });
+
+    it('should allow submit_review without auth_token', async () => {
+      createAnnotation({
+        doc_path: 'test-doc.md',
+        section: 'intro',
+        content: 'Test annotation'
+      });
+
+      const result = await callMcpTool('submit_review', {
+        doc_path: 'test-doc.md'
+      });
+
+      expect(result.content).toBeDefined();
+      expect(result.isError).toBeUndefined();
+      const data = JSON.parse(result.content[0].text);
+      expect(data.status).toBe('review_submitted');
+    });
+  });
+
+  describe('Production mode (FOUNDRY_WRITE_TOKEN set)', () => {
+    beforeEach(() => {
+      process.env.FOUNDRY_WRITE_TOKEN = 'test-secret-token';
+    });
+
+    it('should reject list_annotations without auth_token', async () => {
+      const result = await callMcpTool('list_annotations', {
+        doc_path: 'test-doc.md'
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toBe('Authentication required. Provide a valid auth_token parameter.');
+    });
+
+    it('should reject list_annotations with invalid auth_token', async () => {
+      const result = await callMcpTool('list_annotations', {
+        doc_path: 'test-doc.md',
+        auth_token: 'wrong-token'
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toBe('Authentication required. Provide a valid auth_token parameter.');
+    });
+
+    it('should allow list_annotations with valid auth_token', async () => {
+      createAnnotation({
+        doc_path: 'test-doc.md',
+        section: 'intro',
+        content: 'Test annotation'
+      });
+
+      const result = await callMcpTool('list_annotations', {
+        doc_path: 'test-doc.md',
+        auth_token: 'test-secret-token'
+      });
+
+      expect(result.content).toBeDefined();
+      expect(result.isError).toBeUndefined();
+      const data = JSON.parse(result.content[0].text);
+      expect(data).toHaveLength(1);
+    });
+
+    it('should reject create_annotation without auth_token', async () => {
+      const result = await callMcpTool('create_annotation', {
+        doc_path: 'test-doc.md',
+        section: 'intro',
+        content: 'Test annotation'
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toBe('Authentication required. Provide a valid auth_token parameter.');
+    });
+
+    it('should allow create_annotation with valid auth_token', async () => {
+      const result = await callMcpTool('create_annotation', {
+        doc_path: 'test-doc.md',
+        section: 'intro',
+        content: 'Test annotation',
+        auth_token: 'test-secret-token'
+      });
+
+      expect(result.content).toBeDefined();
+      expect(result.isError).toBeUndefined();
+      const data = JSON.parse(result.content[0].text);
+      expect(data.status).toBe('created');
+    });
+
+    it('should reject resolve_annotation without auth_token', async () => {
+      const annotation = createAnnotation({
+        doc_path: 'test-doc.md',
+        section: 'intro',
+        content: 'Test annotation'
+      });
+
+      const result = await callMcpTool('resolve_annotation', {
+        annotation_id: annotation.id
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toBe('Authentication required. Provide a valid auth_token parameter.');
+    });
+
+    it('should allow resolve_annotation with valid auth_token', async () => {
+      const annotation = createAnnotation({
+        doc_path: 'test-doc.md',
+        section: 'intro',
+        content: 'Test annotation'
+      });
+
+      const result = await callMcpTool('resolve_annotation', {
+        annotation_id: annotation.id,
+        auth_token: 'test-secret-token'
+      });
+
+      expect(result.content).toBeDefined();
+      expect(result.isError).toBeUndefined();
+      const data = JSON.parse(result.content[0].text);
+      expect(data.status).toBe('resolved');
+    });
+
+    it('should reject submit_review without auth_token', async () => {
+      createAnnotation({
+        doc_path: 'test-doc.md',
+        section: 'intro',
+        content: 'Test annotation'
+      });
+
+      const result = await callMcpTool('submit_review', {
+        doc_path: 'test-doc.md'
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toBe('Authentication required. Provide a valid auth_token parameter.');
+    });
+
+    it('should allow submit_review with valid auth_token', async () => {
+      createAnnotation({
+        doc_path: 'test-doc.md',
+        section: 'intro',
+        content: 'Test annotation'
+      });
+
+      const result = await callMcpTool('submit_review', {
+        doc_path: 'test-doc.md',
+        auth_token: 'test-secret-token'
+      });
+
+      expect(result.content).toBeDefined();
+      expect(result.isError).toBeUndefined();
+      const data = JSON.parse(result.content[0].text);
+      expect(data.status).toBe('review_submitted');
+    });
+  });
+});
+
+describe('Search Tool (No Auth Required)', () => {
+  beforeEach(() => {
+    // Test both with and without FOUNDRY_WRITE_TOKEN to verify search is always public
+    process.env.FOUNDRY_WRITE_TOKEN = 'test-secret-token';
+  });
+
+  it('should allow search_docs without auth_token when FOUNDRY_WRITE_TOKEN is set', async () => {
+    const result = await callMcpTool('search_docs', {
+      query: 'test search query'
+    }, true);
+
+    expect(result.content).toBeDefined();
+    expect(result.isError).toBeUndefined();
+    const data = JSON.parse(result.content[0].text);
+    expect(data.results).toBeDefined();
+    expect(data.query).toBe('test search query');
+  });
+
+  it('should allow search_docs without auth_token when FOUNDRY_WRITE_TOKEN is not set', async () => {
+    delete process.env.FOUNDRY_WRITE_TOKEN;
+
+    const result = await callMcpTool('search_docs', {
+      query: 'test search query'
+    }, true);
+
+    expect(result.content).toBeDefined();
+    expect(result.isError).toBeUndefined();
+    const data = JSON.parse(result.content[0].text);
+    expect(data.results).toBeDefined();
+    expect(data.query).toBe('test search query');
+  });
+
+  it('should handle search with top_k parameter', async () => {
+    const result = await callMcpTool('search_docs', {
+      query: 'test search query',
+      top_k: 5
+    }, true);
+
+    expect(result.content).toBeDefined();
+    expect(result.isError).toBeUndefined();
+    const data = JSON.parse(result.content[0].text);
+    expect(data.results).toBeDefined();
+    expect(data.totalResults).toBe(1); // Based on our mock
+  });
+});

--- a/packages/api/src/mcp/server.ts
+++ b/packages/api/src/mcp/server.ts
@@ -5,6 +5,18 @@ import { registerAnnotationTools } from './tools/annotations.js';
 
 /**
  * Creates and configures the MCP server for Foundry
+ *
+ * Available tools:
+ * - search_docs: Public tool for searching documentation (no auth required)
+ * - list_annotations: List annotations for a document (requires auth_token when FOUNDRY_WRITE_TOKEN is set)
+ * - create_annotation: Create new annotation (requires auth_token when FOUNDRY_WRITE_TOKEN is set)
+ * - resolve_annotation: Mark annotation as resolved (requires auth_token when FOUNDRY_WRITE_TOKEN is set)
+ * - submit_review: Submit annotations as review batch (requires auth_token when FOUNDRY_WRITE_TOKEN is set)
+ *
+ * Authentication:
+ * - If FOUNDRY_WRITE_TOKEN environment variable is not set, all tools are accessible (dev mode)
+ * - If FOUNDRY_WRITE_TOKEN is set, annotation tools require auth_token parameter matching the env var
+ * - Search tools are always public and do not require authentication
  */
 export function createMcpServer(anvil: Anvil): Server {
   const server = new Server({

--- a/packages/api/src/mcp/tools/annotations.ts
+++ b/packages/api/src/mcp/tools/annotations.ts
@@ -5,6 +5,29 @@ import { createId } from '@paralleldrive/cuid2';
 import type { Annotation } from '../../types/annotations.js';
 
 /**
+ * Verify authentication token for MCP annotation tools
+ * Returns null if auth is valid, or an error response object if invalid
+ */
+function verifyAuthToken(authToken?: string): { content: Array<{ type: string; text: string }>; isError: true } | null {
+  const expectedToken = process.env.FOUNDRY_WRITE_TOKEN;
+
+  // If auth token is not configured, allow all requests (dev mode)
+  if (!expectedToken) {
+    return null;
+  }
+
+  // Check if auth token is provided and matches
+  if (!authToken || authToken !== expectedToken) {
+    return {
+      content: [{ type: "text", text: "Authentication required. Provide a valid auth_token parameter." }],
+      isError: true
+    };
+  }
+
+  return null;
+}
+
+/**
  * Core annotation functions that can be tested
  */
 export function listAnnotations(docPath: string, section?: string, status?: string): Annotation[] {
@@ -146,6 +169,10 @@ export function registerAnnotationTools(server: Server): void {
               status: {
                 type: 'string',
                 description: 'Optional status filter (draft, submitted, replied, resolved, orphaned)'
+              },
+              auth_token: {
+                type: 'string',
+                description: 'Authentication token (required when FOUNDRY_WRITE_TOKEN is set)'
               }
             },
             required: ['doc_path']
@@ -176,6 +203,10 @@ export function registerAnnotationTools(server: Server): void {
               author_type: {
                 type: 'string',
                 description: 'Optional author type (human or ai), defaults to ai for MCP callers'
+              },
+              auth_token: {
+                type: 'string',
+                description: 'Authentication token (required when FOUNDRY_WRITE_TOKEN is set)'
               }
             },
             required: ['doc_path', 'section', 'content']
@@ -190,6 +221,10 @@ export function registerAnnotationTools(server: Server): void {
               annotation_id: {
                 type: 'string',
                 description: 'ID of the annotation to resolve'
+              },
+              auth_token: {
+                type: 'string',
+                description: 'Authentication token (required when FOUNDRY_WRITE_TOKEN is set)'
               }
             },
             required: ['annotation_id']
@@ -211,6 +246,10 @@ export function registerAnnotationTools(server: Server): void {
                   type: 'string'
                 },
                 description: 'Optional array of annotation IDs to include in review'
+              },
+              auth_token: {
+                type: 'string',
+                description: 'Authentication token (required when FOUNDRY_WRITE_TOKEN is set)'
               }
             },
             required: ['doc_path']
@@ -230,15 +269,27 @@ export function registerAnnotationTools(server: Server): void {
 
     switch (name) {
       case 'list_annotations': {
+        // Verify authentication
+        const authError = verifyAuthToken(args.auth_token as string | undefined);
+        if (authError) {
+          return authError;
+        }
+
         const result = listAnnotations(
-          args.doc_path as string, 
-          args.section as string | undefined, 
+          args.doc_path as string,
+          args.section as string | undefined,
           args.status as string | undefined
         );
         return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
       }
 
       case 'create_annotation': {
+        // Verify authentication
+        const authError = verifyAuthToken(args.auth_token as string | undefined);
+        if (authError) {
+          return authError;
+        }
+
         const result = createAnnotation({
           doc_path: args.doc_path as string,
           section: args.section as string,
@@ -250,13 +301,25 @@ export function registerAnnotationTools(server: Server): void {
       }
 
       case 'resolve_annotation': {
+        // Verify authentication
+        const authError = verifyAuthToken(args.auth_token as string | undefined);
+        if (authError) {
+          return authError;
+        }
+
         const result = resolveAnnotation(args.annotation_id as string);
         return { content: [{ type: "text", text: JSON.stringify(result) }] };
       }
 
       case 'submit_review': {
+        // Verify authentication
+        const authError = verifyAuthToken(args.auth_token as string | undefined);
+        if (authError) {
+          return authError;
+        }
+
         const result = submitReview(
-          args.doc_path as string, 
+          args.doc_path as string,
           args.annotation_ids as string[] | undefined
         );
         return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };


### PR DESCRIPTION
## E5-S3: MCP Tool Auth Integration

### What
- All 4 annotation MCP tools now require `auth_token` parameter
- Token validated against `FOUNDRY_WRITE_TOKEN` env var
- Dev mode (no env var) = auth skipped
- Auth failure returns structured MCP error (not crash)
- Doc search tools remain public (no auth needed)

### MCP Auth Matrix
| Tool | Auth Required |
|------|--------------|
| search_docs | ❌ |
| list_annotations | ✅ |
| create_annotation | ✅ |
| resolve_annotation | ✅ |
| submit_review | ✅ |

### Tests
- MCP annotation tool auth tests (4+ cases)
- Existing route tests still passing

Part of E5: Authentication + Write Protection