### PR TITLE
feat(thread): Slack-style timeline + Active/Archived split (E7-S1)

### DIFF
--- a/packages/site/src/components/AnnotationThread.tsx
+++ b/packages/site/src/components/AnnotationThread.tsx
@@ -105,6 +105,11 @@ export default function AnnotationThread({ docPath }: Props) {
   const [authenticated, setAuthenticated] = useState(false);
   const [resolvingId, setResolvingId] = useState<string | null>(null);
 
+  // Thread collapse/expand state (tracks which threads have replies expanded)
+  const [expandedThreads, setExpandedThreads] = useState<Set<string>>(new Set());
+  // Archived section collapsed by default
+  const [showArchived, setShowArchived] = useState(false);
+
   // Ref for preserving scroll position
   const threadContentRef = useRef<HTMLDivElement>(null);
 
@@ -659,9 +664,26 @@ export default function AnnotationThread({ docPath }: Props) {
             )}
 
             {!isReply && annotation.replies && annotation.replies.length > 0 && (
-              <div className="thread-replies">
-                {annotation.replies.map(reply => renderAnnotation(reply, true))}
-              </div>
+              expandedThreads.has(annotation.id) ? (
+                <>
+                  <button
+                    className="thread-replies-toggle"
+                    onClick={() => setExpandedThreads(prev => { const next = new Set(prev); next.delete(annotation.id); return next; })}
+                  >
+                    💬 {annotation.replies.length} {annotation.replies.length === 1 ? 'reply' : 'replies'} ▾
+                  </button>
+                  <div className="thread-replies">
+                    {annotation.replies.map(reply => renderAnnotation(reply, true))}
+                  </div>
+                </>
+              ) : (
+                <button
+                  className="thread-replies-toggle"
+                  onClick={() => setExpandedThreads(prev => new Set(prev).add(annotation.id))}
+                >
+                  💬 {annotation.replies.length} {annotation.replies.length === 1 ? 'reply' : 'replies'} ▸
+                </button>
+              )
             )}
           </>
         )}
@@ -698,6 +720,58 @@ export default function AnnotationThread({ docPath }: Props) {
 
   const { reviewGroups, ungrouped, orphaned } = groupedAnnotations();
 
+  // Build all non-orphaned threads and split into active/archived
+  const allNonOrphaned = [...ungrouped, ...reviewGroups.flatMap(g => g.annotations)];
+  const allThreads = buildThreads(allNonOrphaned);
+  const activeThreads = allThreads.filter(t => t.status !== 'resolved');
+  const archivedThreads = allThreads.filter(t => t.status === 'resolved');
+
+  // Group active threads by review_id for section headers
+  const renderThreadsByReview = (threads: typeof allThreads) => {
+    // Split into ungrouped (no review_id) and review-grouped
+    const noReview = threads.filter(t => !t.review_id);
+    const byReview = new Map<string, typeof threads>();
+    threads.filter(t => t.review_id).forEach(t => {
+      const list = byReview.get(t.review_id!) || [];
+      list.push(t);
+      byReview.set(t.review_id!, list);
+    });
+
+    return (
+      <>
+        {noReview.map(annotation => renderAnnotation(annotation))}
+        {Array.from(byReview.entries()).map(([reviewId, reviewThreads]) => {
+          const isExpanded = expandedReviews.has(reviewId);
+          return (
+            <div key={reviewId} className="thread-review-group">
+              <button
+                className="thread-review-header"
+                onClick={() => setExpandedReviews(prev => {
+                  const next = new Set(prev);
+                  if (next.has(reviewId)) {
+                    next.delete(reviewId);
+                  } else {
+                    next.add(reviewId);
+                  }
+                  return next;
+                })}
+              >
+                <span className="thread-review-arrow">{isExpanded ? '▼' : '▶'}</span>
+                Review #{reviewId.slice(-6)} — {reviewThreads.length} thread{reviewThreads.length > 1 ? 's' : ''}
+              </button>
+
+              {isExpanded && (
+                <div className="thread-review-comments">
+                  {reviewThreads.map(annotation => renderAnnotation(annotation))}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </>
+    );
+  };
+
   return (
     <div className={`thread-panel ${!isVisible ? 'thread-panel--hidden' : ''}`}>
       <div className="thread-header">
@@ -722,44 +796,29 @@ export default function AnnotationThread({ docPath }: Props) {
           renderEmpty()
         ) : (
           <>
-            {/* Current/ungrouped comments */}
-            {ungrouped.length > 0 && (
+            {/* Active section */}
+            {activeThreads.length > 0 && (
               <div className="thread-section">
-                {buildThreads(ungrouped).map(annotation => renderAnnotation(annotation))}
+                <div className="thread-section-header">
+                  Active ({activeThreads.length})
+                </div>
+                {renderThreadsByReview(activeThreads)}
               </div>
             )}
 
-            {/* Review groups */}
-            {reviewGroups.map(group => {
-              const isExpanded = expandedReviews.has(group.review_id);
-              const threadedAnnotations = buildThreads(group.annotations);
-
-              return (
-                <div key={group.review_id} className="thread-review-group">
-                  <button
-                    className="thread-review-header"
-                    onClick={() => setExpandedReviews(prev => {
-                      const next = new Set(prev);
-                      if (next.has(group.review_id)) {
-                        next.delete(group.review_id);
-                      } else {
-                        next.add(group.review_id);
-                      }
-                      return next;
-                    })}
-                  >
-                    <span className="thread-review-arrow">{isExpanded ? '▼' : '▶'}</span>
-                    Review #{group.review_id.slice(-6)} — {group.annotations.length} comment{group.annotations.length > 1 ? 's' : ''}
-                  </button>
-
-                  {isExpanded && (
-                    <div className="thread-review-comments">
-                      {threadedAnnotations.map(annotation => renderAnnotation(annotation))}
-                    </div>
-                  )}
-                </div>
-              );
-            })}
+            {/* Archived section */}
+            {archivedThreads.length > 0 && (
+              <div className="thread-section">
+                <button
+                  className="thread-section-header thread-section-header--archived"
+                  onClick={() => setShowArchived(!showArchived)}
+                >
+                  <span className="thread-review-arrow">{showArchived ? '▼' : '▶'}</span>
+                  Archived ({archivedThreads.length})
+                </button>
+                {showArchived && renderThreadsByReview(archivedThreads)}
+              </div>
+            )}
 
             {/* Orphaned comments */}
             {orphaned.length > 0 && (
@@ -769,7 +828,7 @@ export default function AnnotationThread({ docPath }: Props) {
                   onClick={() => setShowOrphaned(!showOrphaned)}
                 >
                   <span className="thread-review-arrow">{showOrphaned ? '▼' : '▶'}</span>
-                  ⚠️ Orphaned Comments ({orphaned.length})
+                  ⚠️ Orphaned ({orphaned.length})
                 </button>
 
                 {showOrphaned && (

--- a/packages/site/src/styles/global.css
+++ b/packages/site/src/styles/global.css
@@ -882,17 +882,23 @@ pre.mermaid {
 
 /* --- Thread Comments --- */
 .thread-comment {
-  background: var(--color-bg-secondary);
-  border: 1px solid var(--color-border-light);
-  border-radius: 8px;
-  padding: var(--spacing-md);
-  margin-bottom: var(--spacing-md);
+  background: none;
+  border: none;
+  border-radius: 0;
+  border-left: 2px solid var(--color-border);
+  padding: var(--spacing-sm) var(--spacing-md);
+  margin-bottom: 0;
   font-size: var(--font-size-sm);
   transition: background-color var(--transition-fast);
 }
 
+.thread-comment + .thread-comment {
+  border-top: 1px solid var(--color-border-light);
+}
+
 .thread-comment:hover {
   background: var(--color-sidebar-hover);
+  border-radius: 0 6px 6px 0;
 }
 
 .thread-comment-highlight {
@@ -905,7 +911,7 @@ pre.mermaid {
     background: var(--color-accent-light) !important;
   }
   100% {
-    background: var(--color-bg-secondary) !important;
+    background: transparent !important;
   }
 }
 
@@ -918,8 +924,9 @@ pre.mermaid {
 }
 
 .thread-comment--orphaned {
-  border-color: var(--color-warning-border);
+  border-left-color: var(--color-warning-border);
   background: var(--color-warning-bg);
+  border-radius: 0 6px 6px 0;
 }
 
 .thread-comment-collapsed {
@@ -1121,84 +1128,136 @@ pre.mermaid {
   color: var(--color-text-secondary);
 }
 
+/* --- Thread Collapse Indicator --- */
+.thread-replies-toggle {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: var(--spacing-xs) 0;
+  font-size: 0.75rem;
+  color: var(--color-accent);
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  transition: color var(--transition-fast);
+}
+
+.thread-replies-toggle:hover {
+  color: var(--color-accent-hover);
+}
+
+/* --- Active / Archived Section Headers --- */
+.thread-section-header {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  padding: var(--spacing-xs) 0;
+  margin-bottom: var(--spacing-sm);
+  border-bottom: 1px solid var(--color-border-light);
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.thread-section-header--archived {
+  cursor: pointer;
+  transition: color var(--transition-fast);
+  background: none;
+  border: none;
+  border-bottom: 1px solid var(--color-border-light);
+  width: 100%;
+  text-align: left;
+}
+
+.thread-section-header--archived:hover {
+  color: var(--color-text-secondary);
+}
+
 /* --- Threaded Replies --- */
 .thread-reply {
   margin-left: var(--spacing-md);
-  border-left: 2px solid var(--color-border);
-  padding-left: var(--spacing-sm);
+  border-left-color: var(--color-text-muted);
 }
 
 .thread-replies {
-  margin-top: var(--spacing-sm);
+  margin-top: 0;
 }
 
 /* --- Review Groups --- */
 .thread-review-group {
   margin-bottom: var(--spacing-lg);
-  border: 1px solid var(--color-border);
-  border-radius: 6px;
-  overflow: hidden;
+  border: none;
+  border-radius: 0;
+  overflow: visible;
 }
 
 .thread-review-header {
-  background: var(--color-bg-secondary);
+  background: none;
   border: none;
-  padding: var(--spacing-sm) var(--spacing-md);
+  border-bottom: 1px solid var(--color-border-light);
+  padding: var(--spacing-xs) 0;
   width: 100%;
   text-align: left;
   cursor: pointer;
   display: flex;
   align-items: center;
   gap: var(--spacing-xs);
-  color: var(--color-text);
-  font-size: var(--font-size-sm);
-  font-weight: 600;
-  transition: background-color var(--transition-fast);
+  color: var(--color-text-secondary);
+  font-size: 0.75rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  transition: color var(--transition-fast);
 }
 
 .thread-review-header:hover {
-  background: var(--color-sidebar-hover);
+  color: var(--color-text);
 }
 
 .thread-review-arrow {
-  font-size: 0.8em;
-  color: var(--color-text-secondary);
+  font-size: 0.7em;
+  color: var(--color-text-muted);
 }
 
 .thread-review-comments {
-  padding: var(--spacing-md);
+  padding: var(--spacing-xs) 0;
 }
 
 /* --- Orphaned Comments --- */
 .thread-orphaned {
   margin-top: var(--spacing-lg);
-  border: 1px solid var(--color-warning-border);
-  border-radius: 6px;
-  overflow: hidden;
+  border: none;
+  border-radius: 0;
+  overflow: visible;
 }
 
 .thread-orphaned-header {
-  background: var(--color-warning-bg);
+  background: none;
   border: none;
-  padding: var(--spacing-sm) var(--spacing-md);
+  border-bottom: 1px solid var(--color-warning-border);
+  padding: var(--spacing-xs) 0;
   width: 100%;
   text-align: left;
   cursor: pointer;
   display: flex;
   align-items: center;
   gap: var(--spacing-xs);
-  color: var(--color-text);
-  font-size: var(--font-size-sm);
-  font-weight: 600;
-  transition: background-color var(--transition-fast);
+  color: var(--color-warning-border);
+  font-size: 0.75rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  transition: color var(--transition-fast);
 }
 
 .thread-orphaned-header:hover {
-  background: var(--color-sidebar-hover);
+  color: var(--color-text);
 }
 
 .thread-orphaned-comments {
-  padding: var(--spacing-md);
+  padding: var(--spacing-xs) 0;
 }
 
 /* --- Section Indicators --- */
@@ -1250,12 +1309,13 @@ pre.mermaid {
 
 /* --- Dark Theme Thread Panel --- */
 [data-theme="dark"] .thread-comment--orphaned {
-  background: rgba(251, 146, 60, 0.1);
-  border-color: var(--color-warning-border);
+  background: rgba(251, 146, 60, 0.08);
+  border-left-color: var(--color-warning-border);
 }
 
 [data-theme="dark"] .thread-orphaned-header {
-  background: rgba(251, 146, 60, 0.1);
+  background: none;
+  color: var(--color-warning-border);
 }
 
 /* --- Mobile Thread Panel --- */


### PR DESCRIPTION
## What

Converts thread panel from bordered card-per-comment to Slack-style threaded timeline.

## Changes

- Timeline left-border layout replacing bordered boxes
- Collapsible threads (parent + 'N replies' indicator, default collapsed)
- Active/Archived sections (resolved threads in collapsible Archived section)
- Review group headers use separators instead of bordered containers
- Hover states as subtle tints
- Dark theme compatible

Part of E7: UI/UX Refinement (Batch 1)