### PR TITLE
feat(annotations): resolve/reopen buttons [E4-R3]

### DIFF
--- a/packages/site/src/components/AnnotationThread.tsx
+++ b/packages/site/src/components/AnnotationThread.tsx
@@ -103,6 +103,7 @@ export default function AnnotationThread({ docPath }: Props) {
   const [expandedResolved, setExpandedResolved] = useState<Set<string>>(new Set());
   const [showOrphaned, setShowOrphaned] = useState(false);
   const [authenticated, setAuthenticated] = useState(false);
+  const [resolvingId, setResolvingId] = useState<string | null>(null);
 
   // Reply state management
   const [replyingTo, setReplyingTo] = useState<string | null>(null);
@@ -499,6 +500,19 @@ export default function AnnotationThread({ docPath }: Props) {
             <span className="thread-comment-author">{getAuthorBadge(annotation.author_type, annotation.user_id)}</span>
             <span className="thread-comment-preview">{annotation.content.slice(0, 50)}...</span>
             <span className="thread-comment-time">{relativeTime(annotation.created_at)}</span>
+            {authenticated && (
+              <button
+                className="thread-reopen-btn"
+                onClick={async (e) => {
+                  e.stopPropagation(); // Don't expand the collapsed view
+                  const success = await patchAnnotation(annotation.id, { status: "submitted" });
+                  if (success) fetchAnnotations();
+                }}
+                title="Reopen"
+              >
+                ↩ Reopen
+              </button>
+            )}
           </div>
         ) : (
           <>
@@ -524,6 +538,39 @@ export default function AnnotationThread({ docPath }: Props) {
                   title="Reply"
                 >
                   ↩ Reply
+                </button>
+              )}
+              {authenticated && !isReply && !isResolved && !isOrphaned && (
+                <button
+                  className="thread-resolve-btn"
+                  onClick={async () => {
+                    setResolvingId(annotation.id);
+                    const success = await patchAnnotation(annotation.id, { status: "resolved" });
+                    if (success) {
+                      // Check if all annotations in this review are resolved
+                      if (annotation.review_id) {
+                        const reviewAnnotations = annotations.filter(a => a.review_id === annotation.review_id);
+                        const allResolved = reviewAnnotations.every(a => a.id === annotation.id || a.status === "resolved");
+                        if (allResolved) {
+                          try {
+                            await authFetch(`/api/reviews/${annotation.review_id}`, {
+                              method: "PATCH",
+                              headers: { "Content-Type": "application/json" },
+                              body: JSON.stringify({ status: "complete", completed_at: new Date().toISOString() })
+                            });
+                          } catch (err) {
+                            console.warn("Failed to auto-complete review:", err);
+                          }
+                        }
+                      }
+                      fetchAnnotations();
+                    }
+                    setResolvingId(null);
+                  }}
+                  disabled={resolvingId === annotation.id}
+                  title="Resolve"
+                >
+                  {resolvingId === annotation.id ? "..." : "✅ Resolve"}
                 </button>
               )}
               {isResolved && (

--- a/packages/site/src/styles/global.css
+++ b/packages/site/src/styles/global.css
@@ -990,6 +990,39 @@ pre.mermaid {
   color: var(--color-text);
 }
 
+.thread-resolve-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 0.75rem;
+  color: var(--color-text-secondary);
+  padding: 0 var(--spacing-xs);
+  opacity: 0;
+  transition: opacity var(--transition-fast);
+}
+
+.thread-comment:hover .thread-resolve-btn {
+  opacity: 1;
+}
+
+.thread-resolve-btn:hover {
+  color: #22c55e;
+}
+
+.thread-reopen-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 0.7rem;
+  color: var(--color-text-secondary);
+  padding: 0 var(--spacing-xs);
+  margin-left: auto;
+}
+
+.thread-reopen-btn:hover {
+  color: var(--color-accent);
+}
+
 .thread-comment-quote {
   font-style: italic;
   color: var(--color-text-secondary);


### PR DESCRIPTION
## What

Adds resolve and reopen functionality to the Foundry thread panel, completing the review feedback loop.

## Changes

- **Resolve button** (✅ Resolve) on top-level comments, appears on hover, auth-gated
- **Reopen button** (↩ Reopen) on collapsed resolved comments
- **Auto-complete review** — when all annotations in a review batch are resolved, the review status auto-updates to complete
- **Loading state** — resolve button shows '...' during API call

## How It Works

1. Hover over a top-level comment → ✅ Resolve button appears
2. Click → PATCH annotation status to resolved, comment collapses
3. On collapsed resolved comment → ↩ Reopen button restores to submitted
4. When last annotation in a review is resolved → review auto-completes

## Boundaries

- Does not modify orphan detection (R1) or reply UI (R2)
- Does not modify API routes — uses existing PATCH endpoints
- Only top-level comments can be resolved (not individual replies)