### PR TITLE
fix(api): replies inherit parent review_id (BUG-6)

### DIFF
--- a/packages/api/src/mcp/tools/annotations.ts
+++ b/packages/api/src/mcp/tools/annotations.ts
@@ -60,6 +60,15 @@ export function createAnnotation(params: {
   const id = createId();
   const now = new Date().toISOString();
 
+  // BUG-6: If replying to a parent, inherit its review_id
+  let effectiveReviewId: string | null = null;
+  if (params.parent_id) {
+    const parent = db.prepare('SELECT review_id FROM annotations WHERE id = ?').get(params.parent_id) as { review_id: string | null } | undefined;
+    if (parent?.review_id) {
+      effectiveReviewId = parent.review_id;
+    }
+  }
+
   const annotation = {
     id,
     doc_path: params.doc_path,
@@ -68,7 +77,7 @@ export function createAnnotation(params: {
     quoted_text: null,
     content: params.content,
     parent_id: params.parent_id || null,
-    review_id: null,
+    review_id: effectiveReviewId,
     user_id: 'clay',
     author_type: params.author_type || 'ai',
     status: params.parent_id ? 'replied' : 'submitted',

--- a/packages/api/src/routes/annotations.ts
+++ b/packages/api/src/routes/annotations.ts
@@ -85,6 +85,15 @@ export function createAnnotationsRouter(): Router {
       const id = createId();
       const now = new Date().toISOString();
 
+      // BUG-6: If replying to a parent, inherit its review_id when not explicitly provided
+      let effectiveReviewId = review_id;
+      if (parent_id && !review_id) {
+        const parent = db.prepare('SELECT review_id FROM annotations WHERE id = ?').get(parent_id) as { review_id: string | null } | undefined;
+        if (parent?.review_id) {
+          effectiveReviewId = parent.review_id;
+        }
+      }
+
       // Check for duplicate annotation (same content + quoted_text + review_id within 30 seconds)
       if (review_id) {
         const recentDuplicate = db.prepare(`
@@ -108,7 +117,7 @@ export function createAnnotationsRouter(): Router {
         quoted_text: quoted_text || null,
         content,
         parent_id: parent_id || null,
-        review_id: review_id || null,
+        review_id: effectiveReviewId || null,
         user_id: 'dan',
         author_type,
         status: 'draft',


### PR DESCRIPTION
## What

When `POST /api/annotations` includes `parent_id` but no `review_id`, the reply now auto-inherits the parent's `review_id`. Applied to both the HTTP route and the MCP `create_annotation` tool.

## Why

AI replies via the MCP tool (and any API caller that replies without explicitly passing `review_id`) were orphaned from their parent's review group, showing up in the wrong context in the thread panel.

## BUG-5 Note

Investigated BUG-5 (heading path anchor artifacts). The `getCleanHeadingText()` utility already strips anchors from new annotations. Only one stale DB record (`## Related#`) has the artifact — this will self-heal when the page is re-annotated. No code fix needed.

Closes BUG-6. BUG-5 can be closed as resolved.