### PR TITLE
fix: strip docs/ prefix in nav path routing

### DIFF
--- a/packages/site/src/utils/nav.ts
+++ b/packages/site/src/utils/nav.ts
@@ -20,7 +20,9 @@ interface RawNavItem {
 function pathToHref(filePath: string): string {
   const base = (import.meta.env.BASE_URL || '/').replace(/\/$/, '');
   if (filePath === 'index.md') return base + '/';
-  return base + '/docs/' + filePath.replace(/\.md$/, '') + '/';
+  // Strip leading docs/ prefix — build.sh already strips this when copying content
+  const normalizedPath = filePath.replace(/^docs\//, '');
+  return base + '/docs/' + normalizedPath.replace(/\.md$/, '') + '/';
 }
 
 function processItems(items: RawNavItem[]): NavItem[] {


### PR DESCRIPTION
Fixes #23

When a source repo's content lives inside a `docs/` folder, `nav.yaml` paths include the `docs/` prefix (e.g., `docs/Race Strategy/file.md`). Since `pathToHref()` prepends `/docs/` to the full path, this resulted in doubled `/docs/docs/` URLs.

This strips the leading `docs/` prefix from the file path before building the href, matching how `build.sh` already strips it when copying content.