### PR TITLE
fix(thread): E7 Batch 1 QA fixes

### DIFF
--- a/claude-prompt.txt
+++ b/claude-prompt.txt
@@ -1,0 +1,116 @@
+You are implementing QA fixes for E7 Batch 1. Here are the required changes:
+
+## Files to modify:
+- packages/site/src/components/AnnotationThread.tsx
+- packages/site/src/styles/global.css  
+- packages/site/src/layouts/DocLayout.astro (for SubmitReview relocation)
+
+## Changes Required:
+
+### 1. Fold orphaned comments into Active/Archived sections (AnnotationThread.tsx)
+Currently orphaned annotations are separated out in groupedAnnotations() and rendered in their own thread-orphaned section. Instead:
+- In groupedAnnotations(): STOP filtering out orphaned annotations into a separate array. Let them stay with ungrouped/review-grouped annotations.
+- Orphaned annotations should appear in **Active** section (since they're unresolved by nature — the user can resolve them to move to Archive)  
+- The separate orphaned section, showOrphaned state, and orphaned-specific rendering should be REMOVED entirely
+- In renderAnnotation(): for orphaned annotations, apply a muted/lighter text style instead of warning colors. Add class thread-comment--stale when annotation.status === 'orphaned'
+
+### 2. Section reordering: Draft → Active → Archive (AnnotationThread.tsx)
+Currently the render order is: Active → Archived → Orphaned.
+New order in the JSX return:
+1. **📝 Drafts (N)** — New section. Read drafts from localStorage using getDrafts(docPath) from '../utils/draft-storage.js'. Import it. Show drafts in a collapsible section (collapsed if empty, expanded if drafts exist). Each draft shows its heading_path and content preview. The drafts section is ONLY shown when there are drafts (hide completely when empty).
+2. **Active (N)** — unresolved threads (including orphaned/stale ones now)
+3. **📦 Archive (N)** — resolved threads (collapsed by default, as it already is)
+
+### 3. Submit button → thread header (AnnotationThread.tsx + DocLayout.astro + global.css)
+Currently SubmitReview is a floating positioned component mounted separately in DocLayout.astro. Move the submit functionality INTO the thread panel header:
+- In AnnotationThread.tsx: Import getDrafts, clearDrafts from '../utils/draft-storage.js' and authFetch from '../utils/api.js'. Add a submit button in the .thread-header div (between the title and refresh button) that only shows when drafts exist. Wire it to submit logic (create review, create annotations, patch statuses, clear drafts — same logic as SubmitReview.tsx).
+- In DocLayout.astro: Remove the <SubmitReview> component and its import entirely
+- In global.css: The .submit-review floating styles (lines ~1687-1800) can be removed or left as dead CSS for now
+
+### 4. Rename header title (AnnotationThread.tsx)
+Change <h3>💬 Review Thread</h3> to <h3>💬 Review</h3> — shorter, cleaner.
+
+### 5. Darken hover tint (global.css)
+The .thread-comment:hover background is too light. Change it:
+```css
+.thread-comment:hover {
+  background: var(--color-bg-secondary);
+  border-radius: 0 6px 6px 0;
+}
+```
+This uses --color-bg-secondary which is darker than --color-sidebar-hover. Test in both light and dark themes.
+
+### 6. Fix right margin asymmetry (global.css)
+When the thread panel is hidden, the grid column is 40px for the toggle tab, creating asymmetric margins. Fix:
+Change the grid-template-columns for hidden thread panel states from 40px to 0:
+```css
+.layout:has(.thread-panel--hidden),
+.layout.thread-hidden {
+  grid-template-columns: var(--sidebar-width) 1fr 0;
+}
+
+.layout.sidebar-hidden:has(.thread-panel--hidden),
+.layout.sidebar-hidden.thread-hidden {
+  grid-template-columns: 0 1fr 0;
+}
+```
+The toggle tab already uses position: absolute; left: -44px so it overflows from the panel — it doesn't need grid space.
+
+### 7. Stale comment styling (global.css)
+Add CSS for orphaned/stale comments (muted text instead of warning box):
+```css
+.thread-comment--stale {
+  opacity: 0.6;
+}
+
+.thread-comment--stale:hover {
+  opacity: 0.8;
+}
+
+.thread-comment--stale .thread-comment-header::after {
+  content: 'stale';
+  font-size: 0.65rem;
+  color: var(--color-text-muted);
+  font-style: italic;
+  margin-left: var(--spacing-xs);
+}
+```
+
+Also remove or simplify the .thread-comment--orphaned styles (remove the warning-border/warning-bg, since stale replaces it):
+```css
+/* Remove these or simplify: */
+.thread-comment--orphaned {
+  /* Remove warning colors — handled by --stale now */
+}
+```
+
+And remove the dark theme orphaned overrides:
+```css
+/* Remove: */
+[data-theme="dark"] .thread-comment--orphaned { ... }
+[data-theme="dark"] .thread-orphaned-header { ... }
+```
+
+And remove .thread-orphaned, .thread-orphaned-header, .thread-orphaned-comments styles entirely.
+
+## Boundaries — DO NOT:
+- Change any API routes
+- Change the sidebar or its styling  
+- Change CommentDraft.tsx
+- Add any new npm dependencies
+- Change the orphan detection/recovery LOGIC in the useCallback functions — only change how orphaned annotations are rendered/grouped
+
+## Acceptance Criteria:
+- No separate orphaned section — stale comments appear in Active with muted styling
+- Section order: Draft → Active → Archive
+- Drafts section shows when drafts exist, hidden when empty
+- Submit button in thread header (only shows when drafts exist)
+- SubmitReview component removed from DocLayout.astro
+- Header title says '💬 Review' (not 'Review Thread')
+- Hover tint is darker/more visible  
+- Left and right margins are symmetric when thread panel is hidden
+- Stale comments have muted text + 'stale' label, not warning colors
+- Dark theme still looks correct
+- Build passes: npm run build --workspace=packages/site
+
+Start by examining the current code structure, then implement all changes systematically.

--- a/packages/site/src/components/AnnotationThread.tsx
+++ b/packages/site/src/components/AnnotationThread.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { authFetch, isAuthenticated } from '../utils/api.js';
 import { getCleanHeadingText } from '../utils/heading-text.js';
+import { getDrafts, clearDrafts, type DraftComment } from '../utils/draft-storage.js';
 
 // Types (copied from API package)
 type AnnotationStatus = "draft" | "submitted" | "replied" | "resolved" | "orphaned";
@@ -101,7 +102,6 @@ export default function AnnotationThread({ docPath }: Props) {
   const [isVisible, setIsVisible] = useState(true);
   const [expandedReviews, setExpandedReviews] = useState<Set<string>>(new Set());
   const [expandedResolved, setExpandedResolved] = useState<Set<string>>(new Set());
-  const [showOrphaned, setShowOrphaned] = useState(false);
   const [authenticated, setAuthenticated] = useState(false);
   const [resolvingId, setResolvingId] = useState<string | null>(null);
 
@@ -118,6 +118,16 @@ export default function AnnotationThread({ docPath }: Props) {
   const [replyContent, setReplyContent] = useState('');
   const [replySubmitting, setReplySubmitting] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
+
+  // Drafts state
+  const [drafts, setDrafts] = useState<DraftComment[]>([]);
+  const [showDrafts, setShowDrafts] = useState(true);
+  const [submitState, setSubmitState] = useState<{ isSubmitting: boolean; error: string | null; success: boolean }>({
+    isSubmitting: false,
+    error: null,
+    success: false
+  });
+  const submittingRef = useRef(false);
 
   // Helper to update annotation status via API
   const patchAnnotation = useCallback(async (id: string, updates: Partial<Pick<Annotation, 'status'>>) => {
@@ -349,6 +359,118 @@ export default function AnnotationThread({ docPath }: Props) {
     };
   }, [fetchAnnotations]);
 
+  // Load drafts and keep in sync with localStorage
+  useEffect(() => {
+    const loadDrafts = () => {
+      setDrafts(getDrafts(docPath));
+    };
+    loadDrafts();
+    window.addEventListener('foundry-draft-updated', loadDrafts);
+    window.addEventListener('storage', loadDrafts);
+    return () => {
+      window.removeEventListener('foundry-draft-updated', loadDrafts);
+      window.removeEventListener('storage', loadDrafts);
+    };
+  }, [docPath]);
+
+  // Submit drafts as a review
+  const handleSubmit = useCallback(async () => {
+    if (drafts.length === 0 || submittingRef.current) return;
+    submittingRef.current = true;
+
+    const confirmMessage = `Submit ${drafts.length} comment${drafts.length > 1 ? 's' : ''} for review?`;
+    if (!window.confirm(confirmMessage)) {
+      submittingRef.current = false;
+      return;
+    }
+
+    setSubmitState({ isSubmitting: true, error: null, success: false });
+
+    try {
+      // Step 1: Create the review
+      const reviewResponse = await authFetch(`/api/reviews`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ doc_path: docPath })
+      });
+
+      if (!reviewResponse.ok) {
+        throw new Error(`Failed to create review: HTTP ${reviewResponse.status}`);
+      }
+
+      const review = await reviewResponse.json();
+      const reviewId = review.id;
+
+      // Step 2: Submit each draft as an annotation
+      const annotationPromises = drafts.map(async (draft) => {
+        const annotationResponse = await authFetch(`/api/annotations`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            doc_path: draft.doc_path,
+            heading_path: draft.heading_path,
+            content_hash: draft.content_hash,
+            quoted_text: draft.quoted_text,
+            content: draft.content,
+            author_type: 'human',
+            review_id: reviewId
+          })
+        });
+
+        if (!annotationResponse.ok) {
+          throw new Error(`Failed to create annotation: HTTP ${annotationResponse.status}`);
+        }
+
+        const annotation = await annotationResponse.json();
+
+        const patchResponse = await authFetch(`/api/annotations/${annotation.id}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ status: 'submitted' })
+        });
+
+        if (!patchResponse.ok) {
+          throw new Error(`Failed to update annotation status: HTTP ${patchResponse.status}`);
+        }
+
+        return annotation;
+      });
+
+      await Promise.all(annotationPromises);
+
+      // Step 3: Update review status to submitted
+      const reviewPatchResponse = await authFetch(`/api/reviews/${reviewId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: 'submitted', submitted_at: new Date().toISOString() })
+      });
+
+      if (!reviewPatchResponse.ok) {
+        throw new Error(`Failed to update review status: HTTP ${reviewPatchResponse.status}`);
+      }
+
+      // Step 4: Clear drafts
+      clearDrafts(docPath);
+      setDrafts([]);
+
+      setSubmitState({ isSubmitting: false, error: null, success: true });
+      window.dispatchEvent(new CustomEvent('foundry-review-submitted'));
+
+      setTimeout(() => {
+        setSubmitState(prev => ({ ...prev, success: false }));
+      }, 3000);
+
+    } catch (err) {
+      setSubmitState({
+        isSubmitting: false,
+        error: err instanceof Error ? err.message : 'Failed to submit review',
+        success: false
+      });
+    } finally {
+      submittingRef.current = false;
+    }
+  }, [drafts, docPath]);
+
   // Add section margin indicators
   useEffect(() => {
     if (annotations.length === 0) return;
@@ -416,20 +538,16 @@ export default function AnnotationThread({ docPath }: Props) {
     };
   }, [annotations]);
 
-  // Group annotations
+  // Group annotations — orphaned annotations stay with their review group or ungrouped
   const groupedAnnotations = (): {
     reviewGroups: ReviewGroup[];
     ungrouped: Annotation[];
-    orphaned: Annotation[];
   } => {
     const reviewGroups: Map<string, Annotation[]> = new Map();
     const ungrouped: Annotation[] = [];
-    const orphaned: Annotation[] = [];
 
     annotations.forEach(annotation => {
-      if (annotation.status === 'orphaned') {
-        orphaned.push(annotation);
-      } else if (annotation.review_id) {
+      if (annotation.review_id) {
         if (!reviewGroups.has(annotation.review_id)) {
           reviewGroups.set(annotation.review_id, []);
         }
@@ -444,8 +562,7 @@ export default function AnnotationThread({ docPath }: Props) {
         review_id,
         annotations: annotations.sort((a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime())
       })),
-      ungrouped: ungrouped.sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime()),
-      orphaned: orphaned.sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
+      ungrouped: ungrouped.sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
     };
   };
 
@@ -533,7 +650,7 @@ export default function AnnotationThread({ docPath }: Props) {
     return (
       <div
         key={annotation.id}
-        className={`thread-comment ${isDraft ? 'thread-comment--draft' : ''} ${isResolved ? 'thread-comment--resolved' : ''} ${isReply ? 'thread-reply' : ''}`}
+        className={`thread-comment ${isDraft ? 'thread-comment--draft' : ''} ${isResolved ? 'thread-comment--resolved' : ''} ${isOrphaned ? 'thread-comment--stale' : ''} ${isReply ? 'thread-reply' : ''}`}
         data-annotation-heading={annotation.heading_path}
       >
         {isResolved && !expanded ? (
@@ -573,7 +690,7 @@ export default function AnnotationThread({ docPath }: Props) {
                 📍
               </button>
               <span className="thread-comment-time">{relativeTime(annotation.created_at)}</span>
-              {authenticated && !isOrphaned && (
+              {authenticated && (
                 <button
                   className="thread-reply-btn"
                   onClick={() => { setReplyingTo(annotation.id); setReplyContent(''); }}
@@ -582,7 +699,7 @@ export default function AnnotationThread({ docPath }: Props) {
                   ↩ Reply
                 </button>
               )}
-              {authenticated && !isReply && !isResolved && !isOrphaned && (
+              {authenticated && !isReply && !isResolved && (
                 <button
                   className="thread-resolve-btn"
                   onClick={async () => {
@@ -625,12 +742,6 @@ export default function AnnotationThread({ docPath }: Props) {
                 </button>
               )}
             </div>
-
-            {isOrphaned && (
-              <div className="thread-comment-orphan-context">
-                <strong>Original section:</strong> {annotation.heading_path}
-              </div>
-            )}
 
             {annotation.quoted_text && (
               <blockquote className="thread-comment-quote">
@@ -727,11 +838,10 @@ export default function AnnotationThread({ docPath }: Props) {
     </div>
   );
 
-  const { reviewGroups, ungrouped, orphaned } = groupedAnnotations();
+  const { reviewGroups, ungrouped } = groupedAnnotations();
 
-  // Build all non-orphaned threads and split into active/archived
-  const allNonOrphaned = [...ungrouped, ...reviewGroups.flatMap(g => g.annotations)];
-  const allThreads = buildThreads(allNonOrphaned);
+  // Build all threads and split into active/archived
+  const allThreads = buildThreads([...ungrouped, ...reviewGroups.flatMap(g => g.annotations)]);
   const activeThreads = allThreads.filter(t => t.status !== 'resolved');
   const archivedThreads = allThreads.filter(t => t.status === 'resolved');
 
@@ -784,7 +894,17 @@ export default function AnnotationThread({ docPath }: Props) {
   return (
     <div className={`thread-panel ${!isVisible ? 'thread-panel--hidden' : ''}`}>
       <div className="thread-header">
-        <h3>💬 Review Thread</h3>
+        <h3>💬 Review</h3>
+        {drafts.length > 0 && (
+          <button
+            className={`thread-submit-btn ${submitState.isSubmitting ? 'thread-submit-btn--loading' : ''}`}
+            onClick={handleSubmit}
+            disabled={submitState.isSubmitting}
+            title={`Submit ${drafts.length} comment${drafts.length > 1 ? 's' : ''} for review`}
+          >
+            {submitState.isSubmitting ? '🔄' : `📤 Submit (${drafts.length})`}
+          </button>
+        )}
         <button
           className={`thread-refresh-btn ${refreshing ? 'thread-refresh-btn--spinning' : ''}`}
           onClick={handleRefresh}
@@ -810,10 +930,40 @@ export default function AnnotationThread({ docPath }: Props) {
           <div className="thread-loading">Loading comments...</div>
         ) : error ? (
           <div className="thread-error">{error}</div>
-        ) : annotations.length === 0 ? (
-          renderEmpty()
         ) : (
           <>
+            {submitState.success && (
+              <div className="thread-submit-success">✅ Review submitted!</div>
+            )}
+            {submitState.error && (
+              <div className="thread-submit-error">❌ {submitState.error}</div>
+            )}
+
+            {/* Drafts section — only shown when drafts exist */}
+            {drafts.length > 0 && (
+              <div className="thread-section">
+                <button
+                  className="thread-section-header thread-section-header--drafts"
+                  onClick={() => setShowDrafts(!showDrafts)}
+                >
+                  <span className="thread-review-arrow">{showDrafts ? '▼' : '▶'}</span>
+                  📝 Drafts ({drafts.length})
+                </button>
+                {showDrafts && (
+                  <div className="thread-drafts-list">
+                    {drafts.map(draft => (
+                      <div key={draft.id} className="thread-draft-item">
+                        <div className="thread-draft-heading">{draft.heading_path}</div>
+                        <div className="thread-draft-preview">
+                          {draft.content.slice(0, 80)}{draft.content.length > 80 ? '…' : ''}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
+
             {/* Active section */}
             {activeThreads.length > 0 && (
               <div className="thread-section">
@@ -832,30 +982,14 @@ export default function AnnotationThread({ docPath }: Props) {
                   onClick={() => setShowArchived(!showArchived)}
                 >
                   <span className="thread-review-arrow">{showArchived ? '▼' : '▶'}</span>
-                  Archived ({archivedThreads.length})
+                  📦 Archive ({archivedThreads.length})
                 </button>
                 {showArchived && renderThreadsByReview(archivedThreads)}
               </div>
             )}
 
-            {/* Orphaned comments */}
-            {orphaned.length > 0 && (
-              <div className="thread-orphaned">
-                <button
-                  className="thread-orphaned-header"
-                  onClick={() => setShowOrphaned(!showOrphaned)}
-                >
-                  <span className="thread-review-arrow">{showOrphaned ? '▼' : '▶'}</span>
-                  ⚠️ Orphaned ({orphaned.length})
-                </button>
-
-                {showOrphaned && (
-                  <div className="thread-orphaned-comments">
-                    {buildThreads(orphaned).map(annotation => renderAnnotation(annotation))}
-                  </div>
-                )}
-              </div>
-            )}
+            {/* Empty state */}
+            {annotations.length === 0 && drafts.length === 0 && renderEmpty()}
           </>
         )}
       </div>

--- a/packages/site/src/layouts/DocLayout.astro
+++ b/packages/site/src/layouts/DocLayout.astro
@@ -8,7 +8,7 @@ import PlayAllManager from '../components/PlayAllManager.tsx';
 import TtsControlsBar from '../components/TtsControlsBar.tsx';
 import AnnotationThread from '../components/AnnotationThread.tsx';
 import CommentDraft from '../components/CommentDraft.tsx';
-import SubmitReview from '../components/SubmitReview.tsx';
+
 import TokenModal from '../components/TokenModal.tsx';
 import AuthIndicator from '../components/AuthIndicator.tsx';
 
@@ -76,10 +76,7 @@ const base = import.meta.env.BASE_URL;
       </article>
     </main>
 
-    <SubmitReview
-      docPath={currentPath}
-      client:load
-    />
+
 
     <AnnotationThread
       docPath={currentPath}

--- a/packages/site/src/styles/global.css
+++ b/packages/site/src/styles/global.css
@@ -838,6 +838,41 @@ pre.mermaid {
   color: var(--color-heading);
 }
 
+.thread-submit-btn {
+  background: var(--color-accent);
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: var(--spacing-xs) var(--spacing-sm);
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  white-space: nowrap;
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+}
+
+.thread-submit-btn:hover:not(:disabled) {
+  background: var(--color-accent-hover);
+  transform: translateY(-1px);
+}
+
+.thread-submit-btn:disabled {
+  background: var(--color-text-muted);
+  cursor: not-allowed;
+  transform: none;
+}
+
+.thread-submit-btn--loading {
+  animation: submitPulse 1.5s infinite;
+}
+
+.thread-panel--hidden .thread-submit-btn {
+  display: none;
+}
+
 .thread-toggle {
   background: none;
   border: none;
@@ -931,7 +966,7 @@ pre.mermaid {
 }
 
 .thread-comment:hover {
-  background: var(--color-sidebar-hover);
+  background: var(--color-bg-secondary);
   border-radius: 0 6px 6px 0;
 }
 
@@ -957,10 +992,20 @@ pre.mermaid {
   opacity: 0.7;
 }
 
-.thread-comment--orphaned {
-  border-left-color: var(--color-warning-border);
-  background: var(--color-warning-bg);
-  border-radius: 0 6px 6px 0;
+.thread-comment--stale {
+  opacity: 0.6;
+}
+
+.thread-comment--stale:hover {
+  opacity: 0.8;
+}
+
+.thread-comment--stale .thread-comment-header::after {
+  content: 'stale';
+  font-size: 0.65rem;
+  color: var(--color-text-muted);
+  font-style: italic;
+  margin-left: var(--spacing-xs);
 }
 
 .thread-comment-collapsed {
@@ -1259,40 +1304,7 @@ pre.mermaid {
   padding: var(--spacing-xs) 0;
 }
 
-/* --- Orphaned Comments --- */
-.thread-orphaned {
-  margin-top: var(--spacing-lg);
-  border: none;
-  border-radius: 0;
-  overflow: visible;
-}
 
-.thread-orphaned-header {
-  background: none;
-  border: none;
-  border-bottom: 1px solid var(--color-warning-border);
-  padding: var(--spacing-xs) 0;
-  width: 100%;
-  text-align: left;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-xs);
-  color: var(--color-warning-border);
-  font-size: 0.75rem;
-  font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 0.03em;
-  transition: color var(--transition-fast);
-}
-
-.thread-orphaned-header:hover {
-  color: var(--color-text);
-}
-
-.thread-orphaned-comments {
-  padding: var(--spacing-xs) 0;
-}
 
 /* --- Section Indicators --- */
 .section-indicator {
@@ -1335,24 +1347,16 @@ pre.mermaid {
 /* Hidden thread panel */
 .layout:has(.thread-panel--hidden),
 .layout.thread-hidden {
-  grid-template-columns: var(--sidebar-width) 1fr 40px;
+  grid-template-columns: var(--sidebar-width) 1fr 0;
 }
 
 .layout.sidebar-hidden:has(.thread-panel--hidden),
 .layout.sidebar-hidden.thread-hidden {
-  grid-template-columns: 0 1fr 40px;
+  grid-template-columns: 0 1fr 0;
 }
 
 /* --- Dark Theme Thread Panel --- */
-[data-theme="dark"] .thread-comment--orphaned {
-  background: rgba(251, 146, 60, 0.08);
-  border-left-color: var(--color-warning-border);
-}
 
-[data-theme="dark"] .thread-orphaned-header {
-  background: none;
-  color: var(--color-warning-border);
-}
 
 /* --- Mobile Thread Panel --- */
 @media (max-width: 1024px) {


### PR DESCRIPTION
## What

QA-driven refinements from E7 Batch 1 review.

## Changes

- **Section reorder**: Draft → Active → Archive (was Active → Archive → Orphaned)
- **Orphaned → Stale**: Removed separate orphaned section. Stale comments appear in Active with muted text + 'stale' label instead of warning colors
- **Submit in header**: Moved submit review button from floating component to thread panel header. Removed SubmitReview from DocLayout.
- **Header title**: 'Review Thread' → 'Review'
- **Hover tint**: Darkened comment hover background
- **Margin fix**: Symmetric margins when thread panel hidden (grid column 40px → 0)
- **Dark theme**: Cleaned up orphaned overrides

Addresses all QA feedback from E7 Batch 1 review.