### PR TITLE
feat(api): add review_id filter to list_annotations (FND-E9-S7)

### DIFF
--- a/packages/api/src/mcp/__tests__/annotation-tools.test.ts
+++ b/packages/api/src/mcp/__tests__/annotation-tools.test.ts
@@ -88,6 +88,17 @@ describe('listAnnotations', () => {
     expect(results[0].content).toBe('Resolved annotation');
     expect(mockListAnnotations).toHaveBeenCalledWith('test-doc.md', undefined, 'resolved');
   });
+
+  it('should filter by review_id', async () => {
+    mockListAnnotations.mockResolvedValue([
+      makeAnnotation({ review_id: 'review-1', content: 'Review annotation' }),
+    ]);
+
+    const results = await listAnnotations('test-doc.md', undefined, undefined, 'review-1');
+    expect(results).toHaveLength(1);
+    expect(results[0].review_id).toBe('review-1');
+    expect(mockListAnnotations).toHaveBeenCalledWith('test-doc.md', undefined, undefined, 'review-1');
+  });
 });
 
 describe('getAnnotation', () => {

--- a/packages/api/src/mcp/http-client.ts
+++ b/packages/api/src/mcp/http-client.ts
@@ -35,10 +35,12 @@ export async function listAnnotations(
   docPath: string,
   section?: string,
   status?: string,
+  reviewId?: string,
 ): Promise<Annotation[]> {
   const params = new URLSearchParams({ doc_path: docPath });
   if (section) params.set('section', section);
   if (status) params.set('status', status);
+  if (reviewId) params.set('review_id', reviewId);
   return apiFetch<Annotation[]>(`/api/annotations?${params}`);
 }
 

--- a/packages/api/src/mcp/tools/annotations.ts
+++ b/packages/api/src/mcp/tools/annotations.ts
@@ -39,6 +39,10 @@ export function registerAnnotationTools(server: Server): void {
                 type: 'string',
                 description: 'Optional status filter (draft, submitted, replied, resolved, orphaned)'
               },
+              review_id: {
+                type: 'string',
+                description: 'Optional review ID to filter annotations by review'
+              },
               auth_token: {
                 type: 'string',
                 description: 'Authentication token (kept for backward compatibility)'
@@ -201,7 +205,8 @@ export function registerAnnotationTools(server: Server): void {
         const result = await listAnnotations(
           args.doc_path as string,
           args.section as string | undefined,
-          args.status as string | undefined
+          args.status as string | undefined,
+          args.review_id as string | undefined
         );
         return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
       }

--- a/packages/api/src/routes/__tests__/annotations.test.ts
+++ b/packages/api/src/routes/__tests__/annotations.test.ts
@@ -331,6 +331,73 @@ describe('Annotations Router', () => {
     });
   });
 
+  // ─── GET /annotations?review_id= ─────────────────────────────────
+
+  describe('GET /annotations filtered by review_id', () => {
+    let reviewId: string;
+
+    beforeAll(async () => {
+      // Create a review
+      const review = await request(app)
+        .post('/api/reviews')
+        .set('Authorization', 'Bearer test-token')
+        .send({ doc_path: 'review-filter/doc.md' })
+        .expect(201);
+      reviewId = review.body.id;
+
+      // Create annotations with and without review_id
+      await request(app)
+        .post('/api/annotations')
+        .set('Authorization', 'Bearer test-token')
+        .send(validBody({ doc_path: 'review-filter/doc.md', content: 'with review', review_id: reviewId }))
+        .expect(201);
+
+      const noReview = await request(app)
+        .post('/api/annotations')
+        .set('Authorization', 'Bearer test-token')
+        .send(validBody({ doc_path: 'review-filter/doc.md', content: 'no review' }))
+        .expect(201);
+
+      // Also create a submitted annotation with review_id for combined filter test
+      const submitted = await request(app)
+        .post('/api/annotations')
+        .set('Authorization', 'Bearer test-token')
+        .send(validBody({ doc_path: 'review-filter/doc.md', content: 'submitted with review', review_id: reviewId }))
+        .expect(201);
+
+      await request(app)
+        .patch(`/api/annotations/${submitted.body.id}`)
+        .set('Authorization', 'Bearer test-token')
+        .send({ status: 'submitted' })
+        .expect(200);
+    });
+
+    it('should filter annotations by review_id', async () => {
+      const res = await request(app)
+        .get('/api/annotations')
+        .set('Authorization', 'Bearer test-token')
+        .query({ doc_path: 'review-filter/doc.md', review_id: reviewId })
+        .expect(200);
+
+      expect(res.body.length).toBe(2);
+      for (const ann of res.body) {
+        expect(ann.review_id).toBe(reviewId);
+      }
+    });
+
+    it('should combine review_id and status filters', async () => {
+      const res = await request(app)
+        .get('/api/annotations')
+        .set('Authorization', 'Bearer test-token')
+        .query({ doc_path: 'review-filter/doc.md', review_id: reviewId, status: 'submitted' })
+        .expect(200);
+
+      expect(res.body.length).toBe(1);
+      expect(res.body[0].review_id).toBe(reviewId);
+      expect(res.body[0].status).toBe('submitted');
+    });
+  });
+
   // ─── GET /annotations/:id ─────────────────────────────────────────
 
   describe('GET /annotations/:id', () => {

--- a/packages/api/src/routes/annotations.ts
+++ b/packages/api/src/routes/annotations.ts
@@ -12,6 +12,7 @@ interface AnnotationListQuery {
   doc_path: string;
   section?: string;
   status?: AnnotationStatus;
+  review_id?: string;
 }
 
 /**
@@ -23,7 +24,7 @@ export function createAnnotationsRouter(): Router {
   // GET /annotations - List annotations with filters
   router.get('/annotations', async (req: Request<{}, Annotation[], {}, AnnotationListQuery>, res: Response<Annotation[]>) => {
     try {
-      const { doc_path, section, status } = req.query;
+      const { doc_path, section, status, review_id } = req.query;
 
       if (!doc_path) {
         return res.status(400).json({
@@ -44,6 +45,11 @@ export function createAnnotationsRouter(): Router {
       if (status) {
         query += ' AND status = ?';
         params.push(status);
+      }
+
+      if (review_id) {
+        query += ' AND review_id = ?';
+        params.push(review_id);
       }
 
       query += ' ORDER BY created_at DESC';


### PR DESCRIPTION
## FND-E9-S7: list_annotations review_id filter

Adds optional review_id parameter to list_annotations across all layers:
- HTTP route query param
- http-client.ts function signature
- MCP tool input schema

Small, surgical change — 5 files touched. Tests cover filter-by-review_id and combined filters.