### PR TITLE
feat(E6-S3): Search + MCP access filtering

### DIFF
--- a/packages/api/src/mcp/__tests__/search.test.ts
+++ b/packages/api/src/mcp/__tests__/search.test.ts
@@ -1,0 +1,311 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import type { Anvil } from '@claymore-dev/anvil';
+import { registerSearchTool } from '../tools/search.js';
+import * as access from '../../access.js';
+
+// Mock Anvil instance
+const mockAnvil = {
+  search: vi.fn(),
+} as unknown as Anvil;
+
+describe('MCP search_docs tool access filtering', () => {
+  let server: Server;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Set up test environment for auth
+    process.env.FOUNDRY_WRITE_TOKEN = 'test-token';
+
+    // Mock getAccessLevel to simulate access controls
+    vi.spyOn(access, 'getAccessLevel').mockImplementation((path) => {
+      if (path.startsWith('projects/')) return 'private';
+      return 'public';
+    });
+
+    // Create a new server instance for each test
+    server = new Server(
+      { name: 'test-mcp-server', version: '1.0.0' },
+      { capabilities: {} }
+    );
+
+    // Register the search tool
+    registerSearchTool(server, mockAnvil);
+  });
+
+  it('should filter out private results when no auth token is provided', async () => {
+    const mockResults = [
+      {
+        content: 'Public content in methodology',
+        score: 0.85,
+        metadata: {
+          file_path: 'methodology/process.md',
+          heading_path: 'Process',
+          heading_level: 1,
+          last_modified: '2024-01-01T00:00:00Z',
+          char_count: 100,
+        },
+      },
+      {
+        content: 'Private content in projects',
+        score: 0.75,
+        metadata: {
+          file_path: 'projects/secret/design.md',
+          heading_path: 'Secret Design',
+          heading_level: 1,
+          last_modified: '2024-01-02T00:00:00Z',
+          char_count: 200,
+        },
+      },
+    ];
+
+    mockAnvil.search.mockResolvedValue(mockResults);
+
+    // Simulate calling the tool
+    const result = await server.handleRequest({
+      method: 'tools/call',
+      params: {
+        name: 'search_docs',
+        arguments: {
+          query: 'test query',
+        },
+      },
+    } as any);
+
+    expect(mockAnvil.search).toHaveBeenCalledWith('test query', 10);
+
+    // Parse the response
+    const response = JSON.parse(result.content[0].text);
+
+    // Should only return the public result
+    expect(response.results).toHaveLength(1);
+    expect(response.results[0].path).toBe('methodology/process.md');
+    expect(response.totalResults).toBe(1);
+  });
+
+  it('should include private results when valid auth token is provided', async () => {
+    const mockResults = [
+      {
+        content: 'Public content in methodology',
+        score: 0.85,
+        metadata: {
+          file_path: 'methodology/process.md',
+          heading_path: 'Process',
+          heading_level: 1,
+          last_modified: '2024-01-01T00:00:00Z',
+          char_count: 100,
+        },
+      },
+      {
+        content: 'Private content in projects',
+        score: 0.75,
+        metadata: {
+          file_path: 'projects/secret/design.md',
+          heading_path: 'Secret Design',
+          heading_level: 1,
+          last_modified: '2024-01-02T00:00:00Z',
+          char_count: 200,
+        },
+      },
+    ];
+
+    mockAnvil.search.mockResolvedValue(mockResults);
+
+    // Simulate calling the tool with auth token
+    const result = await server.handleRequest({
+      method: 'tools/call',
+      params: {
+        name: 'search_docs',
+        arguments: {
+          query: 'test query',
+          auth_token: 'test-token',
+        },
+      },
+    } as any);
+
+    expect(mockAnvil.search).toHaveBeenCalledWith('test query', 10);
+
+    // Parse the response
+    const response = JSON.parse(result.content[0].text);
+
+    // Should return both public and private results
+    expect(response.results).toHaveLength(2);
+    expect(response.results.map(r => r.path)).toEqual([
+      'methodology/process.md',
+      'projects/secret/design.md',
+    ]);
+    expect(response.totalResults).toBe(2);
+  });
+
+  it('should filter out private results when invalid auth token is provided', async () => {
+    const mockResults = [
+      {
+        content: 'Public content in methodology',
+        score: 0.85,
+        metadata: {
+          file_path: 'methodology/process.md',
+          heading_path: 'Process',
+          heading_level: 1,
+          last_modified: '2024-01-01T00:00:00Z',
+          char_count: 100,
+        },
+      },
+      {
+        content: 'Private content in projects',
+        score: 0.75,
+        metadata: {
+          file_path: 'projects/secret/design.md',
+          heading_path: 'Secret Design',
+          heading_level: 1,
+          last_modified: '2024-01-02T00:00:00Z',
+          char_count: 200,
+        },
+      },
+    ];
+
+    mockAnvil.search.mockResolvedValue(mockResults);
+
+    // Simulate calling the tool with invalid auth token
+    const result = await server.handleRequest({
+      method: 'tools/call',
+      params: {
+        name: 'search_docs',
+        arguments: {
+          query: 'test query',
+          auth_token: 'invalid-token',
+        },
+      },
+    } as any);
+
+    expect(mockAnvil.search).toHaveBeenCalledWith('test query', 10);
+
+    // Parse the response
+    const response = JSON.parse(result.content[0].text);
+
+    // Should only return the public result
+    expect(response.results).toHaveLength(1);
+    expect(response.results[0].path).toBe('methodology/process.md');
+    expect(response.totalResults).toBe(1);
+  });
+
+  it('should include all results when FOUNDRY_WRITE_TOKEN is not set (dev mode)', async () => {
+    // Clear the env var to simulate dev mode
+    delete process.env.FOUNDRY_WRITE_TOKEN;
+
+    const mockResults = [
+      {
+        content: 'Public content in methodology',
+        score: 0.85,
+        metadata: {
+          file_path: 'methodology/process.md',
+          heading_path: 'Process',
+          heading_level: 1,
+          last_modified: '2024-01-01T00:00:00Z',
+          char_count: 100,
+        },
+      },
+      {
+        content: 'Private content in projects',
+        score: 0.75,
+        metadata: {
+          file_path: 'projects/secret/design.md',
+          heading_path: 'Secret Design',
+          heading_level: 1,
+          last_modified: '2024-01-02T00:00:00Z',
+          char_count: 200,
+        },
+      },
+    ];
+
+    mockAnvil.search.mockResolvedValue(mockResults);
+
+    // Simulate calling the tool without auth token (should work in dev mode)
+    const result = await server.handleRequest({
+      method: 'tools/call',
+      params: {
+        name: 'search_docs',
+        arguments: {
+          query: 'test query',
+        },
+      },
+    } as any);
+
+    expect(mockAnvil.search).toHaveBeenCalledWith('test query', 10);
+
+    // Parse the response
+    const response = JSON.parse(result.content[0].text);
+
+    // Should return both results in dev mode
+    expect(response.results).toHaveLength(2);
+    expect(response.totalResults).toBe(2);
+
+    // Restore the env var for other tests
+    process.env.FOUNDRY_WRITE_TOKEN = 'test-token';
+  });
+
+  it('should respect custom top_k parameter', async () => {
+    const mockResults = [
+      {
+        content: 'Test content',
+        score: 0.85,
+        metadata: {
+          file_path: 'methodology/process.md',
+          heading_path: 'Process',
+          heading_level: 1,
+          last_modified: '2024-01-01T00:00:00Z',
+          char_count: 100,
+        },
+      },
+    ];
+
+    mockAnvil.search.mockResolvedValue(mockResults);
+
+    // Simulate calling the tool with custom top_k
+    await server.handleRequest({
+      method: 'tools/call',
+      params: {
+        name: 'search_docs',
+        arguments: {
+          query: 'test query',
+          top_k: 5,
+        },
+      },
+    } as any);
+
+    expect(mockAnvil.search).toHaveBeenCalledWith('test query', 5);
+  });
+
+  it('should throw error for invalid query', async () => {
+    await expect(
+      server.handleRequest({
+        method: 'tools/call',
+        params: {
+          name: 'search_docs',
+          arguments: {
+            query: '',
+          },
+        },
+      } as any)
+    ).rejects.toThrow('Query is required and must be a non-empty string');
+
+    expect(mockAnvil.search).not.toHaveBeenCalled();
+  });
+
+  it('should handle search errors gracefully', async () => {
+    const searchError = new Error('Search service unavailable');
+    mockAnvil.search.mockRejectedValue(searchError);
+
+    await expect(
+      server.handleRequest({
+        method: 'tools/call',
+        params: {
+          name: 'search_docs',
+          arguments: {
+            query: 'test query',
+          },
+        },
+      } as any)
+    ).rejects.toThrow('Search failed: Search service unavailable');
+  });
+});

--- a/packages/api/src/mcp/tools/search.ts
+++ b/packages/api/src/mcp/tools/search.ts
@@ -4,10 +4,12 @@ import {
   CallToolRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
 import type { Anvil } from '@claymore-dev/anvil';
+import { getAccessLevel } from '../../access.js';
 
 interface SearchToolArgs {
   query: string;
   top_k?: number;
+  auth_token?: string;
 }
 
 interface SearchResultItem {
@@ -15,6 +17,19 @@ interface SearchResultItem {
   heading: string;
   snippet: string;
   score: number;
+}
+
+/**
+ * Check if the provided auth token is valid
+ */
+function isTokenValid(authToken?: string): boolean {
+  const expectedToken = process.env.FOUNDRY_WRITE_TOKEN;
+
+  // If auth token is not configured, allow all requests (dev mode)
+  if (!expectedToken) return true;
+
+  // Check if auth token is provided and matches
+  return authToken === expectedToken;
 }
 
 /**
@@ -40,6 +55,10 @@ export function registerSearchTool(server: Server, anvil: Anvil): void {
                 description: 'Number of results to return (default: 10)',
                 default: 10,
               },
+              auth_token: {
+                type: 'string',
+                description: 'Optional auth token to include private doc results',
+              },
             },
             required: ['query'],
           },
@@ -57,7 +76,7 @@ export function registerSearchTool(server: Server, anvil: Anvil): void {
     }
 
     const searchArgs = args as unknown as SearchToolArgs;
-    const { query, top_k = 10 } = searchArgs;
+    const { query, top_k = 10, auth_token } = searchArgs;
 
     if (!query || typeof query !== 'string' || query.trim() === '') {
       throw new Error('Query is required and must be a non-empty string');
@@ -75,14 +94,20 @@ export function registerSearchTool(server: Server, anvil: Anvil): void {
         score: result.score,
       }));
 
+      // Filter results based on access level and authentication
+      const isAuthed = isTokenValid(auth_token);
+      const filteredResults = isAuthed
+        ? results
+        : results.filter(r => getAccessLevel(r.path) !== "private");
+
       const response = {
-        results,
+        results: filteredResults,
         query,
-        totalResults: results.length,
+        totalResults: filteredResults.length,
       };
 
       // Add warning if no results found
-      if (results.length === 0 && top_k !== 0) {
+      if (filteredResults.length === 0 && top_k !== 0) {
         (response as any).warning = 'No results found. The Anvil index may be empty or the query did not match any content.';
       }
 

--- a/packages/api/src/routes/__tests__/search.test.ts
+++ b/packages/api/src/routes/__tests__/search.test.ts
@@ -3,10 +3,12 @@ import request from 'supertest';
 import express from 'express';
 import type { Anvil } from '@claymore-dev/anvil';
 import { createSearchRouter } from '../search.js';
+import * as access from '../../access.js';
 
 // Mock Anvil instance
 const mockAnvil = {
   search: vi.fn(),
+  getStatus: vi.fn(),
 } as unknown as Anvil;
 
 // Create test app
@@ -17,6 +19,17 @@ app.use('/api', createSearchRouter(mockAnvil));
 describe('POST /search', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Set up test environment for auth
+    process.env.FOUNDRY_WRITE_TOKEN = 'test-token';
+
+    // Mock getAccessLevel to simulate access controls
+    vi.spyOn(access, 'getAccessLevel').mockImplementation((path) => {
+      if (path.startsWith('projects/')) return 'private';
+      return 'public';
+    });
+
+    // Mock getStatus to return a valid status with content
+    mockAnvil.getStatus.mockResolvedValue({ total_chunks: 100 });
   });
 
   it('should return search results successfully', async () => {
@@ -184,5 +197,173 @@ describe('POST /search', () => {
 
     expect(response.body.results[0].snippet).toHaveLength(200);
     expect(response.body.results[0].snippet).toBe('a'.repeat(200));
+  });
+
+  describe('Access filtering', () => {
+    it('should filter out private results when no auth token is provided', async () => {
+      const mockResults = [
+        {
+          content: 'Public content in methodology',
+          score: 0.85,
+          metadata: {
+            file_path: 'methodology/process.md',
+            heading_path: 'Process',
+            heading_level: 1,
+            last_modified: '2024-01-01T00:00:00Z',
+            char_count: 100,
+          },
+        },
+        {
+          content: 'Private content in projects',
+          score: 0.75,
+          metadata: {
+            file_path: 'projects/secret/design.md',
+            heading_path: 'Secret Design',
+            heading_level: 1,
+            last_modified: '2024-01-02T00:00:00Z',
+            char_count: 200,
+          },
+        },
+      ];
+
+      mockAnvil.search.mockResolvedValue(mockResults);
+
+      const response = await request(app)
+        .post('/api/search')
+        .send({ query: 'test query' })
+        .expect(200);
+
+      // Should only return the public result
+      expect(response.body.results).toHaveLength(1);
+      expect(response.body.results[0].path).toBe('methodology/process.md');
+      expect(response.body.totalResults).toBe(1);
+    });
+
+    it('should include private results when valid auth token is provided', async () => {
+      const mockResults = [
+        {
+          content: 'Public content in methodology',
+          score: 0.85,
+          metadata: {
+            file_path: 'methodology/process.md',
+            heading_path: 'Process',
+            heading_level: 1,
+            last_modified: '2024-01-01T00:00:00Z',
+            char_count: 100,
+          },
+        },
+        {
+          content: 'Private content in projects',
+          score: 0.75,
+          metadata: {
+            file_path: 'projects/secret/design.md',
+            heading_path: 'Secret Design',
+            heading_level: 1,
+            last_modified: '2024-01-02T00:00:00Z',
+            char_count: 200,
+          },
+        },
+      ];
+
+      mockAnvil.search.mockResolvedValue(mockResults);
+
+      const response = await request(app)
+        .post('/api/search')
+        .set('Authorization', 'Bearer test-token')
+        .send({ query: 'test query' })
+        .expect(200);
+
+      // Should return both public and private results
+      expect(response.body.results).toHaveLength(2);
+      expect(response.body.results.map(r => r.path)).toEqual([
+        'methodology/process.md',
+        'projects/secret/design.md',
+      ]);
+      expect(response.body.totalResults).toBe(2);
+    });
+
+    it('should filter out private results when invalid auth token is provided', async () => {
+      const mockResults = [
+        {
+          content: 'Public content in methodology',
+          score: 0.85,
+          metadata: {
+            file_path: 'methodology/process.md',
+            heading_path: 'Process',
+            heading_level: 1,
+            last_modified: '2024-01-01T00:00:00Z',
+            char_count: 100,
+          },
+        },
+        {
+          content: 'Private content in projects',
+          score: 0.75,
+          metadata: {
+            file_path: 'projects/secret/design.md',
+            heading_path: 'Secret Design',
+            heading_level: 1,
+            last_modified: '2024-01-02T00:00:00Z',
+            char_count: 200,
+          },
+        },
+      ];
+
+      mockAnvil.search.mockResolvedValue(mockResults);
+
+      const response = await request(app)
+        .post('/api/search')
+        .set('Authorization', 'Bearer invalid-token')
+        .send({ query: 'test query' })
+        .expect(200);
+
+      // Should only return the public result
+      expect(response.body.results).toHaveLength(1);
+      expect(response.body.results[0].path).toBe('methodology/process.md');
+      expect(response.body.totalResults).toBe(1);
+    });
+
+    it('should include all results when FOUNDRY_WRITE_TOKEN is not set (dev mode)', async () => {
+      // Clear the env var to simulate dev mode
+      delete process.env.FOUNDRY_WRITE_TOKEN;
+
+      const mockResults = [
+        {
+          content: 'Public content in methodology',
+          score: 0.85,
+          metadata: {
+            file_path: 'methodology/process.md',
+            heading_path: 'Process',
+            heading_level: 1,
+            last_modified: '2024-01-01T00:00:00Z',
+            char_count: 100,
+          },
+        },
+        {
+          content: 'Private content in projects',
+          score: 0.75,
+          metadata: {
+            file_path: 'projects/secret/design.md',
+            heading_path: 'Secret Design',
+            heading_level: 1,
+            last_modified: '2024-01-02T00:00:00Z',
+            char_count: 200,
+          },
+        },
+      ];
+
+      mockAnvil.search.mockResolvedValue(mockResults);
+
+      const response = await request(app)
+        .post('/api/search')
+        .send({ query: 'test query' })
+        .expect(200);
+
+      // Should return both results in dev mode
+      expect(response.body.results).toHaveLength(2);
+      expect(response.body.totalResults).toBe(2);
+
+      // Restore the env var for other tests
+      process.env.FOUNDRY_WRITE_TOKEN = 'test-token';
+    });
   });
 });

--- a/packages/api/src/routes/search.ts
+++ b/packages/api/src/routes/search.ts
@@ -1,5 +1,6 @@
 import { Router, Request, Response } from 'express';
 import type { Anvil } from '@claymore-dev/anvil';
+import { getAccessLevel } from '../access.js';
 
 interface SearchRequest {
   query: string;
@@ -19,6 +20,15 @@ interface SearchResponse {
   query: string;
   totalResults: number;
   warning?: string;
+}
+
+/**
+ * Check if the request is authenticated
+ */
+function isRequestAuthenticated(req: Request): boolean {
+  if (!process.env.FOUNDRY_WRITE_TOKEN) return true; // dev mode
+  const token = req.headers.authorization?.replace("Bearer ", "");
+  return token === process.env.FOUNDRY_WRITE_TOKEN;
 }
 
 /**
@@ -67,14 +77,19 @@ export function createSearchRouter(anvil: Anvil): Router {
         charCount: result.metadata.char_count,
       }));
 
+      // Filter results based on access level and authentication
+      const filteredResults = isRequestAuthenticated(req)
+        ? results
+        : results.filter(r => getAccessLevel(r.path) !== "private");
+
       const response: SearchResponse = {
-        results,
+        results: filteredResults,
         query,
-        totalResults: results.length,
+        totalResults: filteredResults.length,
       };
 
       // Add warning if index appears empty (no results and topK wasn't 0)
-      if (results.length === 0 && topK !== 0) {
+      if (filteredResults.length === 0 && topK !== 0) {
         response.warning = 'No results found. The Anvil index may be empty or the query did not match any content.';
       }
 


### PR DESCRIPTION
## E6-S3: Search + MCP Access Filtering

### What
- Search endpoint filters private doc results for unauthenticated requests
- Authenticated search returns all results (public + private)
- MCP `search_docs` tool: optional `auth_token` parameter for private results
- Server-side filtering — private content never reaches unauthenticated clients

### Filtering Logic
| Request Type | Private Results |
|-------------|----------------|
| POST /api/search (no token) | ❌ Excluded |
| POST /api/search (valid token) | ✅ Included |
| MCP search_docs (no auth_token) | ❌ Excluded |
| MCP search_docs (valid auth_token) | ✅ Included |

### Tests
- Search endpoint access filtering tests
- MCP search access filtering tests

Part of E6: Public/Private Doc Access Control