### PR TITLE
fix(comments): draft list selection + submit reactivity [BUG-2, BUG-3]

### DIFF
--- a/packages/site/src/components/CommentDraft.tsx
+++ b/packages/site/src/components/CommentDraft.tsx
@@ -45,6 +45,27 @@ export default function CommentDraft({ docPath }: Props) {
     setDrafts(loadedDrafts);
   }, [docPath]);
 
+  // Listen for draft and review events to reload drafts
+  useEffect(() => {
+    const handleDraftUpdated = () => {
+      const loadedDrafts = getDrafts(docPath);
+      setDrafts(loadedDrafts);
+    };
+
+    const handleReviewSubmitted = () => {
+      const loadedDrafts = getDrafts(docPath);
+      setDrafts(loadedDrafts);
+    };
+
+    window.addEventListener('foundry-draft-updated', handleDraftUpdated);
+    window.addEventListener('foundry-review-submitted', handleReviewSubmitted);
+
+    return () => {
+      window.removeEventListener('foundry-draft-updated', handleDraftUpdated);
+      window.removeEventListener('foundry-review-submitted', handleReviewSubmitted);
+    };
+  }, [docPath]);
+
   // Listen for text selection
   useEffect(() => {
     const handleSelection = () => {
@@ -60,6 +81,22 @@ export default function CommentDraft({ docPath }: Props) {
       if (!contentElement || !contentElement.contains(range.commonAncestorContainer)) {
         setFloatingButton({ show: false, x: 0, y: 0, selectedText: '', headingPath: '', contentHash: '' });
         return;
+      }
+
+      // Exclude selections within draft list and comment editor elements
+      const commonAncestor = range.commonAncestorContainer;
+      const ancestorElement = commonAncestor.nodeType === Node.ELEMENT_NODE ?
+        commonAncestor as Element :
+        commonAncestor.parentElement;
+
+      if (ancestorElement) {
+        const draftList = ancestorElement.closest('.draft-list');
+        const commentEditor = ancestorElement.closest('.comment-editor');
+
+        if (draftList || commentEditor) {
+          setFloatingButton({ show: false, x: 0, y: 0, selectedText: '', headingPath: '', contentHash: '' });
+          return;
+        }
       }
 
       const selectedText = selection.toString().trim();


### PR DESCRIPTION
## What

Two CommentDraft bug fixes.

## BUG-2: Can Comment on Draft List UI Elements
Users could select text in the draft list at the bottom of the page and create comments on their own drafts. Fixed by excluding `.draft-list` and `.comment-editor` from the text selection listener.

## BUG-3: Submitted Drafts Still Visible
After submitting a review, drafts remained visible. Fixed by listening for `foundry-review-submitted` and `foundry-draft-updated` events to refresh the draft list.