### PR TITLE
fix(submit): prevent duplicate annotations [BUG-4]

### DIFF
--- a/packages/api/src/routes/annotations.ts
+++ b/packages/api/src/routes/annotations.ts
@@ -85,6 +85,21 @@ export function createAnnotationsRouter(): Router {
       const id = createId();
       const now = new Date().toISOString();
 
+      // Check for duplicate annotation (same content + quoted_text + review_id within 30 seconds)
+      if (review_id) {
+        const recentDuplicate = db.prepare(`
+          SELECT id FROM annotations
+          WHERE review_id = ? AND content = ? AND quoted_text IS ?
+          AND created_at > datetime('now', '-30 seconds')
+        `).get(review_id, content, quoted_text || null);
+
+        if (recentDuplicate) {
+          // Return the existing annotation instead of creating a duplicate
+          const existing = db.prepare('SELECT * FROM annotations WHERE id = ?').get((recentDuplicate as any).id);
+          return res.status(200).json(existing as Annotation);
+        }
+      }
+
       const annotation: Annotation = {
         id,
         doc_path,

--- a/packages/site/src/components/SubmitReview.tsx
+++ b/packages/site/src/components/SubmitReview.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { getDrafts, clearDrafts, type DraftComment } from '../utils/draft-storage.js';
 import { authFetch } from '../utils/api.js';
 
@@ -19,6 +19,7 @@ export default function SubmitReview({ docPath }: Props) {
     error: null,
     success: false
   });
+  const submittingRef = useRef(false);
 
   // Load drafts on mount and when docPath changes
   useEffect(() => {
@@ -44,10 +45,12 @@ export default function SubmitReview({ docPath }: Props) {
   }, [docPath]);
 
   const handleSubmit = async () => {
-    if (drafts.length === 0) return;
+    if (drafts.length === 0 || submittingRef.current) return;
+    submittingRef.current = true;
 
     const confirmMessage = `Submit ${drafts.length} comment${drafts.length > 1 ? 's' : ''} for review?`;
     if (!window.confirm(confirmMessage)) {
+      submittingRef.current = false;
       return;
     }
 
@@ -163,6 +166,8 @@ export default function SubmitReview({ docPath }: Props) {
         error: error instanceof Error ? error.message : 'Failed to submit review',
         success: false
       });
+    } finally {
+      submittingRef.current = false;
     }
   };
 


### PR DESCRIPTION
## What

Prevents duplicate annotations from being created when the Submit Review button is clicked rapidly.

## Changes

### Client-side (SubmitReview.tsx)
- Added `useRef` guard that blocks immediately on first click (faster than React state)
- Existing `disabled={isSubmitting}` kept as backup

### Server-side (annotations.ts)
- Idempotency check on POST: rejects annotations with identical `content` + `quoted_text` + `review_id` created within 30 seconds
- Returns the existing annotation instead of creating a duplicate