### PR TITLE
feat(annotations): inline reply UI [E4-R2]

### DIFF
--- a/packages/site/src/components/AnnotationThread.tsx
+++ b/packages/site/src/components/AnnotationThread.tsx
@@ -104,6 +104,11 @@ export default function AnnotationThread({ docPath }: Props) {
   const [showOrphaned, setShowOrphaned] = useState(false);
   const [authenticated, setAuthenticated] = useState(false);
 
+  // Reply state management
+  const [replyingTo, setReplyingTo] = useState<string | null>(null);
+  const [replyContent, setReplyContent] = useState('');
+  const [replySubmitting, setReplySubmitting] = useState(false);
+
   // Helper to update annotation status via API
   const patchAnnotation = useCallback(async (id: string, updates: Partial<Pick<Annotation, 'status'>>) => {
     try {
@@ -126,6 +131,7 @@ export default function AnnotationThread({ docPath }: Props) {
       return false;
     }
   }, []);
+
 
   // Recovery: restore falsely orphaned annotations
   const recoverOrphanedAnnotations = useCallback(async (annotations: Annotation[]): Promise<Annotation[]> => {
@@ -434,6 +440,47 @@ export default function AnnotationThread({ docPath }: Props) {
     return topLevel.map(addReplies);
   };
 
+  // Submit reply to API
+  const submitReply = useCallback(async (parentAnnotation: Annotation, content: string) => {
+    if (!content.trim()) return;
+
+    setReplySubmitting(true);
+    try {
+      const response = await authFetch('/api/annotations', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          doc_path: parentAnnotation.doc_path,
+          heading_path: parentAnnotation.heading_path,
+          content_hash: '',
+          quoted_text: null,
+          content: content.trim(),
+          parent_id: parentAnnotation.id,
+          review_id: parentAnnotation.review_id,
+          author_type: 'human'
+        })
+      });
+
+      if (!response.ok) {
+        console.warn('Failed to submit reply:', response.status);
+        return false;
+      }
+
+      // Clear reply state and refresh annotations
+      setReplyingTo(null);
+      setReplyContent('');
+      fetchAnnotations();
+      return true;
+    } catch (err) {
+      console.warn('Error submitting reply:', err);
+      return false;
+    } finally {
+      setReplySubmitting(false);
+    }
+  }, [fetchAnnotations]);
+
   const renderAnnotation = (annotation: Annotation & { replies?: Annotation[] }, isReply = false) => {
     const isResolved = annotation.status === 'resolved';
     const isDraft = annotation.status === 'draft';
@@ -470,6 +517,15 @@ export default function AnnotationThread({ docPath }: Props) {
                 📍
               </button>
               <span className="thread-comment-time">{relativeTime(annotation.created_at)}</span>
+              {authenticated && !isOrphaned && (
+                <button
+                  className="thread-reply-btn"
+                  onClick={() => { setReplyingTo(annotation.id); setReplyContent(''); }}
+                  title="Reply"
+                >
+                  ↩ Reply
+                </button>
+              )}
               {isResolved && (
                 <button
                   className="thread-comment-collapse"
@@ -496,6 +552,36 @@ export default function AnnotationThread({ docPath }: Props) {
             <div className="thread-comment-content">
               {annotation.content}
             </div>
+
+            {/* Reply editor */}
+            {replyingTo === annotation.id && (
+              <div className="thread-reply-editor">
+                <textarea
+                  className="thread-reply-editor__textarea"
+                  value={replyContent}
+                  onChange={(e) => setReplyContent(e.target.value)}
+                  placeholder="Write a reply..."
+                  rows={3}
+                  autoFocus
+                />
+                <div className="thread-reply-editor__actions">
+                  <button
+                    className="thread-reply-editor__cancel"
+                    onClick={() => { setReplyingTo(null); setReplyContent(''); }}
+                    disabled={replySubmitting}
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    className="thread-reply-editor__submit"
+                    onClick={() => submitReply(annotation, replyContent)}
+                    disabled={!replyContent.trim() || replySubmitting}
+                  >
+                    {replySubmitting ? 'Replying...' : 'Reply'}
+                  </button>
+                </div>
+              </div>
+            )}
 
             {annotation.replies && annotation.replies.length > 0 && (
               <div className="thread-replies">

--- a/packages/site/src/styles/global.css
+++ b/packages/site/src/styles/global.css
@@ -1011,6 +1011,83 @@ pre.mermaid {
   margin: 0 var(--spacing-sm);
 }
 
+/* --- Reply Button and Editor --- */
+.thread-reply-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 0.75rem;
+  color: var(--color-text-secondary);
+  padding: 0 var(--spacing-xs);
+  opacity: 0;
+  transition: opacity var(--transition-fast);
+}
+
+.thread-comment:hover .thread-reply-btn {
+  opacity: 1;
+}
+
+.thread-reply-btn:hover {
+  color: var(--color-accent);
+}
+
+.thread-reply-editor {
+  margin-top: var(--spacing-sm);
+  padding: var(--spacing-sm);
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  background: var(--color-bg-secondary);
+}
+
+.thread-reply-editor__textarea {
+  width: 100%;
+  padding: var(--spacing-xs);
+  border: 1px solid var(--color-border);
+  border-radius: 4px;
+  font-size: var(--font-size-sm);
+  font-family: inherit;
+  resize: vertical;
+  background: var(--color-bg);
+  color: var(--color-text);
+}
+
+.thread-reply-editor__textarea:focus {
+  outline: none;
+  border-color: var(--color-accent);
+}
+
+.thread-reply-editor__actions {
+  display: flex;
+  gap: var(--spacing-xs);
+  margin-top: var(--spacing-xs);
+  justify-content: flex-end;
+}
+
+.thread-reply-editor__submit {
+  background: var(--color-accent);
+  color: white;
+  border: none;
+  padding: var(--spacing-xs) var(--spacing-sm);
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: var(--font-size-sm);
+}
+
+.thread-reply-editor__submit:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.thread-reply-editor__cancel {
+  background: none;
+  border: 1px solid var(--color-border);
+  padding: var(--spacing-xs) var(--spacing-sm);
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+}
+
 /* --- Threaded Replies --- */
 .thread-reply {
   margin-left: var(--spacing-lg);


### PR DESCRIPTION
## What

Adds inline reply functionality to the Foundry thread panel.

## Changes

- **Reply button** (↩ Reply) on every comment, appears on hover, only when authenticated
- **Inline reply editor** — textarea + Submit/Cancel, appears below the target comment
- **API integration** — POST to /api/annotations with parent_id for threading
- **Auto-refresh** — thread panel refreshes after successful reply submission
- **Styled** — CSS for both light and dark themes, consistent with existing thread panel design

## How It Works

1. Hover over any comment → ↩ Reply button appears
2. Click → inline textarea opens below that comment
3. Type reply, click Reply → annotation created with parent_id
4. Thread refreshes showing the new reply threaded under the parent

## Boundaries

- No draft stage for replies (immediate submit — replies are quick responses)
- Does not modify orphan detection (R1) or any API routes
- author_type is always 'human' for UI-created replies