### PR TITLE
feat(E6-S1): Access JSON API + static file gating

### DIFF
--- a/claude-prompt.txt
+++ b/claude-prompt.txt
@@ -1,0 +1,130 @@
+You are implementing access-level content gating for the Foundry API server — public docs served freely, private docs require authentication.
+
+**Working directory:** /Users/danhannah/.openclaw/workspace/foundry-e6-s1
+
+**Context:**
+- `foundry.config.yaml` has `access: public` and `access: private` per source path
+- Build script already generates `packages/site/content/.access.json` mapping content prefixes to access levels:
+  ```json
+  { "methodology/": "public", "projects/": "private" }
+  ```
+- Static site builds to `packages/site/dist/` with structure like `docs/methodology/...` and `docs/projects/...`
+- `packages/api/src/middleware/auth.ts` exports `requireAuth` middleware (from E5)
+- The Express server serves static files via `app.use(express.static(STATIC_PATH))` at line 168 of `packages/api/src/index.ts`
+- STATIC_PATH = `packages/site/dist`
+
+**What to build:**
+
+1. **Create `packages/api/src/access.ts`** — Access control utilities:
+   ```typescript
+   import { readFileSync } from 'fs';
+   import { join } from 'path';
+   
+   interface AccessMap {
+     [prefix: string]: 'public' | 'private';
+   }
+   
+   let accessMap: AccessMap | null = null;
+   
+   // Load .access.json from the content directory
+   export function loadAccessMap(contentPath: string): AccessMap {
+     try {
+       const raw = readFileSync(join(contentPath, '.access.json'), 'utf-8');
+       accessMap = JSON.parse(raw);
+       return accessMap;
+     } catch {
+       console.warn('⚠️ No .access.json found — all content treated as public');
+       accessMap = {};
+       return accessMap;
+     }
+   }
+   
+   export function getAccessMap(): AccessMap {
+     return accessMap || {};
+   }
+   
+   // Resolve a doc path to its access level
+   // docPath like "projects/routr/design" matches prefix "projects/"
+   export function getAccessLevel(docPath: string): 'public' | 'private' {
+     const map = getAccessMap();
+     // Try longest prefix match first
+     const prefixes = Object.keys(map).sort((a, b) => b.length - a.length);
+     for (const prefix of prefixes) {
+       if (docPath.startsWith(prefix) || docPath === prefix.replace(/\/$/, '')) {
+         return map[prefix];
+       }
+     }
+     return 'public'; // default to public if no match
+   }
+   ```
+
+2. **Create `GET /api/access` endpoint:**
+   - Add to `packages/api/src/routes/access.ts` (new file)
+   - Returns the `.access.json` content as JSON
+   - NO auth required (frontend needs this to filter nav)
+   - Simple: `router.get('/access', (req, res) => res.json(getAccessMap()))`
+
+3. **Update `packages/api/src/index.ts`** — Add access-gated static serving:
+   - Import `loadAccessMap`, `getAccessLevel` from `./access.js`
+   - Load the access map at startup
+   - **Best approach:** Copy `.access.json` into `dist/` during the Astro build or as a post-build step. Add to `packages/site/package.json` scripts: `"postbuild": "cp content/.access.json dist/.access.json 2>/dev/null || true"`. Then load from `join(STATIC_PATH, '.access.json')`
+   - Mount the access router: `app.use('/api', createAccessRouter())`
+   - Add access-gated static middleware BEFORE the generic static middleware:
+     ```typescript
+     // Access-gated static serving for /docs paths
+     app.use('/docs', (req, res, next) => {
+       // Strip leading slash, trailing /index.html, trailing slash
+       let docPath = req.path.replace(/^\//, '').replace(/\/index\.html$/, '').replace(/\/$/, '');
+       // Also remove .html extension
+       docPath = docPath.replace(/\.html$/, '');
+       
+       const level = getAccessLevel(docPath);
+       if (level === 'private') {
+         // Use the same requireAuth middleware from E5
+         return requireAuth(req, res, next);
+       }
+       next();
+     });
+     
+     // Then the regular static serving
+     app.use(express.static(STATIC_PATH));
+     ```
+
+4. **Update `packages/api/src/routes/docs.ts`:**
+   - Import `getAccessLevel` from `../access.js`
+   - Import `requireAuth` from `../middleware/auth.js`
+   - Before returning doc content, check if the requested doc path is private
+   - If private and no valid auth → 401
+
+5. **Add postbuild script to `packages/site/package.json`:**
+   - Add `"postbuild": "cp content/.access.json dist/.access.json 2>/dev/null || true"` to scripts
+
+6. **Tests — Create `packages/api/src/__tests__/access.test.ts`:**
+   - Test `getAccessLevel()`:
+     - "methodology/process" → "public"
+     - "projects/routr/design" → "private"
+     - "unknown/path" → "public" (default)
+     - Empty path → "public"
+   - Test `loadAccessMap()` with valid JSON file
+   - Test `loadAccessMap()` with missing file → empty map, no crash
+   
+7. **Tests — Create `packages/api/src/routes/__tests__/access.test.ts`:**
+   - Test GET /api/access returns the access map
+
+8. **Return 401 (not 404) for private content**
+
+**What NOT to touch:**
+- No nav changes (that's S2)
+- No search changes (that's S3)
+- No MCP changes (that's S3)
+- Don't modify the auth middleware itself
+- Don't change annotation/review routes
+
+**Verification:**
+```bash
+cd /Users/danhannah/.openclaw/workspace/foundry-e6-s1
+# Build site to generate .access.json in dist
+cd packages/site && npx astro build 2>&1
+# Run API tests
+cd ../api && npx vitest run 2>&1
+```

--- a/packages/api/src/__tests__/access.test.ts
+++ b/packages/api/src/__tests__/access.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { loadAccessMap, getAccessMap, getAccessLevel } from '../access.js';
+
+// Mock fs module
+vi.mock('fs', () => ({
+  readFileSync: vi.fn(),
+}));
+
+describe('access', () => {
+  const mockReadFileSync = vi.mocked(readFileSync);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset internal state
+    loadAccessMap('/fake/path');
+  });
+
+  describe('loadAccessMap', () => {
+    it('should load access map from valid JSON file', () => {
+      const mockAccessMap = {
+        'methodology/': 'public' as const,
+        'projects/': 'private' as const,
+      };
+
+      mockReadFileSync.mockReturnValue(JSON.stringify(mockAccessMap));
+
+      const result = loadAccessMap('/test/content');
+
+      expect(mockReadFileSync).toHaveBeenCalledWith(
+        join('/test/content', '.access.json'),
+        'utf-8'
+      );
+      expect(result).toEqual(mockAccessMap);
+      expect(getAccessMap()).toEqual(mockAccessMap);
+    });
+
+    it('should handle missing file gracefully', () => {
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      mockReadFileSync.mockImplementation(() => {
+        throw new Error('File not found');
+      });
+
+      const result = loadAccessMap('/test/content');
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        '⚠️ No .access.json found — all content treated as public'
+      );
+      expect(result).toEqual({});
+      expect(getAccessMap()).toEqual({});
+
+      consoleSpy.mockRestore();
+    });
+
+    it('should handle invalid JSON gracefully', () => {
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      mockReadFileSync.mockReturnValue('invalid json');
+
+      const result = loadAccessMap('/test/content');
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        '⚠️ No .access.json found — all content treated as public'
+      );
+      expect(result).toEqual({});
+      expect(getAccessMap()).toEqual({});
+
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('getAccessLevel', () => {
+    beforeEach(() => {
+      const mockAccessMap = {
+        'methodology/': 'public' as const,
+        'projects/': 'private' as const,
+        'projects/public/': 'public' as const,
+      };
+      mockReadFileSync.mockReturnValue(JSON.stringify(mockAccessMap));
+      loadAccessMap('/test/content');
+    });
+
+    it('should return public for methodology paths', () => {
+      expect(getAccessLevel('methodology/process')).toBe('public');
+      expect(getAccessLevel('methodology/tools/anvil')).toBe('public');
+    });
+
+    it('should return private for projects paths', () => {
+      expect(getAccessLevel('projects/routr/design')).toBe('private');
+      expect(getAccessLevel('projects/internal/secret')).toBe('private');
+    });
+
+    it('should return public for projects/public paths (longest match)', () => {
+      expect(getAccessLevel('projects/public/demo')).toBe('public');
+    });
+
+    it('should return public for unknown paths', () => {
+      expect(getAccessLevel('unknown/path')).toBe('public');
+      expect(getAccessLevel('random')).toBe('public');
+    });
+
+    it('should return public for empty path', () => {
+      expect(getAccessLevel('')).toBe('public');
+    });
+
+    it('should handle exact prefix match without trailing slash', () => {
+      expect(getAccessLevel('methodology')).toBe('public');
+      expect(getAccessLevel('projects')).toBe('private');
+    });
+
+    it('should prefer longer prefix matches', () => {
+      // projects/public/ should match before projects/
+      expect(getAccessLevel('projects/public/demo')).toBe('public');
+      expect(getAccessLevel('projects/private/secret')).toBe('private');
+    });
+  });
+
+  describe('getAccessMap when no map loaded', () => {
+    it('should return empty object when no map is loaded', () => {
+      // First reset any existing state by loading an empty map
+      mockReadFileSync.mockImplementation(() => {
+        throw new Error('File not found');
+      });
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      loadAccessMap('/fake/empty/path');
+      consoleSpy.mockRestore();
+
+      expect(getAccessMap()).toEqual({});
+    });
+  });
+});

--- a/packages/api/src/access.ts
+++ b/packages/api/src/access.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+interface AccessMap {
+  [prefix: string]: 'public' | 'private';
+}
+
+let accessMap: AccessMap | null = null;
+
+/**
+ * Load .access.json from the content directory
+ */
+export function loadAccessMap(contentPath: string): AccessMap {
+  try {
+    const raw = readFileSync(join(contentPath, '.access.json'), 'utf-8');
+    accessMap = JSON.parse(raw);
+    return accessMap;
+  } catch {
+    console.warn('⚠️ No .access.json found — all content treated as public');
+    accessMap = {};
+    return accessMap;
+  }
+}
+
+/**
+ * Get the current access map
+ */
+export function getAccessMap(): AccessMap {
+  return accessMap || {};
+}
+
+/**
+ * Resolve a doc path to its access level
+ * docPath like "projects/routr/design" matches prefix "projects/"
+ */
+export function getAccessLevel(docPath: string): 'public' | 'private' {
+  const map = getAccessMap();
+  // Try longest prefix match first
+  const prefixes = Object.keys(map).sort((a, b) => b.length - a.length);
+  for (const prefix of prefixes) {
+    if (docPath.startsWith(prefix) || docPath === prefix.replace(/\/$/, '')) {
+      return map[prefix];
+    }
+  }
+  return 'public'; // default to public if no match
+}

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -9,7 +9,9 @@ import { createDocsRouter } from './routes/docs.js';
 import { createSearchRouter } from './routes/search.js';
 import { createAnnotationsRouter } from './routes/annotations.js';
 import { createReviewsRouter } from './routes/reviews.js';
+import { createAccessRouter } from './routes/access.js';
 import { requireAuth, logAuthStatus } from './middleware/auth.js';
+import { loadAccessMap, getAccessLevel } from './access.js';
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
 import { createMcpServer } from './mcp/server.js';
 
@@ -76,6 +78,11 @@ async function startServer(): Promise<void> {
     // Initialize Anvil (dynamic import — handles missing package gracefully)
     const anvil = await loadAnvil(docsPath);
 
+    // Load access map from the static build directory
+    console.log('📋 Loading access map...');
+    loadAccessMap(STATIC_PATH);
+    console.log('✅ Access map loaded successfully');
+
     // Create MCP server (only if anvil is available)
     let mcpServer = null;
     if (anvil) {
@@ -135,6 +142,9 @@ async function startServer(): Promise<void> {
       });
     }
 
+    // Mount access router (always available, no anvil dependency)
+    app.use('/api', createAccessRouter());
+
     // Mount routers only when anvil is available
     if (anvil) {
       app.use('/api', createHealthRouter(anvil));
@@ -163,6 +173,21 @@ async function startServer(): Promise<void> {
     protectedReviewsRouter.use('/reviews', requireAuth);
     protectedReviewsRouter.use(createReviewsRouter());
     app.use('/api', protectedReviewsRouter);
+
+    // Access-gated static serving for /docs paths
+    app.use('/docs', (req, res, next) => {
+      // Strip leading slash, trailing /index.html, trailing slash
+      let docPath = req.path.replace(/^\//, '').replace(/\/index\.html$/, '').replace(/\/$/, '');
+      // Also remove .html extension
+      docPath = docPath.replace(/\.html$/, '');
+
+      const level = getAccessLevel(docPath);
+      if (level === 'private') {
+        // Use the same requireAuth middleware from E5
+        return requireAuth(req, res, next);
+      }
+      next();
+    });
 
     // Static file serving — serve the Astro build output
     app.use(express.static(STATIC_PATH));

--- a/packages/api/src/routes/__tests__/access.test.ts
+++ b/packages/api/src/routes/__tests__/access.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { createAccessRouter } from '../access.js';
+
+// Mock the access module
+vi.mock('../../access.js', () => ({
+  getAccessMap: vi.fn(),
+}));
+
+import { getAccessMap } from '../../access.js';
+
+describe('Access Routes', () => {
+  let app: express.Application;
+  const mockGetAccessMap = vi.mocked(getAccessMap);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = express();
+    app.use(express.json());
+    app.use('/api', createAccessRouter());
+  });
+
+  describe('GET /api/access', () => {
+    it('should return the access map', async () => {
+      const mockAccessMap = {
+        'methodology/': 'public' as const,
+        'projects/': 'private' as const,
+      };
+
+      mockGetAccessMap.mockReturnValue(mockAccessMap);
+
+      const response = await request(app)
+        .get('/api/access')
+        .expect(200);
+
+      expect(response.body).toEqual(mockAccessMap);
+      expect(mockGetAccessMap).toHaveBeenCalledOnce();
+    });
+
+    it('should return empty object when no access map is loaded', async () => {
+      mockGetAccessMap.mockReturnValue({});
+
+      const response = await request(app)
+        .get('/api/access')
+        .expect(200);
+
+      expect(response.body).toEqual({});
+      expect(mockGetAccessMap).toHaveBeenCalledOnce();
+    });
+
+    it('should return consistent data on multiple calls', async () => {
+      const mockAccessMap = {
+        'docs/': 'public' as const,
+        'internal/': 'private' as const,
+      };
+
+      mockGetAccessMap.mockReturnValue(mockAccessMap);
+
+      // First request
+      const response1 = await request(app)
+        .get('/api/access')
+        .expect(200);
+
+      // Second request
+      const response2 = await request(app)
+        .get('/api/access')
+        .expect(200);
+
+      expect(response1.body).toEqual(mockAccessMap);
+      expect(response2.body).toEqual(mockAccessMap);
+      expect(mockGetAccessMap).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/packages/api/src/routes/access.ts
+++ b/packages/api/src/routes/access.ts
@@ -1,0 +1,16 @@
+import { Router } from 'express';
+import { getAccessMap } from '../access.js';
+
+/**
+ * Creates the access router
+ */
+export function createAccessRouter(): Router {
+  const router = Router();
+
+  // GET /access - Get access map for frontend navigation filtering
+  router.get('/access', (req, res) => {
+    res.json(getAccessMap());
+  });
+
+  return router;
+}

--- a/packages/api/src/routes/docs.ts
+++ b/packages/api/src/routes/docs.ts
@@ -1,5 +1,7 @@
 import { Router, Request, Response } from 'express';
 import type { Anvil } from '@claymore-dev/anvil';
+import { getAccessLevel } from '../access.js';
+import { requireAuth } from '../middleware/auth.js';
 
 interface DocumentListItem {
   path: string;
@@ -52,6 +54,25 @@ export function createDocsRouter(anvil: Anvil): Router {
   router.get('/docs/:path(*)', async (req: Request, res: Response<DocumentDetail>) => {
     try {
       const path = req.params.path;
+
+      // Check access level for this document path
+      const level = getAccessLevel(path);
+      if (level === 'private') {
+        // Check auth using the same middleware logic
+        try {
+          await new Promise<void>((resolve, reject) => {
+            requireAuth(req, res, (err?: any) => {
+              if (err) reject(err);
+              else resolve();
+            });
+          });
+        } catch (authError) {
+          return res.status(401).json({
+            error: 'Authentication required for private content',
+          } as any);
+        }
+      }
+
       const page = await anvil.getPage(path);
 
       if (!page) {

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",
+    "postbuild": "cp content/.access.json dist/.access.json 2>/dev/null || true",
     "preview": "astro preview",
     "astro": "astro",
     "test": "vitest run"


### PR DESCRIPTION
## E6-S1: Access JSON API + Static File Gating

### What
- `GET /api/access` endpoint — serves .access.json (public, no auth)
- `getAccessLevel()` utility — resolves doc paths to public/private
- Static file gating: private doc HTML returns 401 without token
- `/api/docs/*` endpoints gated by access level
- .access.json copied to dist via postbuild script

### Access Matrix
| Path | Access |
|------|--------|
| /docs/methodology/* | ✅ Public |
| /docs/projects/* | 🔒 Private (requires token) |
| /api/access | ✅ Public |
| /api/docs/methodology/* | ✅ Public |
| /api/docs/projects/* | 🔒 Private |

### Tests
- getAccessLevel() unit tests (prefix matching, defaults)
- loadAccessMap() tests (valid file, missing file)
- GET /api/access endpoint test

Part of E6: Public/Private Doc Access Control