### PR TITLE
feat(layout): fluid content fill + responsive panel toggle (E7-S3)

### DIFF
--- a/packages/site/src/components/AnnotationThread.tsx
+++ b/packages/site/src/components/AnnotationThread.tsx
@@ -237,12 +237,9 @@ export default function AnnotationThread({ docPath }: Props) {
   // Load panel visibility from localStorage
   useEffect(() => {
     const stored = localStorage.getItem(STORAGE_KEY);
-    if (stored !== null) {
-      setIsVisible(stored === 'true');
-    } else {
-      // Default: hidden on mobile, visible on desktop
-      setIsVisible(window.innerWidth >= 1024);
-    }
+    const visible = stored !== null ? stored === 'true' : window.innerWidth >= 1024;
+    setIsVisible(visible);
+    document.getElementById('layout')?.classList.toggle('thread-hidden', !visible);
   }, []);
 
   // Save panel visibility to localStorage
@@ -250,6 +247,7 @@ export default function AnnotationThread({ docPath }: Props) {
     const newVisibility = !isVisible;
     setIsVisible(newVisibility);
     localStorage.setItem(STORAGE_KEY, String(newVisibility));
+    document.getElementById('layout')?.classList.toggle('thread-hidden', !newVisibility);
   }, [isVisible]);
 
   // Fetch annotations

--- a/packages/site/src/styles/global.css
+++ b/packages/site/src/styles/global.css
@@ -43,7 +43,7 @@
   /* Layout */
   --sidebar-width: 280px;
   --thread-panel-width: 320px;
-  --content-max-width: 800px;
+  /* --content-max-width: 800px; */
   --header-height: 56px;
   --spacing-xs: 0.25rem;
   --spacing-sm: 0.5rem;
@@ -273,11 +273,9 @@ h6:hover .heading-anchor {
   grid-column: 2;
   padding: var(--spacing-xl);
   padding-top: calc(var(--header-height) + var(--spacing-xl));
-  max-width: var(--content-max-width);
 }
 
 .content {
-  max-width: var(--content-max-width);
   overflow-x: hidden;
 }
 
@@ -1240,11 +1238,13 @@ pre.mermaid {
 
 /* --- Thread Panel Grid Layout States --- */
 /* Hidden thread panel */
-.layout:has(.thread-panel--hidden) {
+.layout:has(.thread-panel--hidden),
+.layout.thread-hidden {
   grid-template-columns: var(--sidebar-width) 1fr 40px;
 }
 
-.layout.sidebar-hidden:has(.thread-panel--hidden) {
+.layout.sidebar-hidden:has(.thread-panel--hidden),
+.layout.sidebar-hidden.thread-hidden {
   grid-template-columns: 0 1fr 40px;
 }
 


### PR DESCRIPTION
## What

Content area now fills available space fluidly between sidebar and thread panel instead of being capped at 800px.

## Changes

- Removed fixed max-width constraint from content area
- Content expands when sidebar or thread panel is hidden
- Layout grid responds to both sidebar-hidden and thread-hidden states
- Tables and code blocks maintain overflow-x handling
- Mobile responsive layout preserved

Part of E7: UI/UX Refinement (Batch 1)