### PR TITLE
feat(api): add get_annotation MCP tool + HTTP route (FND-E9-S4)

### DIFF
--- a/packages/api/src/mcp/__tests__/annotation-tools.test.ts
+++ b/packages/api/src/mcp/__tests__/annotation-tools.test.ts
@@ -4,6 +4,7 @@ import type { Annotation } from '../../types/annotations.js';
 // Mock the http-client module
 vi.mock('../http-client.js', () => ({
   listAnnotations: vi.fn(),
+  getAnnotation: vi.fn(),
   createAnnotation: vi.fn(),
   resolveAnnotation: vi.fn(),
   deleteAnnotation: vi.fn(),
@@ -14,6 +15,7 @@ vi.mock('../http-client.js', () => ({
 
 import {
   listAnnotations,
+  getAnnotation,
   createAnnotation,
   resolveAnnotation,
   deleteAnnotation,
@@ -23,6 +25,7 @@ import {
 } from '../http-client.js';
 
 const mockListAnnotations = vi.mocked(listAnnotations);
+const mockGetAnnotation = vi.mocked(getAnnotation);
 const mockCreateAnnotation = vi.mocked(createAnnotation);
 const mockResolveAnnotation = vi.mocked(resolveAnnotation);
 const mockDeleteAnnotation = vi.mocked(deleteAnnotation);
@@ -84,6 +87,36 @@ describe('listAnnotations', () => {
     expect(results).toHaveLength(1);
     expect(results[0].content).toBe('Resolved annotation');
     expect(mockListAnnotations).toHaveBeenCalledWith('test-doc.md', undefined, 'resolved');
+  });
+});
+
+describe('getAnnotation', () => {
+  it('should get annotation by ID with replies', async () => {
+    const annotation = makeAnnotation({ id: 'parent-1', content: 'Parent comment' });
+    const replies = [
+      makeAnnotation({ id: 'reply-1', parent_id: 'parent-1', content: 'First reply', created_at: '2024-01-01T01:00:00.000Z' }),
+      makeAnnotation({ id: 'reply-2', parent_id: 'parent-1', content: 'Second reply', created_at: '2024-01-01T02:00:00.000Z' }),
+    ];
+    mockGetAnnotation.mockResolvedValue({ annotation, replies });
+
+    const result = await getAnnotation('parent-1');
+
+    expect(result.annotation.id).toBe('parent-1');
+    expect(result.annotation.content).toBe('Parent comment');
+    expect(result.replies).toHaveLength(2);
+    expect(result.replies[0].id).toBe('reply-1');
+    expect(result.replies[1].id).toBe('reply-2');
+    expect(mockGetAnnotation).toHaveBeenCalledWith('parent-1');
+  });
+
+  it('should return empty replies array when no replies exist', async () => {
+    const annotation = makeAnnotation({ id: 'solo-1' });
+    mockGetAnnotation.mockResolvedValue({ annotation, replies: [] });
+
+    const result = await getAnnotation('solo-1');
+
+    expect(result.annotation.id).toBe('solo-1');
+    expect(result.replies).toEqual([]);
   });
 });
 

--- a/packages/api/src/mcp/http-client.ts
+++ b/packages/api/src/mcp/http-client.ts
@@ -43,6 +43,15 @@ export async function listAnnotations(
 }
 
 /**
+ * Get a single annotation by ID, including its reply thread.
+ */
+export async function getAnnotation(
+  annotationId: string,
+): Promise<{ annotation: Annotation; replies: Annotation[] }> {
+  return apiFetch<{ annotation: Annotation; replies: Annotation[] }>(`/api/annotations/${annotationId}`);
+}
+
+/**
  * Create an annotation via HTTP API.
  */
 export async function createAnnotation(params: {

--- a/packages/api/src/mcp/tools/annotations.ts
+++ b/packages/api/src/mcp/tools/annotations.ts
@@ -2,6 +2,7 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import {
   listAnnotations,
+  getAnnotation,
   createAnnotation,
   resolveAnnotation,
   deleteAnnotation,
@@ -44,6 +45,20 @@ export function registerAnnotationTools(server: Server): void {
               }
             },
             required: ['doc_path']
+          }
+        },
+        {
+          name: 'get_annotation',
+          description: 'Get a single annotation by ID, including its reply thread.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              annotation_id: {
+                type: 'string',
+                description: 'ID of the annotation to retrieve'
+              }
+            },
+            required: ['annotation_id']
           }
         },
         {
@@ -188,6 +203,11 @@ export function registerAnnotationTools(server: Server): void {
           args.section as string | undefined,
           args.status as string | undefined
         );
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case 'get_annotation': {
+        const result = await getAnnotation(args.annotation_id as string);
         return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
       }
 

--- a/packages/api/src/routes/__tests__/annotations.test.ts
+++ b/packages/api/src/routes/__tests__/annotations.test.ts
@@ -331,6 +331,87 @@ describe('Annotations Router', () => {
     });
   });
 
+  // ─── GET /annotations/:id ─────────────────────────────────────────
+
+  describe('GET /annotations/:id', () => {
+    let parentId: string;
+    let replyId1: string;
+    let replyId2: string;
+
+    beforeAll(async () => {
+      // Create a parent annotation
+      const parentRes = await request(app)
+        .post('/api/annotations')
+        .set('Authorization', 'Bearer test-token')
+        .send(validBody({ doc_path: 'getbyid-test/doc.md', content: 'parent annotation' }))
+        .expect(201);
+      parentId = parentRes.body.id;
+
+      // Create replies with slight delay to ensure different created_at
+      const reply1Res = await request(app)
+        .post('/api/annotations')
+        .set('Authorization', 'Bearer test-token')
+        .send(validBody({ doc_path: 'getbyid-test/doc.md', content: 'first reply', parent_id: parentId }))
+        .expect(201);
+      replyId1 = reply1Res.body.id;
+
+      await new Promise((r) => setTimeout(r, 10));
+
+      const reply2Res = await request(app)
+        .post('/api/annotations')
+        .set('Authorization', 'Bearer test-token')
+        .send(validBody({ doc_path: 'getbyid-test/doc.md', content: 'second reply', parent_id: parentId }))
+        .expect(201);
+      replyId2 = reply2Res.body.id;
+    });
+
+    it('should return annotation by ID with empty replies array', async () => {
+      // Get a reply (which has no children)
+      const res = await request(app)
+        .get(`/api/annotations/${replyId1}`)
+        .set('Authorization', 'Bearer test-token')
+        .expect(200);
+
+      expect(res.body.annotation).toBeDefined();
+      expect(res.body.annotation.id).toBe(replyId1);
+      expect(res.body.annotation.content).toBe('first reply');
+      expect(res.body.replies).toEqual([]);
+    });
+
+    it('should return annotation with replies sorted by created_at ASC', async () => {
+      const res = await request(app)
+        .get(`/api/annotations/${parentId}`)
+        .set('Authorization', 'Bearer test-token')
+        .expect(200);
+
+      expect(res.body.annotation).toBeDefined();
+      expect(res.body.annotation.id).toBe(parentId);
+      expect(res.body.annotation.content).toBe('parent annotation');
+      expect(res.body.replies).toHaveLength(2);
+      expect(res.body.replies[0].id).toBe(replyId1);
+      expect(res.body.replies[1].id).toBe(replyId2);
+      // Verify chronological order
+      expect(res.body.replies[0].created_at <= res.body.replies[1].created_at).toBe(true);
+    });
+
+    it('should return 404 for non-existent annotation ID', async () => {
+      const res = await request(app)
+        .get('/api/annotations/nonexistent-id-99999')
+        .set('Authorization', 'Bearer test-token')
+        .expect(404);
+
+      expect(res.body.error).toBe('Annotation not found');
+    });
+
+    it('should return 401 without auth token', async () => {
+      const res = await request(app)
+        .get(`/api/annotations/${parentId}`)
+        .expect(401);
+
+      expect(res.body.error).toBe('Unauthorized');
+    });
+  });
+
   // ─── PATCH /annotations/:id ────────────────────────────────────────
 
   describe('PATCH /annotations/:id', () => {

--- a/packages/api/src/routes/annotations.ts
+++ b/packages/api/src/routes/annotations.ts
@@ -60,6 +60,29 @@ export function createAnnotationsRouter(): Router {
     }
   });
 
+  // GET /annotations/:id - Get single annotation with reply thread
+  router.get('/annotations/:id', async (req: Request<{ id: string }>, res: Response) => {
+    try {
+      const { id } = req.params;
+      const db = getDb();
+
+      const annotation = db.prepare('SELECT * FROM annotations WHERE id = ?').get(id) as Annotation | undefined;
+
+      if (!annotation) {
+        return res.status(404).json({ error: 'Annotation not found' });
+      }
+
+      const replies = db.prepare(
+        'SELECT * FROM annotations WHERE parent_id = ? ORDER BY created_at ASC'
+      ).all(id) as Annotation[];
+
+      res.json({ annotation, replies });
+    } catch (error) {
+      console.error('Error getting annotation:', error);
+      res.status(500).json({ error: 'Failed to get annotation' });
+    }
+  });
+
   // POST /annotations - Create new annotation
   router.post('/annotations', async (req: Request<{}, Annotation, CreateAnnotationBody>, res: Response<Annotation>) => {
     try {


### PR DESCRIPTION
## FND-E9-S4: get_annotation

### What
- **GET /api/annotations/:id** HTTP route returning annotation + reply thread
- **getAnnotation()** in http-client.ts
- **get_annotation** MCP tool registration

### Acceptance Criteria
- ✅ GET returns annotation + replies array
- ✅ Replies sorted by created_at ASC (chronological thread order)
- ✅ Returns 404 for non-existent IDs
- ✅ 6 new tests (4 route + 2 MCP tool)
- ✅ Build passes, all new tests pass

### Notes
- Route registered after list route to avoid path conflicts
- Pre-existing content_hash test failure is unrelated