### PR TITLE
feat(theme): warm text + scroll progress bar (E7-polish)

### DIFF
--- a/packages/site/src/layouts/DocLayout.astro
+++ b/packages/site/src/layouts/DocLayout.astro
@@ -113,6 +113,22 @@ const base = import.meta.env.BASE_URL;
     }
   </script>
 
+  {/* Scroll progress bar */}
+  <script is:inline>
+    (function() {
+      const header = document.querySelector('.header');
+      if (!header) return;
+      function updateProgress() {
+        const scrollTop = window.scrollY || document.documentElement.scrollTop;
+        const docHeight = document.documentElement.scrollHeight - window.innerHeight;
+        const progress = docHeight > 0 ? Math.min(scrollTop / docHeight, 1) : 0;
+        header.style.setProperty('--scroll-progress', String(progress));
+      }
+      window.addEventListener('scroll', updateProgress, { passive: true });
+      updateProgress();
+    })();
+  </script>
+
   {/* Cancel TTS on navigation */}
   <script is:inline>
     window.addEventListener("beforeunload", function() {

--- a/packages/site/src/styles/global.css
+++ b/packages/site/src/styles/global.css
@@ -69,10 +69,10 @@
   --color-bg: #111318;
   --color-bg-secondary: #1a1d24;
   --color-bg-code: #1e2028;
-  --color-text: #e2e8f0;
-  --color-text-secondary: #94a3b8;
-  --color-text-muted: #64748b;
-  --color-heading: #f1f5f9;
+  --color-text: #e8e4df;
+  --color-text-secondary: #9e9a95;
+  --color-text-muted: #6b6862;
+  --color-heading: #f5f0eb;
   --color-link: #60a5fa;
   --color-link-hover: #93bbfd;
   --color-border: #2a2d35;
@@ -109,6 +109,9 @@
   height: 3px;
   background: linear-gradient(90deg, var(--color-accent), #f59e0b);
   z-index: 1;
+  transform-origin: left;
+  transform: scaleX(var(--scroll-progress, 0));
+  transition: transform 50ms linear;
 }
 
 /* --- Reset & Base --- */


### PR DESCRIPTION
## What

Two polish touches from Dan's feedback:

### Warm Text Colors (Dark Theme)
Shifted dark theme text from cool blue-white to warm off-white to complement the orange accent:
- `--color-text`: `#e2e8f0` → `#e8e4df`
- `--color-text-secondary`: `#94a3b8` → `#9e9a95`
- `--color-text-muted`: `#64748b` → `#6b6862`
- `--color-heading`: `#f1f5f9` → `#f5f0eb`

### Scroll Progress Gradient Bar
The header's gradient accent bar now grows left-to-right as the user scrolls. Uses a CSS custom property (`--scroll-progress`) driven by a passive scroll listener. Zero layout impact.

Part of E7: UI/UX Refinement (polish pass).