### PR TITLE
fix(ui): panel sticky regression, scroll preservation on reply, larger action buttons (E7 QA)

### DIFF
--- a/packages/site/src/components/AnnotationThread.tsx
+++ b/packages/site/src/components/AnnotationThread.tsx
@@ -377,7 +377,7 @@ export default function AnnotationThread({ docPath }: Props) {
   }, [isVisible]);
 
   // Fetch annotations
-  const fetchAnnotations = useCallback(async () => {
+  const fetchAnnotations = useCallback(async (silent = false) => {
     if (!isAuthenticated()) {
       setLoading(false);
       setAnnotations([]);
@@ -385,7 +385,12 @@ export default function AnnotationThread({ docPath }: Props) {
       return;
     }
 
-    setLoading(true);
+    // Capture scroll position BEFORE any state changes that trigger re-render
+    const scrollTop = threadContentRef.current?.scrollTop ?? 0;
+
+    if (!silent) {
+      setLoading(true);
+    }
     setError(null);
 
     try {
@@ -401,7 +406,6 @@ export default function AnnotationThread({ docPath }: Props) {
       const recoveredAnnotations = await recoverOrphanedAnnotations(data);
 
       // Then run orphan detection with simple quoted-text logic
-      const scrollTop = threadContentRef.current?.scrollTop ?? 0;
       const processedAnnotations = await detectOrphansAndDrift(recoveredAnnotations);
       setAnnotations(processedAnnotations);
       // Restore scroll position after React re-render
@@ -807,10 +811,10 @@ export default function AnnotationThread({ docPath }: Props) {
         return false;
       }
 
-      // Clear reply state and refresh annotations
+      // Clear reply state and refresh annotations (silent to preserve scroll)
       setReplyingTo(null);
       setReplyContent('');
-      fetchAnnotations();
+      fetchAnnotations(true);
       return true;
     } catch (err) {
       console.warn('Error submitting reply:', err);
@@ -852,7 +856,7 @@ export default function AnnotationThread({ docPath }: Props) {
                 }}
                 title="Reopen"
               >
-                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="1 4 1 10 7 10"/><path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"/></svg>
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="1 4 1 10 7 10"/><path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"/></svg>
               </button>
             )}
           </div>
@@ -872,7 +876,7 @@ export default function AnnotationThread({ docPath }: Props) {
                     onClick={(e) => { e.stopPropagation(); setReplyingTo(annotation.id); setReplyContent(''); }}
                     title="Reply"
                   >
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="9 17 4 12 9 7"/><path d="M20 18v-2a4 4 0 0 0-4-4H4"/></svg>
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="9 17 4 12 9 7"/><path d="M20 18v-2a4 4 0 0 0-4-4H4"/></svg>
                   </button>
                 )}
                 {authenticated && !isReply && !isResolved && (
@@ -905,7 +909,7 @@ export default function AnnotationThread({ docPath }: Props) {
                     disabled={resolvingId === annotation.id}
                     title="Resolve"
                   >
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>
                   </button>
                 )}
                 {isResolved && (
@@ -1090,7 +1094,7 @@ export default function AnnotationThread({ docPath }: Props) {
           aria-label="Refresh annotations"
           title="Refresh annotations"
         >
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="23 4 23 10 17 10"/><polyline points="1 20 1 14 7 14"/><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"/></svg>
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="23 4 23 10 17 10"/><polyline points="1 20 1 14 7 14"/><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"/></svg>
         </button>
         <button
           className="thread-toggle"

--- a/packages/site/src/styles/global.css
+++ b/packages/site/src/styles/global.css
@@ -280,7 +280,7 @@ h6:hover .heading-anchor {
   display: grid;
   grid-template-columns: var(--sidebar-width) 1fr var(--thread-panel-width);
   min-height: 100vh;
-  overflow: hidden; /* prevent grid blowout */
+  overflow-x: hidden; /* prevent wide content blowout without breaking sticky */
 }
 
 .sidebar {
@@ -1179,8 +1179,8 @@ pre.mermaid {
   border: none;
   cursor: pointer;
   color: var(--color-text-muted);
-  padding: 2px;
-  border-radius: 3px;
+  padding: 4px;
+  border-radius: 4px;
   transition: color var(--transition-fast);
 }
 
@@ -1195,8 +1195,8 @@ pre.mermaid {
   border: none;
   cursor: pointer;
   color: var(--color-text-muted);
-  padding: 2px;
-  border-radius: 3px;
+  padding: 4px;
+  border-radius: 4px;
   margin-left: auto;
   transition: color var(--transition-fast);
 }
@@ -1234,8 +1234,8 @@ pre.mermaid {
   border: none;
   cursor: pointer;
   color: var(--color-text-muted);
-  padding: 2px;
-  border-radius: 3px;
+  padding: 4px;
+  border-radius: 4px;
   transition: color var(--transition-fast);
 }
 


### PR DESCRIPTION
## Fixes

### 1. Panel sticky regression
`overflow: hidden` on `.layout` (from PR #43 content blowout fix) broke `position: sticky` on sidebar and thread panel. Changed to `overflow-x: hidden` — constrains horizontal overflow without breaking vertical sticky behavior.

### 2. Scroll-to-top after reply
`fetchAnnotations()` set `loading=true` which re-rendered the panel as 'Loading...' before capturing scroll position. Two fixes:
- Capture `scrollTop` BEFORE any state changes
- Added `silent` parameter — reply submission uses `fetchAnnotations(true)` to skip the loading state entirely

### 3. Larger action buttons
- Reply/Resolve SVGs: 14×14 → 16×16
- Reopen SVG: 12×12 → 14×14
- Header refresh SVG: 14×14 → 16×16
- Button padding: 2px → 4px, border-radius: 3px → 4px

2 files, +20/-16 lines.