### PR TITLE
refactor(mcp): wrap HTTP API instead of direct SQLite (R4)

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -83,64 +83,49 @@ async function startServer(): Promise<void> {
     loadAccessMap(STATIC_PATH);
     console.log('✅ Access map loaded successfully');
 
-    // Create MCP server (only if anvil is available)
-    let mcpServer = null;
-    if (anvil) {
-      console.log('🔧 Initializing MCP server...');
-      mcpServer = createMcpServer(anvil);
-      console.log('✅ MCP server initialized successfully');
-    } else {
-      console.log('⚠️ MCP server disabled (Anvil unavailable)');
-    }
+    // Create MCP server (uses HTTP API, no Anvil dependency)
+    console.log('🔧 Initializing MCP server...');
+    const mcpServer = createMcpServer();
+    console.log('✅ MCP server initialized successfully');
 
     // Store active SSE transports
     const transports = new Map<string, SSEServerTransport>();
 
     // MCP SSE endpoints (only if mcpServer is available)
-    if (mcpServer) {
-      app.get('/mcp/sse', async (req, res) => {
-        try {
-          const transport = new SSEServerTransport('/mcp/message', res);
-          transports.set(transport.sessionId, transport);
+    // MCP SSE endpoints (always available — MCP uses HTTP API, not Anvil)
+    app.get('/mcp/sse', async (req, res) => {
+      try {
+        const transport = new SSEServerTransport('/mcp/message', res);
+        transports.set(transport.sessionId, transport);
 
-          // Clean up transport when connection closes
-          res.on('close', () => {
-            transports.delete(transport.sessionId);
-          });
+        // Clean up transport when connection closes
+        res.on('close', () => {
+          transports.delete(transport.sessionId);
+        });
 
-          await mcpServer.connect(transport);
-        } catch (error) {
-          console.error('MCP SSE connection error:', error);
-          res.status(500).json({ error: 'Failed to establish MCP connection' });
+        await mcpServer.connect(transport);
+      } catch (error) {
+        console.error('MCP SSE connection error:', error);
+        res.status(500).json({ error: 'Failed to establish MCP connection' });
+      }
+    });
+
+    app.post('/mcp/message', async (req, res) => {
+      try {
+        const sessionId = req.query.sessionId as string;
+        const transport = transports.get(sessionId);
+
+        if (!transport) {
+          return res.status(404).json({ error: 'Session not found' });
         }
-      });
 
-      app.post('/mcp/message', async (req, res) => {
-        try {
-          const sessionId = req.query.sessionId as string;
-          const transport = transports.get(sessionId);
-
-          if (!transport) {
-            return res.status(404).json({ error: 'Session not found' });
-          }
-
-          await transport.handleMessage(req.body);
-          res.status(200).end();
-        } catch (error) {
-          console.error('MCP message handling error:', error);
-          res.status(500).json({ error: 'Failed to handle MCP message' });
-        }
-      });
-    } else {
-      // Disable MCP endpoints when Anvil is not available
-      app.get('/mcp/sse', (req, res) => {
-        res.status(503).json({ error: 'MCP service unavailable (Anvil disabled)' });
-      });
-
-      app.post('/mcp/message', (req, res) => {
-        res.status(503).json({ error: 'MCP service unavailable (Anvil disabled)' });
-      });
-    }
+        await transport.handleMessage(req.body);
+        res.status(200).end();
+      } catch (error) {
+        console.error('MCP message handling error:', error);
+        res.status(500).json({ error: 'Failed to handle MCP message' });
+      }
+    });
 
     // Mount access router (always available, no anvil dependency)
     app.use('/api', createAccessRouter());
@@ -204,12 +189,8 @@ async function startServer(): Promise<void> {
       console.log(`🚀 Foundry API server running on port ${PORT}`);
       console.log(`📊 Health endpoint: http://localhost:${PORT}/api/health`);
       console.log(`📂 Static files: ${STATIC_PATH}`);
-      if (mcpServer) {
-        console.log(`🔌 MCP SSE endpoint: http://localhost:${PORT}/mcp/sse`);
-        console.log(`📨 MCP message endpoint: http://localhost:${PORT}/mcp/message`);
-      } else {
-        console.log(`🔌 MCP endpoints disabled (Anvil unavailable)`);
-      }
+      console.log(`🔌 MCP SSE endpoint: http://localhost:${PORT}/mcp/sse`);
+      console.log(`📨 MCP message endpoint: http://localhost:${PORT}/mcp/message`);
       console.log(`🌐 CORS enabled for GitHub Pages and localhost`);
       logAuthStatus();
     });

--- a/packages/api/src/mcp/__tests__/annotation-tools.test.ts
+++ b/packages/api/src/mcp/__tests__/annotation-tools.test.ts
@@ -1,195 +1,150 @@
-import { beforeEach, afterEach, describe, expect, it } from 'vitest';
-import { mkdtempSync, rmSync } from 'fs';
-import { join } from 'path';
-import { tmpdir } from 'os';
-import { getDb, closeDb } from '../../db.js';
-import { 
-  listAnnotations, 
-  createAnnotation, 
-  resolveAnnotation, 
-  submitReview 
-} from '../tools/annotations.js';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { Annotation } from '../../types/annotations.js';
 
-// Mock the db module to use a test database
-let testDbPath: string;
+// Mock the http-client module
+vi.mock('../http-client.js', () => ({
+  listAnnotations: vi.fn(),
+  createAnnotation: vi.fn(),
+  resolveAnnotation: vi.fn(),
+  submitReview: vi.fn(),
+}));
+
+import {
+  listAnnotations,
+  createAnnotation,
+  resolveAnnotation,
+  submitReview,
+} from '../http-client.js';
+
+const mockListAnnotations = vi.mocked(listAnnotations);
+const mockCreateAnnotation = vi.mocked(createAnnotation);
+const mockResolveAnnotation = vi.mocked(resolveAnnotation);
+const mockSubmitReview = vi.mocked(submitReview);
+
+function makeAnnotation(overrides: Partial<Annotation> = {}): Annotation {
+  return {
+    id: 'test-id-1',
+    doc_path: 'test-doc.md',
+    heading_path: 'intro',
+    content_hash: '',
+    quoted_text: null,
+    content: 'Test annotation',
+    parent_id: null,
+    review_id: null,
+    user_id: 'clay',
+    author_type: 'ai',
+    status: 'submitted',
+    created_at: '2024-01-01T00:00:00.000Z',
+    updated_at: '2024-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
 
 beforeEach(() => {
-  // Create a temporary directory for test database
-  const tempDir = mkdtempSync(join(tmpdir(), 'foundry-test-'));
-  testDbPath = join(tempDir, 'test.db');
-  process.env.FOUNDRY_DB_PATH = testDbPath;
-  
-  // Initialize the test database
-  const db = getDb();
-  
-  // Create tables
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS annotations (
-      id TEXT PRIMARY KEY,
-      doc_path TEXT NOT NULL,
-      heading_path TEXT,
-      content_hash TEXT,
-      quoted_text TEXT,
-      content TEXT NOT NULL,
-      parent_id TEXT,
-      review_id TEXT,
-      user_id TEXT NOT NULL,
-      author_type TEXT NOT NULL CHECK (author_type IN ('human', 'ai')),
-      status TEXT NOT NULL CHECK (status IN ('draft', 'submitted', 'replied', 'resolved', 'orphaned')),
-      created_at TEXT NOT NULL,
-      updated_at TEXT NOT NULL
-    );
-
-    CREATE TABLE IF NOT EXISTS reviews (
-      id TEXT PRIMARY KEY,
-      doc_path TEXT NOT NULL,
-      user_id TEXT NOT NULL,
-      status TEXT NOT NULL CHECK (status IN ('draft', 'submitted', 'approved', 'rejected')),
-      submitted_at TEXT,
-      created_at TEXT NOT NULL,
-      updated_at TEXT NOT NULL
-    );
-  `);
-});
-
-afterEach(() => {
-  // Clean up test database
-  closeDb();
-  if (testDbPath) {
-    try {
-      rmSync(testDbPath, { recursive: true, force: true });
-    } catch (error) {
-      // Ignore cleanup errors
-    }
-  }
-  delete process.env.FOUNDRY_DB_PATH;
+  vi.clearAllMocks();
 });
 
 describe('listAnnotations', () => {
-  it('should list annotations for a doc_path', () => {
-    const annotation = createAnnotation({
-      doc_path: 'test-doc.md',
-      section: 'intro',
-      content: 'Test annotation'
-    });
+  it('should list annotations for a doc_path', async () => {
+    const annotations = [makeAnnotation()];
+    mockListAnnotations.mockResolvedValue(annotations);
 
-    const results = listAnnotations('test-doc.md');
+    const results = await listAnnotations('test-doc.md');
     expect(results).toHaveLength(1);
-    expect(results[0].id).toBe(annotation.id);
+    expect(results[0].id).toBe('test-id-1');
     expect(results[0].content).toBe('Test annotation');
   });
 
-  it('should filter by section', () => {
-    createAnnotation({
-      doc_path: 'test-doc.md',
-      section: 'intro',
-      content: 'Intro annotation'
-    });
-    createAnnotation({
-      doc_path: 'test-doc.md',
-      section: 'conclusion',
-      content: 'Conclusion annotation'
-    });
+  it('should filter by section', async () => {
+    mockListAnnotations.mockResolvedValue([
+      makeAnnotation({ content: 'Intro annotation' }),
+    ]);
 
-    const results = listAnnotations('test-doc.md', 'intro');
+    const results = await listAnnotations('test-doc.md', 'intro');
     expect(results).toHaveLength(1);
     expect(results[0].content).toBe('Intro annotation');
+    expect(mockListAnnotations).toHaveBeenCalledWith('test-doc.md', 'intro');
   });
 
-  it('should filter by status', () => {
-    createAnnotation({
-      doc_path: 'test-doc.md',
-      section: 'intro',
-      content: 'Draft annotation'
-    });
-    const resolved = createAnnotation({
-      doc_path: 'test-doc.md',
-      section: 'intro',
-      content: 'Resolved annotation'
-    });
-    resolveAnnotation(resolved.id);
+  it('should filter by status', async () => {
+    mockListAnnotations.mockResolvedValue([
+      makeAnnotation({ status: 'resolved', content: 'Resolved annotation' }),
+    ]);
 
-    const submittedResults = listAnnotations('test-doc.md', undefined, 'submitted');
-    expect(submittedResults).toHaveLength(1);
-    expect(submittedResults[0].content).toBe('Draft annotation');
-
-    const resolvedResults = listAnnotations('test-doc.md', undefined, 'resolved');
-    expect(resolvedResults).toHaveLength(1);
-    expect(resolvedResults[0].content).toBe('Resolved annotation');
+    const results = await listAnnotations('test-doc.md', undefined, 'resolved');
+    expect(results).toHaveLength(1);
+    expect(results[0].content).toBe('Resolved annotation');
+    expect(mockListAnnotations).toHaveBeenCalledWith('test-doc.md', undefined, 'resolved');
   });
 });
 
 describe('createAnnotation', () => {
-  it('should create annotation with default values', () => {
-    const annotation = createAnnotation({
+  it('should create annotation with default values', async () => {
+    const annotation = makeAnnotation();
+    mockCreateAnnotation.mockResolvedValue(annotation);
+
+    const result = await createAnnotation({
       doc_path: 'test-doc.md',
       section: 'intro',
-      content: 'Test annotation'
+      content: 'Test annotation',
     });
 
-    expect(annotation.id).toBeTruthy();
-    expect(annotation.doc_path).toBe('test-doc.md');
-    expect(annotation.heading_path).toBe('intro');
-    expect(annotation.content).toBe('Test annotation');
-    expect(annotation.user_id).toBe('clay');
-    expect(annotation.author_type).toBe('ai');
-    expect(annotation.status).toBe('submitted');
-    expect(annotation.parent_id).toBeNull();
-    expect(annotation.created_at).toBeTruthy();
-    expect(annotation.updated_at).toBeTruthy();
+    expect(result.id).toBeTruthy();
+    expect(result.doc_path).toBe('test-doc.md');
+    expect(result.heading_path).toBe('intro');
+    expect(result.content).toBe('Test annotation');
+    expect(result.user_id).toBe('clay');
+    expect(result.author_type).toBe('ai');
+    expect(result.status).toBe('submitted');
+    expect(result.parent_id).toBeNull();
+    expect(result.created_at).toBeTruthy();
+    expect(result.updated_at).toBeTruthy();
   });
 
-  it('should create reply annotation when parent_id provided', () => {
-    const parent = createAnnotation({
-      doc_path: 'test-doc.md',
-      section: 'intro',
-      content: 'Parent annotation'
-    });
+  it('should create reply annotation when parent_id provided', async () => {
+    const reply = makeAnnotation({ parent_id: 'parent-1', status: 'replied' });
+    mockCreateAnnotation.mockResolvedValue(reply);
 
-    const reply = createAnnotation({
+    const result = await createAnnotation({
       doc_path: 'test-doc.md',
       section: 'intro',
       content: 'Reply annotation',
-      parent_id: parent.id
+      parent_id: 'parent-1',
     });
 
-    expect(reply.parent_id).toBe(parent.id);
-    expect(reply.status).toBe('replied');
+    expect(result.parent_id).toBe('parent-1');
+    expect(result.status).toBe('replied');
   });
 
-  it('should use custom author_type when provided', () => {
-    const annotation = createAnnotation({
+  it('should use custom author_type when provided', async () => {
+    const annotation = makeAnnotation({ author_type: 'human' });
+    mockCreateAnnotation.mockResolvedValue(annotation);
+
+    const result = await createAnnotation({
       doc_path: 'test-doc.md',
       section: 'intro',
       content: 'Human annotation',
-      author_type: 'human'
+      author_type: 'human',
     });
 
-    expect(annotation.author_type).toBe('human');
+    expect(result.author_type).toBe('human');
   });
 });
 
 describe('resolveAnnotation', () => {
-  it('should resolve existing annotation', () => {
-    const annotation = createAnnotation({
-      doc_path: 'test-doc.md',
-      section: 'intro',
-      content: 'Test annotation'
-    });
+  it('should resolve existing annotation', async () => {
+    mockResolveAnnotation.mockResolvedValue({ status: 'resolved', annotation_id: 'test-id-1' });
 
-    const result = resolveAnnotation(annotation.id);
+    const result = await resolveAnnotation('test-id-1');
 
     expect(result.status).toBe('resolved');
-    expect(result.annotation_id).toBe(annotation.id);
-
-    // Verify annotation is actually resolved in database
-    const resolved = listAnnotations('test-doc.md', undefined, 'resolved');
-    expect(resolved).toHaveLength(1);
-    expect(resolved[0].id).toBe(annotation.id);
+    expect(result.annotation_id).toBe('test-id-1');
   });
 
-  it('should return error for non-existent annotation', () => {
-    const result = resolveAnnotation('non-existent-id');
+  it('should return error for non-existent annotation', async () => {
+    mockResolveAnnotation.mockResolvedValue({ status: 'error', message: 'Annotation not found' });
+
+    const result = await resolveAnnotation('non-existent-id');
 
     expect(result.status).toBe('error');
     expect(result.message).toBe('Annotation not found');
@@ -197,60 +152,59 @@ describe('resolveAnnotation', () => {
 });
 
 describe('submitReview', () => {
-  it('should create review with specified annotation IDs', () => {
-    const annotation1 = createAnnotation({
+  it('should create review with specified annotation IDs', async () => {
+    const payload = {
+      status: 'review_submitted',
+      review_id: 'review-1',
       doc_path: 'test-doc.md',
-      section: 'intro',
-      content: 'First annotation'
-    });
-    const annotation2 = createAnnotation({
-      doc_path: 'test-doc.md',
-      section: 'conclusion',
-      content: 'Second annotation'
-    });
+      submitted_at: '2024-01-01T00:00:00.000Z',
+      comment_count: 2,
+      comments: [
+        { id: 'ann-1', heading_path: 'intro', quoted_text: null, content: 'First annotation' },
+        { id: 'ann-2', heading_path: 'conclusion', quoted_text: null, content: 'Second annotation' },
+      ],
+    };
+    mockSubmitReview.mockResolvedValue(payload);
 
-    const result = submitReview('test-doc.md', [annotation1.id, annotation2.id]);
+    const result = await submitReview('test-doc.md', ['ann-1', 'ann-2']);
 
     expect(result).toMatchObject({
       status: 'review_submitted',
       doc_path: 'test-doc.md',
-      comment_count: 2
+      comment_count: 2,
     });
-
     expect((result as any).review_id).toBeTruthy();
     expect((result as any).submitted_at).toBeTruthy();
     expect((result as any).comments).toHaveLength(2);
   });
 
-  it('should include all draft/submitted annotations when no IDs specified', () => {
-    createAnnotation({
+  it('should include all draft/submitted annotations when no IDs specified', async () => {
+    mockSubmitReview.mockResolvedValue({
+      status: 'review_submitted',
+      review_id: 'review-2',
       doc_path: 'test-doc.md',
-      section: 'intro',
-      content: 'First annotation'
-    });
-    createAnnotation({
-      doc_path: 'test-doc.md',
-      section: 'conclusion',
-      content: 'Second annotation'
+      submitted_at: '2024-01-01T00:00:00.000Z',
+      comment_count: 2,
+      comments: [],
     });
 
-    const result = submitReview('test-doc.md');
+    const result = await submitReview('test-doc.md');
 
     expect((result as any).comment_count).toBe(2);
   });
 
-  it('should update annotation statuses to submitted', () => {
-    const annotation = createAnnotation({
+  it('should update annotation statuses to submitted', async () => {
+    mockSubmitReview.mockResolvedValue({
+      status: 'review_submitted',
+      review_id: 'review-3',
       doc_path: 'test-doc.md',
-      section: 'intro',
-      content: 'Test annotation'
+      submitted_at: '2024-01-01T00:00:00.000Z',
+      comment_count: 1,
+      comments: [{ id: 'ann-1', heading_path: 'intro', quoted_text: null, content: 'Test' }],
     });
 
-    submitReview('test-doc.md', [annotation.id]);
+    const result = await submitReview('test-doc.md', ['ann-1']);
 
-    // Verify annotation status was updated
-    const updated = listAnnotations('test-doc.md', undefined, 'submitted');
-    expect(updated).toHaveLength(1);
-    expect(updated[0].id).toBe(annotation.id);
+    expect((result as any).status).toBe('review_submitted');
   });
 });

--- a/packages/api/src/mcp/__tests__/annotations.test.ts
+++ b/packages/api/src/mcp/__tests__/annotations.test.ts
@@ -1,228 +1,148 @@
-import { beforeEach, afterEach, describe, expect, it } from 'vitest';
-import { mkdtempSync, rmSync } from 'fs';
-import { join } from 'path';
-import { tmpdir } from 'os';
-import { getDb, closeDb } from '../../db.js';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { Annotation } from '../../types/annotations.js';
+
+// Mock the http-client module
+vi.mock('../http-client.js', () => ({
+  listAnnotations: vi.fn(),
+  createAnnotation: vi.fn(),
+  resolveAnnotation: vi.fn(),
+  submitReview: vi.fn(),
+  searchDocs: vi.fn(),
+}));
+
 import {
   listAnnotations,
   createAnnotation,
   resolveAnnotation,
   submitReview,
-  registerAnnotationTools,
-  verifyAuthToken
-} from '../tools/annotations.js';
-import { registerSearchTool, executeSearchQuery } from '../tools/search.js';
+} from '../http-client.js';
 
-// Mock Anvil for search tool tests
-const mockAnvil = {
-  search: async (query: string, topK: number) => {
-    // Return mock search results for testing
-    return [
-      {
-        content: 'This is test content for the search query',
-        metadata: {
-          file_path: 'test-doc.md',
-          heading_path: 'Test Section'
-        },
-        score: 0.95
-      }
-    ];
-  }
-} as any;
-
-// Mock the db module to use a test database
-let testDbPath: string;
-let originalToken: string | undefined;
+const mockListAnnotations = vi.mocked(listAnnotations);
+const mockCreateAnnotation = vi.mocked(createAnnotation);
+const mockResolveAnnotation = vi.mocked(resolveAnnotation);
+const mockSubmitReview = vi.mocked(submitReview);
 
 beforeEach(() => {
-  // Save original env
-  originalToken = process.env.FOUNDRY_WRITE_TOKEN;
-
-  // Create a temporary directory for test database
-  const tempDir = mkdtempSync(join(tmpdir(), 'foundry-test-'));
-  testDbPath = join(tempDir, 'test.db');
-  process.env.FOUNDRY_DB_PATH = testDbPath;
-
-  // Initialize the test database
-  const db = getDb();
-
-  // Create tables
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS annotations (
-      id TEXT PRIMARY KEY,
-      doc_path TEXT NOT NULL,
-      heading_path TEXT,
-      content_hash TEXT,
-      quoted_text TEXT,
-      content TEXT NOT NULL,
-      parent_id TEXT,
-      review_id TEXT,
-      user_id TEXT NOT NULL,
-      author_type TEXT NOT NULL CHECK (author_type IN ('human', 'ai')),
-      status TEXT NOT NULL CHECK (status IN ('draft', 'submitted', 'replied', 'resolved', 'orphaned')),
-      created_at TEXT NOT NULL,
-      updated_at TEXT NOT NULL
-    );
-
-    CREATE TABLE IF NOT EXISTS reviews (
-      id TEXT PRIMARY KEY,
-      doc_path TEXT NOT NULL,
-      user_id TEXT NOT NULL,
-      status TEXT NOT NULL CHECK (status IN ('draft', 'submitted', 'approved', 'rejected')),
-      submitted_at TEXT,
-      created_at TEXT NOT NULL,
-      updated_at TEXT NOT NULL
-    );
-  `);
+  vi.clearAllMocks();
 });
 
-afterEach(() => {
-  // Restore original env
-  if (originalToken === undefined) {
-    delete process.env.FOUNDRY_WRITE_TOKEN;
-  } else {
-    process.env.FOUNDRY_WRITE_TOKEN = originalToken;
-  }
+function makeAnnotation(overrides: Partial<Annotation> = {}): Annotation {
+  return {
+    id: 'test-id-1',
+    doc_path: 'test-doc.md',
+    heading_path: 'intro',
+    content_hash: '',
+    quoted_text: null,
+    content: 'Test annotation',
+    parent_id: null,
+    review_id: null,
+    user_id: 'clay',
+    author_type: 'ai',
+    status: 'submitted',
+    created_at: '2024-01-01T00:00:00.000Z',
+    updated_at: '2024-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
 
-  // Clean up test database
-  closeDb();
-  if (testDbPath) {
-    try {
-      rmSync(testDbPath, { recursive: true, force: true });
-    } catch (error) {
-      // Ignore cleanup errors
-    }
-  }
-  delete process.env.FOUNDRY_DB_PATH;
-});
-
-
-describe('Core annotation functions (no auth)', () => {
+describe('HTTP client annotation functions', () => {
   describe('listAnnotations', () => {
-    it('should list annotations for a doc_path', () => {
-      const annotation = createAnnotation({
-        doc_path: 'test-doc.md',
-        section: 'intro',
-        content: 'Test annotation'
-      });
+    it('should list annotations for a doc_path', async () => {
+      const annotations = [makeAnnotation()];
+      mockListAnnotations.mockResolvedValue(annotations);
 
-      const results = listAnnotations('test-doc.md');
+      const results = await listAnnotations('test-doc.md');
       expect(results).toHaveLength(1);
-      expect(results[0].id).toBe(annotation.id);
+      expect(results[0].id).toBe('test-id-1');
       expect(results[0].content).toBe('Test annotation');
+      expect(mockListAnnotations).toHaveBeenCalledWith('test-doc.md');
     });
 
-    it('should filter by section', () => {
-      createAnnotation({
-        doc_path: 'test-doc.md',
-        section: 'intro',
-        content: 'Intro annotation'
-      });
-      createAnnotation({
-        doc_path: 'test-doc.md',
-        section: 'conclusion',
-        content: 'Conclusion annotation'
-      });
+    it('should filter by section', async () => {
+      const annotations = [makeAnnotation({ heading_path: 'intro', content: 'Intro annotation' })];
+      mockListAnnotations.mockResolvedValue(annotations);
 
-      const results = listAnnotations('test-doc.md', 'intro');
+      const results = await listAnnotations('test-doc.md', 'intro');
       expect(results).toHaveLength(1);
       expect(results[0].content).toBe('Intro annotation');
+      expect(mockListAnnotations).toHaveBeenCalledWith('test-doc.md', 'intro');
     });
 
-    it('should filter by status', () => {
-      createAnnotation({
-        doc_path: 'test-doc.md',
-        section: 'intro',
-        content: 'Draft annotation'
-      });
-      const resolved = createAnnotation({
-        doc_path: 'test-doc.md',
-        section: 'intro',
-        content: 'Resolved annotation'
-      });
-      resolveAnnotation(resolved.id);
+    it('should filter by status', async () => {
+      const annotations = [makeAnnotation({ status: 'resolved', content: 'Resolved annotation' })];
+      mockListAnnotations.mockResolvedValue(annotations);
 
-      const submittedResults = listAnnotations('test-doc.md', undefined, 'submitted');
-      expect(submittedResults).toHaveLength(1);
-      expect(submittedResults[0].content).toBe('Draft annotation');
-
-      const resolvedResults = listAnnotations('test-doc.md', undefined, 'resolved');
-      expect(resolvedResults).toHaveLength(1);
-      expect(resolvedResults[0].content).toBe('Resolved annotation');
+      const results = await listAnnotations('test-doc.md', undefined, 'resolved');
+      expect(results).toHaveLength(1);
+      expect(results[0].content).toBe('Resolved annotation');
+      expect(mockListAnnotations).toHaveBeenCalledWith('test-doc.md', undefined, 'resolved');
     });
   });
 
   describe('createAnnotation', () => {
-    it('should create annotation with default values', () => {
-      const annotation = createAnnotation({
+    it('should create annotation with default values', async () => {
+      const annotation = makeAnnotation();
+      mockCreateAnnotation.mockResolvedValue(annotation);
+
+      const result = await createAnnotation({
         doc_path: 'test-doc.md',
         section: 'intro',
-        content: 'Test annotation'
+        content: 'Test annotation',
       });
 
-      expect(annotation.id).toBeTruthy();
-      expect(annotation.doc_path).toBe('test-doc.md');
-      expect(annotation.heading_path).toBe('intro');
-      expect(annotation.content).toBe('Test annotation');
-      expect(annotation.user_id).toBe('clay');
-      expect(annotation.author_type).toBe('ai');
-      expect(annotation.status).toBe('submitted');
-      expect(annotation.parent_id).toBeNull();
-      expect(annotation.created_at).toBeTruthy();
-      expect(annotation.updated_at).toBeTruthy();
+      expect(result.id).toBeTruthy();
+      expect(result.doc_path).toBe('test-doc.md');
+      expect(result.content).toBe('Test annotation');
+      expect(result.user_id).toBe('clay');
+      expect(result.author_type).toBe('ai');
+      expect(result.status).toBe('submitted');
+      expect(result.parent_id).toBeNull();
     });
 
-    it('should create reply annotation when parent_id provided', () => {
-      const parent = createAnnotation({
-        doc_path: 'test-doc.md',
-        section: 'intro',
-        content: 'Parent annotation'
-      });
+    it('should create reply annotation when parent_id provided', async () => {
+      const reply = makeAnnotation({ parent_id: 'parent-1', status: 'replied' });
+      mockCreateAnnotation.mockResolvedValue(reply);
 
-      const reply = createAnnotation({
+      const result = await createAnnotation({
         doc_path: 'test-doc.md',
         section: 'intro',
         content: 'Reply annotation',
-        parent_id: parent.id
+        parent_id: 'parent-1',
       });
 
-      expect(reply.parent_id).toBe(parent.id);
-      expect(reply.status).toBe('replied');
+      expect(result.parent_id).toBe('parent-1');
+      expect(result.status).toBe('replied');
     });
 
-    it('should use custom author_type when provided', () => {
-      const annotation = createAnnotation({
+    it('should use custom author_type when provided', async () => {
+      const annotation = makeAnnotation({ author_type: 'human' });
+      mockCreateAnnotation.mockResolvedValue(annotation);
+
+      const result = await createAnnotation({
         doc_path: 'test-doc.md',
         section: 'intro',
         content: 'Human annotation',
-        author_type: 'human'
+        author_type: 'human',
       });
 
-      expect(annotation.author_type).toBe('human');
+      expect(result.author_type).toBe('human');
     });
   });
 
   describe('resolveAnnotation', () => {
-    it('should resolve existing annotation', () => {
-      const annotation = createAnnotation({
-        doc_path: 'test-doc.md',
-        section: 'intro',
-        content: 'Test annotation'
-      });
+    it('should resolve existing annotation', async () => {
+      mockResolveAnnotation.mockResolvedValue({ status: 'resolved', annotation_id: 'test-id-1' });
 
-      const result = resolveAnnotation(annotation.id);
+      const result = await resolveAnnotation('test-id-1');
 
       expect(result.status).toBe('resolved');
-      expect(result.annotation_id).toBe(annotation.id);
-
-      // Verify annotation is actually resolved in database
-      const resolved = listAnnotations('test-doc.md', undefined, 'resolved');
-      expect(resolved).toHaveLength(1);
-      expect(resolved[0].id).toBe(annotation.id);
+      expect(result.annotation_id).toBe('test-id-1');
     });
 
-    it('should return error for non-existent annotation', () => {
-      const result = resolveAnnotation('non-existent-id');
+    it('should return error for non-existent annotation', async () => {
+      mockResolveAnnotation.mockResolvedValue({ status: 'error', message: 'Annotation not found' });
+
+      const result = await resolveAnnotation('non-existent-id');
 
       expect(result.status).toBe('error');
       expect(result.message).toBe('Annotation not found');
@@ -230,149 +150,45 @@ describe('Core annotation functions (no auth)', () => {
   });
 
   describe('submitReview', () => {
-    it('should create review with specified annotation IDs', () => {
-      const annotation1 = createAnnotation({
+    it('should create review with specified annotation IDs', async () => {
+      const payload = {
+        status: 'review_submitted',
+        review_id: 'review-1',
         doc_path: 'test-doc.md',
-        section: 'intro',
-        content: 'First annotation'
-      });
-      const annotation2 = createAnnotation({
-        doc_path: 'test-doc.md',
-        section: 'conclusion',
-        content: 'Second annotation'
-      });
+        submitted_at: '2024-01-01T00:00:00.000Z',
+        comment_count: 2,
+        comments: [
+          { id: 'ann-1', heading_path: 'intro', quoted_text: null, content: 'First' },
+          { id: 'ann-2', heading_path: 'conclusion', quoted_text: null, content: 'Second' },
+        ],
+      };
+      mockSubmitReview.mockResolvedValue(payload);
 
-      const result = submitReview('test-doc.md', [annotation1.id, annotation2.id]);
+      const result = submitReview('test-doc.md', ['ann-1', 'ann-2']);
 
-      expect(result).toMatchObject({
+      expect(mockSubmitReview).toHaveBeenCalledWith('test-doc.md', ['ann-1', 'ann-2']);
+      await expect(result).resolves.toMatchObject({
         status: 'review_submitted',
         doc_path: 'test-doc.md',
-        comment_count: 2
+        comment_count: 2,
       });
-
-      expect((result as any).review_id).toBeTruthy();
-      expect((result as any).submitted_at).toBeTruthy();
-      expect((result as any).comments).toHaveLength(2);
     });
 
-    it('should include all draft/submitted annotations when no IDs specified', () => {
-      createAnnotation({
+    it('should include all draft/submitted annotations when no IDs specified', async () => {
+      const payload = {
+        status: 'review_submitted',
+        review_id: 'review-2',
         doc_path: 'test-doc.md',
-        section: 'intro',
-        content: 'First annotation'
-      });
-      createAnnotation({
-        doc_path: 'test-doc.md',
-        section: 'conclusion',
-        content: 'Second annotation'
-      });
+        submitted_at: '2024-01-01T00:00:00.000Z',
+        comment_count: 2,
+        comments: [],
+      };
+      mockSubmitReview.mockResolvedValue(payload);
 
-      const result = submitReview('test-doc.md');
+      const result = await submitReview('test-doc.md');
 
+      expect(mockSubmitReview).toHaveBeenCalledWith('test-doc.md');
       expect((result as any).comment_count).toBe(2);
     });
-
-    it('should update annotation statuses to submitted', () => {
-      const annotation = createAnnotation({
-        doc_path: 'test-doc.md',
-        section: 'intro',
-        content: 'Test annotation'
-      });
-
-      submitReview('test-doc.md', [annotation.id]);
-
-      // Verify annotation status was updated
-      const updated = listAnnotations('test-doc.md', undefined, 'submitted');
-      expect(updated).toHaveLength(1);
-      expect(updated[0].id).toBe(annotation.id);
-    });
-  });
-});
-
-describe('MCP Tool Authentication (Direct Testing)', () => {
-  describe('Dev mode (no FOUNDRY_WRITE_TOKEN)', () => {
-    beforeEach(() => {
-      delete process.env.FOUNDRY_WRITE_TOKEN;
-    });
-
-    it('should allow requests without auth_token when FOUNDRY_WRITE_TOKEN is not set', () => {
-      const result = verifyAuthToken();
-      expect(result).toBeNull();
-    });
-
-    it('should allow requests with auth_token when FOUNDRY_WRITE_TOKEN is not set', () => {
-      const result = verifyAuthToken('any-token');
-      expect(result).toBeNull();
-    });
-  });
-
-  describe('Production mode (FOUNDRY_WRITE_TOKEN set)', () => {
-    beforeEach(() => {
-      process.env.FOUNDRY_WRITE_TOKEN = 'test-secret-token';
-    });
-
-    it('should reject requests without auth_token', () => {
-      const result = verifyAuthToken();
-      expect(result).not.toBeNull();
-      expect(result?.isError).toBe(true);
-      expect(result?.content[0].text).toBe('Authentication required. Provide a valid auth_token parameter.');
-    });
-
-    it('should reject requests with invalid auth_token', () => {
-      const result = verifyAuthToken('wrong-token');
-      expect(result).not.toBeNull();
-      expect(result?.isError).toBe(true);
-      expect(result?.content[0].text).toBe('Authentication required. Provide a valid auth_token parameter.');
-    });
-
-    it('should allow requests with valid auth_token', () => {
-      const result = verifyAuthToken('test-secret-token');
-      expect(result).toBeNull();
-    });
-
-    it('should reject requests with empty auth_token', () => {
-      const result = verifyAuthToken('');
-      expect(result).not.toBeNull();
-      expect(result?.isError).toBe(true);
-      expect(result?.content[0].text).toBe('Authentication required. Provide a valid auth_token parameter.');
-    });
-  });
-});
-
-describe('Search Tool (Direct Testing)', () => {
-  it('should allow search without auth_token when FOUNDRY_WRITE_TOKEN is set', async () => {
-    process.env.FOUNDRY_WRITE_TOKEN = 'test-secret-token';
-
-    const result = await executeSearchQuery(mockAnvil, 'test search query');
-
-    expect(result.results).toBeDefined();
-    expect(result.query).toBe('test search query');
-    expect(result.totalResults).toBe(1); // Based on our mock
-  });
-
-  it('should allow search without auth_token when FOUNDRY_WRITE_TOKEN is not set', async () => {
-    delete process.env.FOUNDRY_WRITE_TOKEN;
-
-    const result = await executeSearchQuery(mockAnvil, 'test search query');
-
-    expect(result.results).toBeDefined();
-    expect(result.query).toBe('test search query');
-    expect(result.totalResults).toBe(1); // Based on our mock
-  });
-
-  it('should handle search with custom top_k parameter', async () => {
-    const result = await executeSearchQuery(mockAnvil, 'test search query', 5);
-
-    expect(result.results).toBeDefined();
-    expect(result.totalResults).toBe(1); // Based on our mock
-    expect(result.query).toBe('test search query');
-  });
-
-  it('should throw error for empty query', async () => {
-    await expect(executeSearchQuery(mockAnvil, '')).rejects.toThrow('Query is required and must be a non-empty string');
-  });
-
-  it('should throw error for whitespace-only query', async () => {
-    await expect(executeSearchQuery(mockAnvil, '   ')).rejects.toThrow('Query is required and must be a non-empty string');
   });
 });

--- a/packages/api/src/mcp/__tests__/search.test.ts
+++ b/packages/api/src/mcp/__tests__/search.test.ts
@@ -1,223 +1,81 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { Anvil } from '@claymore-dev/anvil';
-import { executeSearchQuery } from '../tools/search.js';
-import * as access from '../../access.js';
 
-// Mock Anvil instance
-const mockAnvil = {
-  search: vi.fn(),
-} as unknown as Anvil;
+// Mock the http-client module
+vi.mock('../http-client.js', () => ({
+  searchDocs: vi.fn(),
+}));
 
-describe('MCP search_docs tool access filtering (Direct Testing)', () => {
+import { searchDocs } from '../http-client.js';
+
+const mockSearchDocs = vi.mocked(searchDocs);
+
+describe('MCP search_docs via HTTP client', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
 
-    // Set up test environment for auth
-    process.env.FOUNDRY_WRITE_TOKEN = 'test-token';
-
-    // Mock getAccessLevel to simulate access controls
-    vi.spyOn(access, 'getAccessLevel').mockImplementation((path) => {
-      if (path.startsWith('projects/')) return 'private';
-      return 'public';
+  it('should return search results from HTTP API', async () => {
+    mockSearchDocs.mockResolvedValue({
+      results: [
+        { path: 'methodology/process.md', heading: 'Process', snippet: 'Public content', score: 0.85 },
+      ],
+      query: 'test query',
+      totalResults: 1,
     });
-  });
 
-  it('should filter out private results when no auth token is provided', async () => {
-    const mockResults = [
-      {
-        content: 'Public content in methodology',
-        score: 0.85,
-        metadata: {
-          file_path: 'methodology/process.md',
-          heading_path: 'Process',
-          heading_level: 1,
-          last_modified: '2024-01-01T00:00:00Z',
-          char_count: 100,
-        },
-      },
-      {
-        content: 'Private content in projects',
-        score: 0.75,
-        metadata: {
-          file_path: 'projects/secret/design.md',
-          heading_path: 'Secret Design',
-          heading_level: 1,
-          last_modified: '2024-01-02T00:00:00Z',
-          char_count: 200,
-        },
-      },
-    ];
+    const response = await searchDocs('test query');
 
-    mockAnvil.search.mockResolvedValue(mockResults);
-
-    const response = await executeSearchQuery(mockAnvil, 'test query');
-
-    expect(mockAnvil.search).toHaveBeenCalledWith('test query', 10);
-
-    // Should only return the public result
+    expect(mockSearchDocs).toHaveBeenCalledWith('test query');
     expect(response.results).toHaveLength(1);
     expect(response.results[0].path).toBe('methodology/process.md');
     expect(response.totalResults).toBe(1);
   });
 
-  it('should include private results when valid auth token is provided', async () => {
-    const mockResults = [
-      {
-        content: 'Public content in methodology',
-        score: 0.85,
-        metadata: {
-          file_path: 'methodology/process.md',
-          heading_path: 'Process',
-          heading_level: 1,
-          last_modified: '2024-01-01T00:00:00Z',
-          char_count: 100,
-        },
-      },
-      {
-        content: 'Private content in projects',
-        score: 0.75,
-        metadata: {
-          file_path: 'projects/secret/design.md',
-          heading_path: 'Secret Design',
-          heading_level: 1,
-          last_modified: '2024-01-02T00:00:00Z',
-          char_count: 200,
-        },
-      },
-    ];
+  it('should pass auth_token as parameter for private results', async () => {
+    mockSearchDocs.mockResolvedValue({
+      results: [
+        { path: 'methodology/process.md', heading: 'Process', snippet: 'Public', score: 0.85 },
+        { path: 'projects/secret/design.md', heading: 'Secret', snippet: 'Private', score: 0.75 },
+      ],
+      query: 'test query',
+      totalResults: 2,
+    });
 
-    mockAnvil.search.mockResolvedValue(mockResults);
+    const response = await searchDocs('test query', 10, 'test-token');
 
-    const response = await executeSearchQuery(mockAnvil, 'test query', 10, 'test-token');
-
-    expect(mockAnvil.search).toHaveBeenCalledWith('test query', 10);
-
-    // Should return both public and private results
+    expect(mockSearchDocs).toHaveBeenCalledWith('test query', 10, 'test-token');
     expect(response.results).toHaveLength(2);
-    expect(response.results.map(r => r.path)).toEqual([
-      'methodology/process.md',
-      'projects/secret/design.md',
-    ]);
-    expect(response.totalResults).toBe(2);
-  });
-
-  it('should filter out private results when invalid auth token is provided', async () => {
-    const mockResults = [
-      {
-        content: 'Public content in methodology',
-        score: 0.85,
-        metadata: {
-          file_path: 'methodology/process.md',
-          heading_path: 'Process',
-          heading_level: 1,
-          last_modified: '2024-01-01T00:00:00Z',
-          char_count: 100,
-        },
-      },
-      {
-        content: 'Private content in projects',
-        score: 0.75,
-        metadata: {
-          file_path: 'projects/secret/design.md',
-          heading_path: 'Secret Design',
-          heading_level: 1,
-          last_modified: '2024-01-02T00:00:00Z',
-          char_count: 200,
-        },
-      },
-    ];
-
-    mockAnvil.search.mockResolvedValue(mockResults);
-
-    const response = await executeSearchQuery(mockAnvil, 'test query', 10, 'invalid-token');
-
-    expect(mockAnvil.search).toHaveBeenCalledWith('test query', 10);
-
-    // Should only return the public result
-    expect(response.results).toHaveLength(1);
-    expect(response.results[0].path).toBe('methodology/process.md');
-    expect(response.totalResults).toBe(1);
-  });
-
-  it('should include all results when FOUNDRY_WRITE_TOKEN is not set (dev mode)', async () => {
-    // Clear the env var to simulate dev mode
-    delete process.env.FOUNDRY_WRITE_TOKEN;
-
-    const mockResults = [
-      {
-        content: 'Public content in methodology',
-        score: 0.85,
-        metadata: {
-          file_path: 'methodology/process.md',
-          heading_path: 'Process',
-          heading_level: 1,
-          last_modified: '2024-01-01T00:00:00Z',
-          char_count: 100,
-        },
-      },
-      {
-        content: 'Private content in projects',
-        score: 0.75,
-        metadata: {
-          file_path: 'projects/secret/design.md',
-          heading_path: 'Secret Design',
-          heading_level: 1,
-          last_modified: '2024-01-02T00:00:00Z',
-          char_count: 200,
-        },
-      },
-    ];
-
-    mockAnvil.search.mockResolvedValue(mockResults);
-
-    const response = await executeSearchQuery(mockAnvil, 'test query');
-
-    expect(mockAnvil.search).toHaveBeenCalledWith('test query', 10);
-
-    // Should return both results in dev mode
-    expect(response.results).toHaveLength(2);
-    expect(response.totalResults).toBe(2);
-
-    // Restore the env var for other tests
-    process.env.FOUNDRY_WRITE_TOKEN = 'test-token';
   });
 
   it('should respect custom top_k parameter', async () => {
-    const mockResults = [
-      {
-        content: 'Test content',
-        score: 0.85,
-        metadata: {
-          file_path: 'methodology/process.md',
-          heading_path: 'Process',
-          heading_level: 1,
-          last_modified: '2024-01-01T00:00:00Z',
-          char_count: 100,
-        },
-      },
-    ];
+    mockSearchDocs.mockResolvedValue({
+      results: [{ path: 'test.md', heading: 'Test', snippet: 'Content', score: 0.9 }],
+      query: 'test query',
+      totalResults: 1,
+    });
 
-    mockAnvil.search.mockResolvedValue(mockResults);
+    await searchDocs('test query', 5);
 
-    await executeSearchQuery(mockAnvil, 'test query', 5);
-
-    expect(mockAnvil.search).toHaveBeenCalledWith('test query', 5);
+    expect(mockSearchDocs).toHaveBeenCalledWith('test query', 5);
   });
 
-  it('should throw error for invalid query', async () => {
-    await expect(
-      executeSearchQuery(mockAnvil, '')
-    ).rejects.toThrow('Query is required and must be a non-empty string');
+  it('should propagate errors from HTTP API', async () => {
+    mockSearchDocs.mockRejectedValue(new Error('API POST /api/search failed (500): Internal error'));
 
-    expect(mockAnvil.search).not.toHaveBeenCalled();
+    await expect(searchDocs('test query')).rejects.toThrow('API POST /api/search failed');
   });
 
-  it('should handle search errors gracefully', async () => {
-    const searchError = new Error('Search service unavailable');
-    mockAnvil.search.mockRejectedValue(searchError);
+  it('should return warning when no results found', async () => {
+    mockSearchDocs.mockResolvedValue({
+      results: [],
+      query: 'obscure query',
+      totalResults: 0,
+      warning: 'No results found. The Anvil index may be empty or the query did not match any content.',
+    });
 
-    await expect(
-      executeSearchQuery(mockAnvil, 'test query')
-    ).rejects.toThrow('Search failed: Search service unavailable');
+    const response = await searchDocs('obscure query');
+
+    expect(response.results).toHaveLength(0);
+    expect(response.warning).toBeDefined();
   });
 });

--- a/packages/api/src/mcp/http-client.ts
+++ b/packages/api/src/mcp/http-client.ts
@@ -1,0 +1,182 @@
+import type { Annotation } from '../types/annotations.js';
+
+const BASE_URL = process.env.FOUNDRY_API_URL || 'http://localhost:3001';
+const WRITE_TOKEN = () => process.env.FOUNDRY_WRITE_TOKEN || '';
+
+function authHeaders(): Record<string, string> {
+  const token = WRITE_TOKEN();
+  if (!token) return {};
+  return { Authorization: `Bearer ${token}` };
+}
+
+async function apiFetch<T>(path: string, options: RequestInit = {}): Promise<T> {
+  const url = `${BASE_URL}${path}`;
+  const res = await fetch(url, {
+    ...options,
+    headers: {
+      'Content-Type': 'application/json',
+      ...authHeaders(),
+      ...(options.headers as Record<string, string> || {}),
+    },
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`API ${options.method || 'GET'} ${path} failed (${res.status}): ${body}`);
+  }
+
+  return res.json() as Promise<T>;
+}
+
+/**
+ * List annotations for a document, optionally filtered by section/status.
+ */
+export async function listAnnotations(
+  docPath: string,
+  section?: string,
+  status?: string,
+): Promise<Annotation[]> {
+  const params = new URLSearchParams({ doc_path: docPath });
+  if (section) params.set('section', section);
+  if (status) params.set('status', status);
+  return apiFetch<Annotation[]>(`/api/annotations?${params}`);
+}
+
+/**
+ * Create an annotation via HTTP API.
+ */
+export async function createAnnotation(params: {
+  doc_path: string;
+  section: string;
+  content: string;
+  parent_id?: string;
+  author_type?: string;
+}): Promise<Annotation> {
+  return apiFetch<Annotation>('/api/annotations', {
+    method: 'POST',
+    body: JSON.stringify({
+      doc_path: params.doc_path,
+      heading_path: params.section,
+      content: params.content,
+      parent_id: params.parent_id || undefined,
+      author_type: params.author_type || 'ai',
+      user_id: 'clay',
+      status: params.parent_id ? 'replied' : 'submitted',
+    }),
+  });
+}
+
+/**
+ * Resolve an annotation by setting status to "resolved".
+ */
+export async function resolveAnnotation(
+  annotationId: string,
+): Promise<{ status: string; annotation_id?: string; message?: string }> {
+  try {
+    const updated = await apiFetch<Annotation>(`/api/annotations/${annotationId}`, {
+      method: 'PATCH',
+      body: JSON.stringify({ status: 'resolved' }),
+    });
+    return { status: 'resolved', annotation_id: updated.id };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg.includes('404')) {
+      return { status: 'error', message: 'Annotation not found' };
+    }
+    throw err;
+  }
+}
+
+/**
+ * Submit a review batch:
+ * 1. POST /api/reviews to create review record
+ * 2. PATCH each annotation with review_id + status
+ * 3. PATCH review to submitted
+ */
+export async function submitReview(
+  docPath: string,
+  annotationIds?: string[],
+): Promise<object> {
+  // 1. Create review
+  const review = await apiFetch<{ id: string; doc_path: string }>('/api/reviews', {
+    method: 'POST',
+    body: JSON.stringify({ doc_path: docPath }),
+  });
+
+  // Get annotations to include
+  let annotations: Annotation[];
+  if (annotationIds && annotationIds.length > 0) {
+    // Fetch each specified annotation
+    const all = await listAnnotations(docPath);
+    annotations = all.filter(a => annotationIds.includes(a.id));
+  } else {
+    // Default: all draft/submitted annotations for this doc
+    const drafts = await listAnnotations(docPath, undefined, 'draft');
+    const submitted = await listAnnotations(docPath, undefined, 'submitted');
+    annotations = [...drafts, ...submitted];
+  }
+
+  const now = new Date().toISOString();
+
+  // 2. Update each annotation with review_id and status
+  for (const ann of annotations) {
+    await apiFetch(`/api/annotations/${ann.id}`, {
+      method: 'PATCH',
+      body: JSON.stringify({ review_id: review.id, status: 'submitted' }),
+    });
+  }
+
+  // 3. Mark review as submitted
+  await apiFetch(`/api/reviews/${review.id}`, {
+    method: 'PATCH',
+    body: JSON.stringify({ status: 'submitted', submitted_at: now }),
+  });
+
+  return {
+    status: 'review_submitted',
+    review_id: review.id,
+    doc_path: docPath,
+    submitted_at: now,
+    comment_count: annotations.length,
+    comments: annotations.map(a => ({
+      id: a.id,
+      heading_path: a.heading_path,
+      quoted_text: a.quoted_text,
+      content: a.content,
+    })),
+  };
+}
+
+interface SearchResult {
+  path: string;
+  heading: string;
+  snippet: string;
+  score: number;
+}
+
+interface SearchResponse {
+  results: SearchResult[];
+  query: string;
+  totalResults: number;
+  warning?: string;
+}
+
+/**
+ * Semantic search via HTTP API.
+ */
+export async function searchDocs(
+  query: string,
+  topK: number = 10,
+  authToken?: string,
+): Promise<SearchResponse> {
+  const headers: Record<string, string> = {};
+  if (authToken) {
+    headers.Authorization = `Bearer ${authToken}`;
+  }
+
+  return apiFetch<SearchResponse>('/api/search', {
+    method: 'POST',
+    body: JSON.stringify({ query, topK }),
+    headers,
+  });
+}

--- a/packages/api/src/mcp/server.ts
+++ b/packages/api/src/mcp/server.ts
@@ -1,24 +1,19 @@
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
-import type { Anvil } from '@claymore-dev/anvil';
 import { registerSearchTool } from './tools/search.js';
 import { registerAnnotationTools } from './tools/annotations.js';
 
 /**
- * Creates and configures the MCP server for Foundry
+ * Creates and configures the MCP server for Foundry.
+ * All tools communicate via HTTP API (no direct DB or Anvil dependency).
  *
  * Available tools:
- * - search_docs: Public tool for searching documentation (no auth required)
- * - list_annotations: List annotations for a document (requires auth_token when FOUNDRY_WRITE_TOKEN is set)
- * - create_annotation: Create new annotation (requires auth_token when FOUNDRY_WRITE_TOKEN is set)
- * - resolve_annotation: Mark annotation as resolved (requires auth_token when FOUNDRY_WRITE_TOKEN is set)
- * - submit_review: Submit annotations as review batch (requires auth_token when FOUNDRY_WRITE_TOKEN is set)
- *
- * Authentication:
- * - If FOUNDRY_WRITE_TOKEN environment variable is not set, all tools are accessible (dev mode)
- * - If FOUNDRY_WRITE_TOKEN is set, annotation tools require auth_token parameter matching the env var
- * - Search tools are always public and do not require authentication
+ * - search_docs: Semantic search (delegates auth filtering to HTTP API)
+ * - list_annotations: List annotations for a document
+ * - create_annotation: Create new annotation
+ * - resolve_annotation: Mark annotation as resolved
+ * - submit_review: Submit annotations as review batch
  */
-export function createMcpServer(anvil: Anvil): Server {
+export function createMcpServer(): Server {
   const server = new Server({
     name: 'foundry',
     version: '0.2.0',
@@ -29,9 +24,9 @@ export function createMcpServer(anvil: Anvil): Server {
   });
 
   // Register the search_docs tool
-  registerSearchTool(server, anvil);
+  registerSearchTool(server);
 
-  // Register annotation tool schemas (interface only — implementation in E4)
+  // Register annotation tools
   registerAnnotationTools(server);
 
   return server;

--- a/packages/api/src/mcp/tools/annotations.ts
+++ b/packages/api/src/mcp/tools/annotations.ts
@@ -1,159 +1,15 @@
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
-import { getDb } from '../../db.js';
-import { createId } from '@paralleldrive/cuid2';
-import type { Annotation } from '../../types/annotations.js';
+import {
+  listAnnotations,
+  createAnnotation,
+  resolveAnnotation,
+  submitReview,
+} from '../http-client.js';
 
 /**
- * Verify authentication token for MCP annotation tools
- * Returns null if auth is valid, or an error response object if invalid
- */
-export function verifyAuthToken(authToken?: string): { content: Array<{ type: string; text: string }>; isError: true } | null {
-  const expectedToken = process.env.FOUNDRY_WRITE_TOKEN;
-
-  // If auth token is not configured, allow all requests (dev mode)
-  if (!expectedToken) {
-    return null;
-  }
-
-  // Check if auth token is provided and matches
-  if (!authToken || authToken !== expectedToken) {
-    return {
-      content: [{ type: "text", text: "Authentication required. Provide a valid auth_token parameter." }],
-      isError: true
-    };
-  }
-
-  return null;
-}
-
-/**
- * Core annotation functions that can be tested
- */
-export function listAnnotations(docPath: string, section?: string, status?: string): Annotation[] {
-  const db = getDb();
-  let query = 'SELECT * FROM annotations WHERE doc_path = ?';
-  const params: any[] = [docPath];
-
-  if (section) {
-    query += ' AND heading_path LIKE ?';
-    params.push(`%${section}%`);
-  }
-  if (status) {
-    query += ' AND status = ?';
-    params.push(status);
-  }
-
-  query += ' ORDER BY created_at DESC';
-  const rows = db.prepare(query).all(...params);
-  return rows as Annotation[];
-}
-
-export function createAnnotation(params: {
-  doc_path: string;
-  section: string;
-  content: string;
-  parent_id?: string;
-  author_type?: string
-}): Annotation {
-  const db = getDb();
-  const id = createId();
-  const now = new Date().toISOString();
-
-  // BUG-6: If replying to a parent, inherit its review_id
-  let effectiveReviewId: string | null = null;
-  if (params.parent_id) {
-    const parent = db.prepare('SELECT review_id FROM annotations WHERE id = ?').get(params.parent_id) as { review_id: string | null } | undefined;
-    if (parent?.review_id) {
-      effectiveReviewId = parent.review_id;
-    }
-  }
-
-  const annotation = {
-    id,
-    doc_path: params.doc_path,
-    heading_path: params.section,
-    content_hash: '', // MCP callers don't need to provide this
-    quoted_text: null,
-    content: params.content,
-    parent_id: params.parent_id || null,
-    review_id: effectiveReviewId,
-    user_id: 'clay',
-    author_type: params.author_type || 'ai',
-    status: params.parent_id ? 'replied' : 'submitted',
-    created_at: now,
-    updated_at: now,
-  } as Annotation;
-
-  // INSERT into annotations table
-  db.prepare(`INSERT INTO annotations (id, doc_path, heading_path, content_hash, quoted_text, content, parent_id, review_id, user_id, author_type, status, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`).run(
-    annotation.id, annotation.doc_path, annotation.heading_path, annotation.content_hash,
-    annotation.quoted_text, annotation.content, annotation.parent_id, annotation.review_id,
-    annotation.user_id, annotation.author_type, annotation.status, annotation.created_at, annotation.updated_at
-  );
-
-  return annotation;
-}
-
-export function resolveAnnotation(annotationId: string): { status: string; annotation_id?: string; message?: string } {
-  const db = getDb();
-
-  const existing = db.prepare('SELECT * FROM annotations WHERE id = ?').get(annotationId);
-  if (!existing) {
-    return { status: "error", message: "Annotation not found" };
-  }
-
-  const now = new Date().toISOString();
-  db.prepare('UPDATE annotations SET status = ?, updated_at = ? WHERE id = ?').run('resolved', now, annotationId);
-
-  return { status: "resolved", annotation_id: annotationId };
-}
-
-export function submitReview(docPath: string, annotationIds?: string[]): object {
-  const db = getDb();
-
-  // Create review record
-  const reviewId = createId();
-  const now = new Date().toISOString();
-  db.prepare('INSERT INTO reviews (id, doc_path, user_id, status, submitted_at, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)').run(
-    reviewId, docPath, 'dan', 'submitted', now, now, now
-  );
-
-  // Get annotations to include
-  let annotations: Annotation[];
-  if (annotationIds && annotationIds.length > 0) {
-    const placeholders = annotationIds.map(() => '?').join(',');
-    annotations = db.prepare(`SELECT * FROM annotations WHERE id IN (${placeholders})`).all(...annotationIds) as Annotation[];
-  } else {
-    // Default: all draft/submitted annotations for this doc
-    annotations = db.prepare('SELECT * FROM annotations WHERE doc_path = ? AND status IN (?, ?)').all(docPath, 'draft', 'submitted') as Annotation[];
-  }
-
-  // Update annotations with review_id and status
-  for (const ann of annotations) {
-    db.prepare('UPDATE annotations SET review_id = ?, status = ?, updated_at = ? WHERE id = ?').run(reviewId, 'submitted', now, ann.id);
-  }
-
-  // Build structured payload for OpenClaw
-  const payload = {
-    status: "review_submitted",
-    review_id: reviewId,
-    doc_path: docPath,
-    submitted_at: now,
-    comment_count: annotations.length,
-    comments: annotations.map(a => ({
-      id: a.id,
-      heading_path: a.heading_path,
-      quoted_text: a.quoted_text,
-      content: a.content,
-    })),
-  };
-
-  return payload;
-}
-
-/**
- * Register annotation tools with the MCP server
+ * Register annotation tools with the MCP server.
+ * All data access goes through the HTTP API via http-client.
  */
 export function registerAnnotationTools(server: Server): void {
 
@@ -181,7 +37,7 @@ export function registerAnnotationTools(server: Server): void {
               },
               auth_token: {
                 type: 'string',
-                description: 'Authentication token (required when FOUNDRY_WRITE_TOKEN is set)'
+                description: 'Authentication token (kept for backward compatibility)'
               }
             },
             required: ['doc_path']
@@ -215,7 +71,7 @@ export function registerAnnotationTools(server: Server): void {
               },
               auth_token: {
                 type: 'string',
-                description: 'Authentication token (required when FOUNDRY_WRITE_TOKEN is set)'
+                description: 'Authentication token (kept for backward compatibility)'
               }
             },
             required: ['doc_path', 'section', 'content']
@@ -233,7 +89,7 @@ export function registerAnnotationTools(server: Server): void {
               },
               auth_token: {
                 type: 'string',
-                description: 'Authentication token (required when FOUNDRY_WRITE_TOKEN is set)'
+                description: 'Authentication token (kept for backward compatibility)'
               }
             },
             required: ['annotation_id']
@@ -258,7 +114,7 @@ export function registerAnnotationTools(server: Server): void {
               },
               auth_token: {
                 type: 'string',
-                description: 'Authentication token (required when FOUNDRY_WRITE_TOKEN is set)'
+                description: 'Authentication token (kept for backward compatibility)'
               }
             },
             required: ['doc_path']
@@ -271,20 +127,14 @@ export function registerAnnotationTools(server: Server): void {
   // Handle tool calls
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
     const { name, arguments: args } = request.params;
-    
+
     if (!args) {
       throw new Error('Tool arguments are required');
     }
 
     switch (name) {
       case 'list_annotations': {
-        // Verify authentication
-        const authError = verifyAuthToken(args.auth_token as string | undefined);
-        if (authError) {
-          return authError;
-        }
-
-        const result = listAnnotations(
+        const result = await listAnnotations(
           args.doc_path as string,
           args.section as string | undefined,
           args.status as string | undefined
@@ -293,13 +143,7 @@ export function registerAnnotationTools(server: Server): void {
       }
 
       case 'create_annotation': {
-        // Verify authentication
-        const authError = verifyAuthToken(args.auth_token as string | undefined);
-        if (authError) {
-          return authError;
-        }
-
-        const result = createAnnotation({
+        const result = await createAnnotation({
           doc_path: args.doc_path as string,
           section: args.section as string,
           content: args.content as string,
@@ -310,24 +154,12 @@ export function registerAnnotationTools(server: Server): void {
       }
 
       case 'resolve_annotation': {
-        // Verify authentication
-        const authError = verifyAuthToken(args.auth_token as string | undefined);
-        if (authError) {
-          return authError;
-        }
-
-        const result = resolveAnnotation(args.annotation_id as string);
+        const result = await resolveAnnotation(args.annotation_id as string);
         return { content: [{ type: "text", text: JSON.stringify(result) }] };
       }
 
       case 'submit_review': {
-        // Verify authentication
-        const authError = verifyAuthToken(args.auth_token as string | undefined);
-        if (authError) {
-          return authError;
-        }
-
-        const result = submitReview(
+        const result = await submitReview(
           args.doc_path as string,
           args.annotation_ids as string[] | undefined
         );

--- a/packages/api/src/mcp/tools/search.ts
+++ b/packages/api/src/mcp/tools/search.ts
@@ -3,8 +3,7 @@ import {
   ListToolsRequestSchema,
   CallToolRequestSchema,
 } from '@modelcontextprotocol/sdk/types.js';
-import type { Anvil } from '@claymore-dev/anvil';
-import { getAccessLevel } from '../../access.js';
+import { searchDocs } from '../http-client.js';
 
 interface SearchToolArgs {
   query: string;
@@ -12,79 +11,11 @@ interface SearchToolArgs {
   auth_token?: string;
 }
 
-interface SearchResultItem {
-  path: string;
-  heading: string;
-  snippet: string;
-  score: number;
-}
-
 /**
- * Check if the provided auth token is valid
+ * Registers the search_docs tool with the MCP server.
+ * Search goes through the HTTP API via http-client (no Anvil dependency).
  */
-function isTokenValid(authToken?: string): boolean {
-  const expectedToken = process.env.FOUNDRY_WRITE_TOKEN;
-
-  // If auth token is not configured, allow all requests (dev mode)
-  if (!expectedToken) return true;
-
-  // Check if auth token is provided and matches
-  return authToken === expectedToken;
-}
-
-/**
- * Execute a search query with access filtering
- * This function contains the core logic that can be tested directly
- */
-export async function executeSearchQuery(
-  anvil: Anvil,
-  query: string,
-  topK: number = 10,
-  authToken?: string
-): Promise<{ results: SearchResultItem[]; query: string; totalResults: number; warning?: string }> {
-  if (!query || typeof query !== 'string' || query.trim() === '') {
-    throw new Error('Query is required and must be a non-empty string');
-  }
-
-  try {
-    // Call anvil search with the same logic as the REST endpoint
-    const searchResults = await anvil.search(query, topK);
-
-    // Transform results to match the REST endpoint format
-    const results: SearchResultItem[] = searchResults.map(result => ({
-      path: result.metadata.file_path,
-      heading: result.metadata.heading_path,
-      snippet: result.content.slice(0, 200),
-      score: result.score,
-    }));
-
-    // Filter results based on access level and authentication
-    const isAuthed = isTokenValid(authToken);
-    const filteredResults = isAuthed
-      ? results
-      : results.filter(r => getAccessLevel(r.path) !== "private");
-
-    const response = {
-      results: filteredResults,
-      query,
-      totalResults: filteredResults.length,
-    };
-
-    // Add warning if no results found
-    if (filteredResults.length === 0 && topK !== 0) {
-      (response as any).warning = 'No results found. The Anvil index may be empty or the query did not match any content.';
-    }
-
-    return response;
-  } catch (error) {
-    throw new Error(`Search failed: ${error instanceof Error ? error.message : String(error)}`);
-  }
-}
-
-/**
- * Registers the search_docs tool with the MCP server
- */
-export function registerSearchTool(server: Server, anvil: Anvil): void {
+export function registerSearchTool(server: Server): void {
   // Register the tool
   server.setRequestHandler(ListToolsRequestSchema, async () => {
     return {
@@ -127,8 +58,11 @@ export function registerSearchTool(server: Server, anvil: Anvil): void {
     const searchArgs = args as unknown as SearchToolArgs;
     const { query, top_k = 10, auth_token } = searchArgs;
 
-    // Use the extracted function for testability
-    const response = await executeSearchQuery(anvil, query, top_k, auth_token);
+    if (!query || typeof query !== 'string' || query.trim() === '') {
+      throw new Error('Query is required and must be a non-empty string');
+    }
+
+    const response = await searchDocs(query, top_k, auth_token);
 
     return {
       content: [


### PR DESCRIPTION
## What

MCP tools now call the Foundry HTTP API via configurable `FOUNDRY_API_URL` instead of importing `getDb()` directly.

## Why

Enables remote MCP usage for GMPPU and other deployments where the MCP client runs on a different machine than the Foundry server.

## Changes

- New `http-client.ts` with typed fetch wrappers for all API endpoints
- Annotation + search MCP tools refactored to use HTTP client
- `createMcpServer()` no longer requires Anvil parameter
- MCP SSE endpoints work regardless of Anvil availability
- All tests updated with HTTP client mocks

## Config

```env
FOUNDRY_API_URL=https://foundry-claymore.fly.dev  # defaults to http://localhost:3001
FOUNDRY_WRITE_TOKEN=your-token                      # used for API auth
```