### PR TITLE
feat(sidebar): MkDocs Material-style restyle (E7-S4)

### DIFF
--- a/packages/site/src/styles/global.css
+++ b/packages/site/src/styles/global.css
@@ -261,10 +261,10 @@ h6:hover .heading-anchor {
   position: sticky;
   top: var(--header-height);
   height: calc(100vh - var(--header-height));
-  background: var(--color-sidebar-bg);
-  border-right: 1px solid var(--color-border);
+  background: var(--color-bg);
+  border-right: 1px solid var(--color-border-light);
   overflow-y: auto;
-  padding: var(--spacing-md);
+  padding: var(--spacing-sm) var(--spacing-md);
   z-index: 10;
   transition: transform var(--transition-normal);
 }
@@ -391,15 +391,17 @@ h6:hover .heading-anchor {
 }
 
 .nav-item:hover {
-  background: var(--color-sidebar-hover);
+  background: var(--color-bg-secondary);
+  border-radius: 4px;
 }
 
 .nav-item.active {
-  background: var(--color-sidebar-active);
+  border-left: 3px solid var(--color-accent);
+  border-radius: 0 4px 4px 0;
 }
 
 .nav-item.active .nav-link {
-  color: var(--color-sidebar-active-text);
+  color: var(--color-accent);
   font-weight: 600;
 }
 
@@ -419,7 +421,7 @@ h6:hover .heading-anchor {
 }
 
 .nav-link.active {
-  color: var(--color-sidebar-active-text);
+  color: var(--color-accent);
   font-weight: 600;
 }
 
@@ -442,8 +444,15 @@ h6:hover .heading-anchor {
 }
 
 .nav-section > summary::before {
-  content: '▸';
-  font-size: 0.75rem;
+  content: '';
+  display: inline-block;
+  width: 1rem;
+  height: 1rem;
+  flex-shrink: 0;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%2394a3b8' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='9 18 15 12 9 6'%3E%3C/polyline%3E%3C/svg%3E");
+  background-size: contain;
+  background-repeat: no-repeat;
+  background-position: center;
   transition: transform var(--transition-fast);
 }
 
@@ -452,12 +461,24 @@ h6:hover .heading-anchor {
 }
 
 .nav-section > summary:hover {
-  background: var(--color-sidebar-hover);
+  background: var(--color-bg-secondary);
   color: var(--color-text);
 }
 
 .nav-section > summary::-webkit-details-marker {
   display: none;
+}
+
+/* Top-level section titles — uppercase label style */
+.nav-list > .nav-section > summary {
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  font-weight: 700;
+}
+
+/* Dark theme SVG chevron — lighter stroke */
+[data-theme="dark"] .nav-section > summary::before {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%2364748b' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='9 18 15 12 9 6'%3E%3C/polyline%3E%3C/svg%3E");
 }
 
 /* --- Breadcrumbs --- */


### PR DESCRIPTION
## What

Restyles the navigation sidebar to match MkDocs Material's clean, integrated look.

## Changes

- Sidebar background matches page (no separate panel color)
- SVG chevrons replace text arrows with smooth rotation
- Active page left accent bar (3px orange) instead of background highlight
- Top-level section titles uppercase
- Tighter padding, subtle hover states
- Dark theme compatible

Part of E7: UI/UX Refinement (Batch 2)