### PR TITLE
fix: Docker Alpine→Debian runtime native module fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,14 @@ COPY packages/api/ ./
 RUN npm run build
 
 # Stage 4: Production runtime
-FROM node:22-alpine
+FROM node:22-slim
 WORKDIR /app
+
+# Install native dependencies required by sqlite-vss
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libopenblas0 \
+    libgomp1 \
+    && rm -rf /var/lib/apt/lists/*
 
 # Copy built artifacts
 COPY --from=site-builder /app/packages/site/dist packages/site/dist
@@ -43,6 +49,13 @@ COPY --from=api-builder /app/packages/api/dist packages/api/dist
 COPY --from=api-builder /app/packages/api/node_modules packages/api/node_modules
 COPY --from=api-builder /app/packages/api/package.json packages/api/
 COPY foundry.config.yaml nav.yaml ./
+
+# Fix cross-platform native modules (Alpine build → Debian runtime)
+RUN cd packages/api && npm install --os=linux --cpu=x64 sharp
+RUN cd packages/api && npm rebuild better-sqlite3
+RUN cd packages/api/node_modules/sqlite-vss-linux-x64/lib && \
+    ln -sf vss0.so vss0.so.so && \
+    ln -sf vector0.so vector0.so.so
 
 # Create data directory for SQLite
 RUN mkdir -p /data


### PR DESCRIPTION
Fixes #22

## Problem
Stage 4 of the Dockerfile used `node:22-alpine` as the runtime base, but Stages 1-3 compile native modules (sharp, better-sqlite3, sqlite-vss) against Alpine's musl libc. In production, the runtime is Debian/glibc (`node:22-slim`), causing 5 sequential failures:

1. Missing sharp native bindings (musl vs glibc)
2. better-sqlite3 ABI mismatch
3. sqlite-vss shared library loading failures
4. Missing libopenblas dependency
5. Missing libgomp dependency

## Changes
- Changed Stage 4 base from `node:22-alpine` to `node:22-slim`
- Added `apt-get install` for `libopenblas0` and `libgomp1` (sqlite-vss runtime deps)
- Added `npm install sharp` with platform flags to get correct glibc bindings
- Added `npm rebuild better-sqlite3` to recompile for Debian
- Added symlinks for sqlite-vss `.so` files