### PR TITLE
fix(thread): toggle clipping + add refresh button (E7-S2)

### DIFF
--- a/packages/site/src/components/AnnotationThread.tsx
+++ b/packages/site/src/components/AnnotationThread.tsx
@@ -112,6 +112,7 @@ export default function AnnotationThread({ docPath }: Props) {
   const [replyingTo, setReplyingTo] = useState<string | null>(null);
   const [replyContent, setReplyContent] = useState('');
   const [replySubmitting, setReplySubmitting] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
 
   // Helper to update annotation status via API
   const patchAnnotation = useCallback(async (id: string, updates: Partial<Pick<Annotation, 'status'>>) => {
@@ -294,6 +295,16 @@ export default function AnnotationThread({ docPath }: Props) {
       setLoading(false);
     }
   }, [docPath, recoverOrphanedAnnotations, detectOrphansAndDrift]);
+
+  // Manual refresh handler
+  const handleRefresh = useCallback(async () => {
+    setRefreshing(true);
+    try {
+      await fetchAnnotations();
+    } finally {
+      setRefreshing(false);
+    }
+  }, [fetchAnnotations]);
 
   useEffect(() => {
     if (docPath) {
@@ -702,6 +713,15 @@ export default function AnnotationThread({ docPath }: Props) {
     <div className={`thread-panel ${!isVisible ? 'thread-panel--hidden' : ''}`}>
       <div className="thread-header">
         <h3>💬 Review Thread</h3>
+        <button
+          className={`thread-refresh-btn ${refreshing ? 'thread-refresh-btn--spinning' : ''}`}
+          onClick={handleRefresh}
+          disabled={refreshing}
+          aria-label="Refresh annotations"
+          title="Refresh annotations"
+        >
+          🔄
+        </button>
         <button
           className="thread-toggle"
           onClick={toggleVisibility}

--- a/packages/site/src/styles/global.css
+++ b/packages/site/src/styles/global.css
@@ -796,9 +796,9 @@ pre.mermaid {
 /* Floating toggle tab when panel is hidden */
 .thread-panel--hidden .thread-header {
   position: absolute;
-  left: -40px;
+  left: -44px;
   top: 0;
-  width: 40px;
+  width: 44px;
   height: 40px;
   padding: 0;
   border: 1px solid var(--color-border);
@@ -815,6 +815,10 @@ pre.mermaid {
   display: none;
 }
 
+.thread-panel--hidden .thread-refresh-btn {
+  display: none;
+}
+
 .thread-panel--hidden .thread-content {
   display: none;
 }
@@ -822,7 +826,7 @@ pre.mermaid {
 .thread-header {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  gap: var(--spacing-xs);
   padding: var(--spacing-md);
   border-bottom: 1px solid var(--color-border);
   background: var(--color-bg-secondary);
@@ -830,6 +834,7 @@ pre.mermaid {
 
 .thread-header h3 {
   margin: 0;
+  flex: 1;
   font-size: var(--font-size-base);
   font-weight: 600;
   color: var(--color-heading);
@@ -849,6 +854,37 @@ pre.mermaid {
 .thread-toggle:hover {
   color: var(--color-text);
   background: var(--color-sidebar-hover);
+}
+
+.thread-refresh-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: var(--spacing-xs);
+  border-radius: 4px;
+  color: var(--color-text-secondary);
+  font-size: 1em;
+  line-height: 1;
+  transition: color var(--transition-fast), background-color var(--transition-fast);
+}
+
+.thread-refresh-btn:hover {
+  color: var(--color-text);
+  background: var(--color-sidebar-hover);
+}
+
+.thread-refresh-btn:disabled {
+  cursor: default;
+  opacity: 0.6;
+}
+
+.thread-refresh-btn--spinning {
+  animation: thread-spin 0.8s linear infinite;
+}
+
+@keyframes thread-spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
 }
 
 .thread-content {


### PR DESCRIPTION
## What

Fixes thread panel toggle arrow clipping and adds a refresh button to the thread header.

## Changes

- Increased toggle tab width (40px → 44px) to prevent clipping
- Added 🔄 refresh button between title and toggle arrow
- Loading state during annotation fetch
- Subtle ghost button styling matching existing theme

Part of E7: UI/UX Refinement (Batch 1)