### PR TITLE
feat(theme): warmer color palette + accent gradient bar (E7-S5)

### DIFF
--- a/packages/site/src/styles/global.css
+++ b/packages/site/src/styles/global.css
@@ -5,8 +5,8 @@
 /* --- Theme Custom Properties --- */
 :root {
   /* Colors — Light theme */
-  --color-bg: #ffffff;
-  --color-bg-secondary: #f8f9fa;
+  --color-bg: #fafafa;
+  --color-bg-secondary: #f4f4f5;
   --color-bg-code: #f4f4f5;
   --color-text: #1a1a2e;
   --color-text-secondary: #64748b;
@@ -18,10 +18,10 @@
   --color-border-light: #f1f5f9;
 
   /* Sidebar */
-  --color-sidebar-bg: #f8f9fa;
-  --color-sidebar-active: #eff6ff;
-  --color-sidebar-active-text: #2563eb;
-  --color-sidebar-hover: #f1f5f9;
+  --color-sidebar-bg: #fafafa;
+  --color-sidebar-active: #fff7ed;
+  --color-sidebar-active-text: #ea580c;
+  --color-sidebar-hover: #f0f0f1;
 
   /* Accent (deep orange from MkDocs theme) */
   --color-accent: #ea580c;
@@ -66,22 +66,22 @@
 
 /* --- Dark Theme --- */
 [data-theme="dark"] {
-  --color-bg: #0f172a;
-  --color-bg-secondary: #1e293b;
-  --color-bg-code: #1e293b;
+  --color-bg: #111318;
+  --color-bg-secondary: #1a1d24;
+  --color-bg-code: #1e2028;
   --color-text: #e2e8f0;
   --color-text-secondary: #94a3b8;
   --color-text-muted: #64748b;
   --color-heading: #f1f5f9;
   --color-link: #60a5fa;
   --color-link-hover: #93bbfd;
-  --color-border: #334155;
-  --color-border-light: #1e293b;
+  --color-border: #2a2d35;
+  --color-border-light: #1e2028;
 
-  --color-sidebar-bg: #1e293b;
-  --color-sidebar-active: #1e3a5f;
-  --color-sidebar-active-text: #60a5fa;
-  --color-sidebar-hover: #334155;
+  --color-sidebar-bg: #111318;
+  --color-sidebar-active: rgba(249, 115, 22, 0.1);
+  --color-sidebar-active-text: #f97316;
+  --color-sidebar-hover: #1e2028;
 
   --color-accent: #f97316;
   --color-accent-hover: #fb923c;
@@ -97,6 +97,18 @@
   --color-danger-border: #ef4444;
   --color-info-bg: #0c4a6e;
   --color-info-border: #0ea5e9;
+}
+
+/* --- Header Gradient Accent Bar --- */
+.header::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: linear-gradient(90deg, var(--color-accent), #f59e0b);
+  z-index: 1;
 }
 
 /* --- Reset & Base --- */


### PR DESCRIPTION
## What

Refreshes the color palette to warmer neutrals and aligns interactive states to the orange accent color.

## Changes

### Dark Theme
- Background: cold navy → near-black neutral
- Secondary/borders: blue-gray → warm dark gray
- Active states: blue → orange accent tint

### Light Theme
- Background: pure white → off-white
- Active states: blue → orange accent

### Header
- 3px gradient accent bar (orange → amber) at top

Admonitions, text colors, link colors, and accent values unchanged.

Part of E7: UI/UX Refinement (Batch 2). Iterative — expect adjustments after live review.