### PR TITLE
feat(api): add delete_annotation MCP tool + HTTP route (FND-E9-S1)

### DIFF
--- a/packages/api/src/mcp/__tests__/annotation-tools.test.ts
+++ b/packages/api/src/mcp/__tests__/annotation-tools.test.ts
@@ -6,6 +6,7 @@ vi.mock('../http-client.js', () => ({
   listAnnotations: vi.fn(),
   createAnnotation: vi.fn(),
   resolveAnnotation: vi.fn(),
+  deleteAnnotation: vi.fn(),
   submitReview: vi.fn(),
 }));
 
@@ -13,12 +14,14 @@ import {
   listAnnotations,
   createAnnotation,
   resolveAnnotation,
+  deleteAnnotation,
   submitReview,
 } from '../http-client.js';
 
 const mockListAnnotations = vi.mocked(listAnnotations);
 const mockCreateAnnotation = vi.mocked(createAnnotation);
 const mockResolveAnnotation = vi.mocked(resolveAnnotation);
+const mockDeleteAnnotation = vi.mocked(deleteAnnotation);
 const mockSubmitReview = vi.mocked(submitReview);
 
 function makeAnnotation(overrides: Partial<Annotation> = {}): Annotation {
@@ -206,5 +209,25 @@ describe('submitReview', () => {
     const result = await submitReview('test-doc.md', ['ann-1']);
 
     expect((result as any).status).toBe('review_submitted');
+  });
+});
+
+describe('deleteAnnotation', () => {
+  it('should delete an existing annotation', async () => {
+    mockDeleteAnnotation.mockResolvedValue({ status: 'deleted' });
+
+    const result = await deleteAnnotation('test-id-1');
+
+    expect(result.status).toBe('deleted');
+    expect(mockDeleteAnnotation).toHaveBeenCalledWith('test-id-1');
+  });
+
+  it('should return error for non-existent annotation', async () => {
+    mockDeleteAnnotation.mockResolvedValue({ status: 'error', message: 'Annotation not found' });
+
+    const result = await deleteAnnotation('non-existent-id');
+
+    expect(result.status).toBe('error');
+    expect(result.message).toBe('Annotation not found');
   });
 });

--- a/packages/api/src/mcp/http-client.ts
+++ b/packages/api/src/mcp/http-client.ts
@@ -147,6 +147,32 @@ export async function submitReview(
   };
 }
 
+/**
+ * Delete an annotation by ID. Cascade-deletes child replies and cleans up orphan reviews.
+ */
+export async function deleteAnnotation(
+  annotationId: string,
+): Promise<{ status: 'deleted' | 'error'; message?: string }> {
+  const url = `${BASE_URL}/api/annotations/${annotationId}`;
+  const res = await fetch(url, {
+    method: 'DELETE',
+    headers: {
+      ...authHeaders(),
+    },
+  });
+
+  if (res.status === 204) {
+    return { status: 'deleted' };
+  }
+
+  if (res.status === 404) {
+    return { status: 'error', message: 'Annotation not found' };
+  }
+
+  const body = await res.text();
+  throw new Error(`API DELETE /api/annotations/${annotationId} failed (${res.status}): ${body}`);
+}
+
 interface SearchResult {
   path: string;
   heading: string;

--- a/packages/api/src/mcp/tools/annotations.ts
+++ b/packages/api/src/mcp/tools/annotations.ts
@@ -4,6 +4,7 @@ import {
   listAnnotations,
   createAnnotation,
   resolveAnnotation,
+  deleteAnnotation,
   submitReview,
 } from '../http-client.js';
 
@@ -119,6 +120,20 @@ export function registerAnnotationTools(server: Server): void {
             },
             required: ['doc_path']
           }
+        },
+        {
+          name: 'delete_annotation',
+          description: 'Delete an annotation by ID. If the annotation has child replies, all replies are cascade-deleted.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              annotation_id: {
+                type: 'string',
+                description: 'ID of the annotation to delete'
+              }
+            },
+            required: ['annotation_id']
+          }
         }
       ]
     };
@@ -164,6 +179,11 @@ export function registerAnnotationTools(server: Server): void {
           args.annotation_ids as string[] | undefined
         );
         return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case 'delete_annotation': {
+        const result = await deleteAnnotation(args.annotation_id as string);
+        return { content: [{ type: "text", text: JSON.stringify(result) }] };
       }
 
       default:

--- a/packages/api/src/routes/__tests__/annotations.test.ts
+++ b/packages/api/src/routes/__tests__/annotations.test.ts
@@ -5,6 +5,7 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 import { unlinkSync } from 'fs';
 import { createAnnotationsRouter } from '../annotations.js';
+import { createReviewsRouter } from '../reviews.js';
 import { requireAuth } from '../../middleware/auth.js';
 import { getDb, closeDb } from '../../db.js';
 
@@ -26,6 +27,12 @@ beforeAll(() => {
   protectedAnnotationsRouter.use('/annotations', requireAuth);
   protectedAnnotationsRouter.use(createAnnotationsRouter());
   app.use('/api', protectedAnnotationsRouter);
+
+  // Create protected reviews router (needed for orphan review cleanup tests)
+  const protectedReviewsRouter = express.Router();
+  protectedReviewsRouter.use('/reviews', requireAuth);
+  protectedReviewsRouter.use(createReviewsRouter());
+  app.use('/api', protectedReviewsRouter);
 });
 
 afterAll(() => {
@@ -416,6 +423,122 @@ describe('Annotations Router', () => {
         .expect(404);
 
       expect(res.body.error).toContain('not found');
+    });
+  });
+
+  // ─── DELETE /annotations/:id ──────────────────────────────────────
+
+  describe('DELETE /annotations/:id', () => {
+    it('should delete a single annotation and return 204', async () => {
+      const created = await request(app)
+        .post('/api/annotations')
+        .set('Authorization', 'Bearer test-token')
+        .send(validBody({ doc_path: 'delete-test/doc.md', content: 'to be deleted' }))
+        .expect(201);
+
+      await request(app)
+        .delete(`/api/annotations/${created.body.id}`)
+        .set('Authorization', 'Bearer test-token')
+        .expect(204);
+
+      // Verify it's gone
+      const list = await request(app)
+        .get('/api/annotations')
+        .set('Authorization', 'Bearer test-token')
+        .query({ doc_path: 'delete-test/doc.md' })
+        .expect(200);
+
+      const ids = list.body.map((a: any) => a.id);
+      expect(ids).not.toContain(created.body.id);
+    });
+
+    it('should cascade delete child replies', async () => {
+      // Create parent
+      const parent = await request(app)
+        .post('/api/annotations')
+        .set('Authorization', 'Bearer test-token')
+        .send(validBody({ doc_path: 'delete-cascade/doc.md', content: 'parent' }))
+        .expect(201);
+
+      // Create children
+      await request(app)
+        .post('/api/annotations')
+        .set('Authorization', 'Bearer test-token')
+        .send(validBody({ doc_path: 'delete-cascade/doc.md', content: 'child 1', parent_id: parent.body.id }))
+        .expect(201);
+
+      await request(app)
+        .post('/api/annotations')
+        .set('Authorization', 'Bearer test-token')
+        .send(validBody({ doc_path: 'delete-cascade/doc.md', content: 'child 2', parent_id: parent.body.id }))
+        .expect(201);
+
+      // Delete parent
+      await request(app)
+        .delete(`/api/annotations/${parent.body.id}`)
+        .set('Authorization', 'Bearer test-token')
+        .expect(204);
+
+      // Verify all are gone
+      const list = await request(app)
+        .get('/api/annotations')
+        .set('Authorization', 'Bearer test-token')
+        .query({ doc_path: 'delete-cascade/doc.md' })
+        .expect(200);
+
+      expect(list.body).toHaveLength(0);
+    });
+
+    it('should clean up orphaned review when last annotation is deleted', async () => {
+      // Create a review
+      const review = await request(app)
+        .post('/api/reviews')
+        .set('Authorization', 'Bearer test-token')
+        .send({ doc_path: 'delete-review/doc.md' })
+        .expect(201);
+
+      // Create annotation linked to review
+      const ann = await request(app)
+        .post('/api/annotations')
+        .set('Authorization', 'Bearer test-token')
+        .send(validBody({ doc_path: 'delete-review/doc.md', content: 'review comment', review_id: review.body.id }))
+        .expect(201);
+
+      // Patch annotation to set review_id (POST may not set it via body directly)
+      await request(app)
+        .patch(`/api/annotations/${ann.body.id}`)
+        .set('Authorization', 'Bearer test-token')
+        .send({ review_id: review.body.id })
+        .expect(200);
+
+      // Delete the annotation
+      await request(app)
+        .delete(`/api/annotations/${ann.body.id}`)
+        .set('Authorization', 'Bearer test-token')
+        .expect(204);
+
+      // Verify review is also deleted
+      const reviews = await request(app)
+        .get('/api/reviews')
+        .set('Authorization', 'Bearer test-token')
+        .query({ doc_path: 'delete-review/doc.md' })
+        .expect(200);
+
+      const reviewIds = reviews.body.map((r: any) => r.id);
+      expect(reviewIds).not.toContain(review.body.id);
+    });
+
+    it('should return 404 for non-existent annotation', async () => {
+      await request(app)
+        .delete('/api/annotations/nonexistent-id-99999')
+        .set('Authorization', 'Bearer test-token')
+        .expect(404);
+    });
+
+    it('should return 401 without auth token', async () => {
+      await request(app)
+        .delete('/api/annotations/any-id')
+        .expect(401);
     });
   });
 });

--- a/packages/api/src/routes/annotations.ts
+++ b/packages/api/src/routes/annotations.ts
@@ -223,5 +223,46 @@ export function createAnnotationsRouter(): Router {
     }
   });
 
+  // DELETE /annotations/:id - Delete annotation (cascade children + orphan review cleanup)
+  router.delete('/annotations/:id', async (req: Request<{ id: string }>, res: Response) => {
+    try {
+      const { id } = req.params;
+      const db = getDb();
+
+      // Check if annotation exists
+      const existing = db.prepare('SELECT * FROM annotations WHERE id = ?').get(id) as Annotation | undefined;
+
+      if (!existing) {
+        return res.status(404).json({
+          error: 'Annotation not found',
+        } as any);
+      }
+
+      // Cascade delete child replies first (foreign key constraint)
+      db.prepare('DELETE FROM annotations WHERE parent_id = ?').run(id);
+
+      // Delete the annotation itself
+      db.prepare('DELETE FROM annotations WHERE id = ?').run(id);
+
+      // Orphan review cleanup: if annotation had a review_id, check if any annotations remain
+      if (existing.review_id) {
+        const remaining = db.prepare(
+          'SELECT COUNT(*) as count FROM annotations WHERE review_id = ?'
+        ).get(existing.review_id) as { count: number };
+
+        if (remaining.count === 0) {
+          db.prepare('DELETE FROM reviews WHERE id = ?').run(existing.review_id);
+        }
+      }
+
+      res.status(204).send();
+    } catch (error) {
+      console.error('Error deleting annotation:', error);
+      res.status(500).json({
+        error: 'Failed to delete annotation',
+      } as any);
+    }
+  });
+
   return router;
 }


### PR DESCRIPTION
## FND-E9-S1: delete_annotation

### What
- **DELETE /api/annotations/:id** HTTP route with cascade child deletion and orphan review cleanup
- **deleteAnnotation()** in http-client.ts (handles 204 no-body response)
- **delete_annotation** MCP tool registration

### Acceptance Criteria
- ✅ DELETE returns 204 and removes annotation from DB
- ✅ Child replies are cascade-deleted
- ✅ Orphaned reviews cleaned up (last annotation in review → review deleted)
- ✅ Returns 404 for non-existent IDs
- ✅ 7 new tests (5 route + 2 MCP tool)
- ✅ Build passes, all new tests pass

### Notes
- Pre-existing content_hash test failure is unrelated (tech debt item)
- 233 lines added across 5 files