### PR TITLE
feat(api): add list_reviews + get_review MCP tools + HTTP route (FND-E9-S5)

### DIFF
--- a/packages/api/src/mcp/__tests__/review-tools.test.ts
+++ b/packages/api/src/mcp/__tests__/review-tools.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { Annotation, Review } from '../../types/annotations.js';
+
+// Mock the http-client module
+vi.mock('../http-client.js', () => ({
+  listReviews: vi.fn(),
+  getReview: vi.fn(),
+}));
+
+import { listReviews, getReview } from '../http-client.js';
+
+const mockListReviews = vi.mocked(listReviews);
+const mockGetReview = vi.mocked(getReview);
+
+function makeReview(overrides: Partial<Review> = {}): Review {
+  return {
+    id: 'review-1',
+    doc_path: 'test-doc.md',
+    user_id: 'dan',
+    status: 'draft',
+    submitted_at: null,
+    completed_at: null,
+    created_at: '2024-01-01T00:00:00.000Z',
+    updated_at: '2024-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function makeAnnotation(overrides: Partial<Annotation> = {}): Annotation {
+  return {
+    id: 'test-id-1',
+    doc_path: 'test-doc.md',
+    heading_path: 'intro',
+    content_hash: '',
+    quoted_text: null,
+    content: 'Test annotation',
+    parent_id: null,
+    review_id: 'review-1',
+    user_id: 'dan',
+    author_type: 'human',
+    status: 'submitted',
+    created_at: '2024-01-01T00:00:00.000Z',
+    updated_at: '2024-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('listReviews', () => {
+  it('should list reviews for a doc_path', async () => {
+    const reviews = [makeReview()];
+    mockListReviews.mockResolvedValue(reviews);
+
+    const results = await listReviews('test-doc.md');
+    expect(results).toHaveLength(1);
+    expect(results[0].id).toBe('review-1');
+    expect(results[0].doc_path).toBe('test-doc.md');
+    expect(mockListReviews).toHaveBeenCalledWith('test-doc.md');
+  });
+
+  it('should filter by status', async () => {
+    mockListReviews.mockResolvedValue([
+      makeReview({ status: 'submitted' }),
+    ]);
+
+    const results = await listReviews('test-doc.md', 'submitted');
+    expect(results).toHaveLength(1);
+    expect(results[0].status).toBe('submitted');
+    expect(mockListReviews).toHaveBeenCalledWith('test-doc.md', 'submitted');
+  });
+
+  it('should return empty array when no reviews exist', async () => {
+    mockListReviews.mockResolvedValue([]);
+
+    const results = await listReviews('empty-doc.md');
+    expect(results).toEqual([]);
+  });
+});
+
+describe('getReview', () => {
+  it('should get review by ID with annotations', async () => {
+    const review = makeReview({ id: 'review-1' });
+    const annotations = [
+      makeAnnotation({ id: 'ann-1', content: 'First comment', created_at: '2024-01-01T01:00:00.000Z' }),
+      makeAnnotation({ id: 'ann-2', content: 'Second comment', created_at: '2024-01-01T02:00:00.000Z' }),
+    ];
+    mockGetReview.mockResolvedValue({ review, annotations });
+
+    const result = await getReview('review-1');
+
+    expect(result.review.id).toBe('review-1');
+    expect(result.review.doc_path).toBe('test-doc.md');
+    expect(result.annotations).toHaveLength(2);
+    expect(result.annotations[0].id).toBe('ann-1');
+    expect(result.annotations[1].id).toBe('ann-2');
+    expect(mockGetReview).toHaveBeenCalledWith('review-1');
+  });
+
+  it('should return empty annotations array when no annotations exist', async () => {
+    const review = makeReview({ id: 'review-2' });
+    mockGetReview.mockResolvedValue({ review, annotations: [] });
+
+    const result = await getReview('review-2');
+
+    expect(result.review.id).toBe('review-2');
+    expect(result.annotations).toEqual([]);
+  });
+});

--- a/packages/api/src/mcp/http-client.ts
+++ b/packages/api/src/mcp/http-client.ts
@@ -1,4 +1,4 @@
-import type { Annotation } from '../types/annotations.js';
+import type { Annotation, Review } from '../types/annotations.js';
 
 const BASE_URL = process.env.FOUNDRY_API_URL || 'http://localhost:3001';
 const WRITE_TOKEN = () => process.env.FOUNDRY_WRITE_TOKEN || '';
@@ -221,6 +221,27 @@ export async function reopenAnnotation(
     }
     throw err;
   }
+}
+
+/**
+ * List reviews for a document, optionally filtered by status.
+ */
+export async function listReviews(
+  docPath: string,
+  status?: string,
+): Promise<Review[]> {
+  const params = new URLSearchParams({ doc_path: docPath });
+  if (status) params.set('status', status);
+  return apiFetch<Review[]>(`/api/reviews?${params}`);
+}
+
+/**
+ * Get a single review by ID, including its annotations.
+ */
+export async function getReview(
+  reviewId: string,
+): Promise<{ review: Review; annotations: Annotation[] }> {
+  return apiFetch<{ review: Review; annotations: Annotation[] }>(`/api/reviews/${reviewId}`);
 }
 
 interface SearchResult {

--- a/packages/api/src/mcp/server.ts
+++ b/packages/api/src/mcp/server.ts
@@ -1,6 +1,7 @@
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { registerSearchTool } from './tools/search.js';
 import { registerAnnotationTools } from './tools/annotations.js';
+import { registerReviewTools } from './tools/review-tools.js';
 
 /**
  * Creates and configures the MCP server for Foundry.
@@ -28,6 +29,9 @@ export function createMcpServer(): Server {
 
   // Register annotation tools
   registerAnnotationTools(server);
+
+  // Register review tools
+  registerReviewTools(server);
 
   return server;
 }

--- a/packages/api/src/mcp/tools/review-tools.ts
+++ b/packages/api/src/mcp/tools/review-tools.ts
@@ -1,0 +1,80 @@
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import {
+  ListToolsRequestSchema,
+  CallToolRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+import { listReviews, getReview } from '../http-client.js';
+
+/**
+ * Register review tools with the MCP server.
+ * All data access goes through the HTTP API via http-client.
+ */
+export function registerReviewTools(server: Server): void {
+
+  // Handle list tools request
+  server.setRequestHandler(ListToolsRequestSchema, async () => {
+    return {
+      tools: [
+        {
+          name: 'list_reviews',
+          description: 'List reviews for a document, optionally filtered by status',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              doc_path: {
+                type: 'string',
+                description: 'Path to the document'
+              },
+              status: {
+                type: 'string',
+                description: 'Optional status filter (draft, submitted, complete)'
+              }
+            },
+            required: ['doc_path']
+          }
+        },
+        {
+          name: 'get_review',
+          description: 'Get a single review by ID, including its annotations.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              review_id: {
+                type: 'string',
+                description: 'ID of the review to retrieve'
+              }
+            },
+            required: ['review_id']
+          }
+        }
+      ]
+    };
+  });
+
+  // Handle tool calls
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const { name, arguments: args } = request.params;
+
+    if (!args) {
+      throw new Error('Tool arguments are required');
+    }
+
+    switch (name) {
+      case 'list_reviews': {
+        const result = await listReviews(
+          args.doc_path as string,
+          args.status as string | undefined,
+        );
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      case 'get_review': {
+        const result = await getReview(args.review_id as string);
+        return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+      }
+
+      default:
+        throw new Error(`Unknown tool: ${name}`);
+    }
+  });
+}

--- a/packages/api/src/routes/__tests__/reviews.test.ts
+++ b/packages/api/src/routes/__tests__/reviews.test.ts
@@ -238,5 +238,107 @@ describe('Reviews Router', () => {
       expect(res.body.length).toBe(1);
       expect(res.body[0].doc_path).toBe('get-test/other.md');
     });
+
+    it('should filter reviews by status', async () => {
+      // Create a review and update its status to submitted
+      const created = await request(app)
+        .post('/api/reviews')
+        .set("Authorization", "Bearer test-token")
+        .send({ doc_path: 'status-test/doc.md' })
+        .expect(201);
+
+      await request(app)
+        .patch(`/api/reviews/${created.body.id}`)
+        .set("Authorization", "Bearer test-token")
+        .send({ status: 'submitted', submitted_at: new Date().toISOString() })
+        .expect(200);
+
+      // Also create a draft review for the same doc
+      await request(app)
+        .post('/api/reviews')
+        .set("Authorization", "Bearer test-token")
+        .send({ doc_path: 'status-test/doc.md' })
+        .expect(201);
+
+      // Filter by submitted status
+      const res = await request(app)
+        .get('/api/reviews')
+        .set("Authorization", "Bearer test-token")
+        .query({ doc_path: 'status-test/doc.md', status: 'submitted' })
+        .expect(200);
+
+      expect(res.body.length).toBe(1);
+      expect(res.body[0].status).toBe('submitted');
+    });
+  });
+
+  // ─── GET /reviews/:id ───────────────────────────────────────────────
+
+  describe('GET /reviews/:id', () => {
+    it('should return 401 without auth', async () => {
+      await request(app)
+        .get('/api/reviews/some-id')
+        .expect(401);
+    });
+
+    it('should return 404 for non-existent review', async () => {
+      const res = await request(app)
+        .get('/api/reviews/non-existent-id')
+        .set("Authorization", "Bearer test-token")
+        .expect(404);
+
+      expect(res.body.error).toBe('Review not found');
+    });
+
+    it('should return review with empty annotations array', async () => {
+      // Create a review
+      const created = await request(app)
+        .post('/api/reviews')
+        .set("Authorization", "Bearer test-token")
+        .send({ doc_path: 'getbyid-test/doc.md' })
+        .expect(201);
+
+      const res = await request(app)
+        .get(`/api/reviews/${created.body.id}`)
+        .set("Authorization", "Bearer test-token")
+        .expect(200);
+
+      expect(res.body.review.id).toBe(created.body.id);
+      expect(res.body.review.doc_path).toBe('getbyid-test/doc.md');
+      expect(res.body.annotations).toEqual([]);
+    });
+
+    it('should return review with its annotations', async () => {
+      // Create a review
+      const created = await request(app)
+        .post('/api/reviews')
+        .set("Authorization", "Bearer test-token")
+        .send({ doc_path: 'getbyid-ann/doc.md' })
+        .expect(201);
+
+      const reviewId = created.body.id;
+
+      // Insert annotations directly into the DB
+      const db = getDb();
+      const now = new Date().toISOString();
+      const insertStmt = db.prepare(`
+        INSERT INTO annotations (id, doc_path, heading_path, content_hash, quoted_text, content, parent_id, review_id, user_id, author_type, status, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `);
+
+      insertStmt.run('ann-1', 'getbyid-ann/doc.md', 'intro', '', null, 'First comment', null, reviewId, 'dan', 'human', 'submitted', now, now);
+      insertStmt.run('ann-2', 'getbyid-ann/doc.md', 'conclusion', '', null, 'Second comment', null, reviewId, 'dan', 'human', 'submitted', now, now);
+
+      const res = await request(app)
+        .get(`/api/reviews/${reviewId}`)
+        .set("Authorization", "Bearer test-token")
+        .expect(200);
+
+      expect(res.body.review.id).toBe(reviewId);
+      expect(res.body.annotations).toHaveLength(2);
+      expect(res.body.annotations[0].id).toBe('ann-1');
+      expect(res.body.annotations[1].id).toBe('ann-2');
+      expect(res.body.annotations[0].review_id).toBe(reviewId);
+    });
   });
 });

--- a/packages/api/src/routes/reviews.ts
+++ b/packages/api/src/routes/reviews.ts
@@ -2,12 +2,14 @@ import { Router, Request, Response } from 'express';
 import { createId } from '@paralleldrive/cuid2';
 import { getDb } from '../db.js';
 import {
+  Annotation,
   Review,
   CreateReviewBody
 } from '../types/annotations.js';
 
 interface ReviewListQuery {
   doc_path: string;
+  status?: string;
 }
 
 /**
@@ -19,7 +21,7 @@ export function createReviewsRouter(): Router {
   // GET /reviews - List reviews for a document
   router.get('/reviews', async (req: Request<{}, Review[], {}, ReviewListQuery>, res: Response<Review[]>) => {
     try {
-      const { doc_path } = req.query;
+      const { doc_path, status } = req.query;
 
       if (!doc_path) {
         return res.status(400).json({
@@ -29,8 +31,18 @@ export function createReviewsRouter(): Router {
 
       const db = getDb();
 
-      const stmt = db.prepare('SELECT * FROM reviews WHERE doc_path = ? ORDER BY created_at DESC');
-      const rows = stmt.all(doc_path) as Review[];
+      let query = 'SELECT * FROM reviews WHERE doc_path = ?';
+      const params: any[] = [doc_path];
+
+      if (status) {
+        query += ' AND status = ?';
+        params.push(status);
+      }
+
+      query += ' ORDER BY created_at DESC';
+
+      const stmt = db.prepare(query);
+      const rows = stmt.all(...params) as Review[];
 
       res.json(rows);
     } catch (error) {
@@ -38,6 +50,29 @@ export function createReviewsRouter(): Router {
       res.status(500).json({
         error: 'Failed to list reviews',
       } as any);
+    }
+  });
+
+  // GET /reviews/:id - Get single review with its annotations
+  router.get('/reviews/:id', async (req: Request<{ id: string }>, res: Response) => {
+    try {
+      const { id } = req.params;
+      const db = getDb();
+
+      const review = db.prepare('SELECT * FROM reviews WHERE id = ?').get(id) as Review | undefined;
+
+      if (!review) {
+        return res.status(404).json({ error: 'Review not found' });
+      }
+
+      const annotations = db.prepare(
+        'SELECT * FROM annotations WHERE review_id = ? ORDER BY created_at ASC'
+      ).all(id) as Annotation[];
+
+      res.json({ review, annotations });
+    } catch (error) {
+      console.error('Error getting review:', error);
+      res.status(500).json({ error: 'Failed to get review' });
     }
   });
 


### PR DESCRIPTION
## FND-E9-S5: list_reviews + get_review

### What
- **GET /api/reviews/:id** — new route returning review + associated annotations
- **list_reviews** + **get_review** MCP tools in new review-tools.ts
- **listReviews()** + **getReview()** in http-client.ts
- Status filter added to existing list reviews route
- Registered in MCP server

### Tests
- 5 route tests (auth, 404, empty, with annotations, status filter)
- 5 MCP tool tests (list with/without status, empty, get with/without annotations)