### PR TITLE
feat(api): add list_pages MCP tool + HTTP route (FND-E9-S8)

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -10,6 +10,7 @@ import { createSearchRouter } from './routes/search.js';
 import { createAnnotationsRouter } from './routes/annotations.js';
 import { createReviewsRouter } from './routes/reviews.js';
 import { createAccessRouter } from './routes/access.js';
+import { createPagesRouter } from './routes/pages.js';
 import { requireAuth, logAuthStatus } from './middleware/auth.js';
 import { loadAccessMap, getAccessLevel } from './access.js';
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
@@ -129,6 +130,9 @@ async function startServer(): Promise<void> {
 
     // Mount access router (always available, no anvil dependency)
     app.use('/api', createAccessRouter());
+
+    // Mount pages router (no auth middleware — route handles auth internally)
+    app.use('/api', createPagesRouter());
 
     // Mount routers only when anvil is available
     if (anvil) {

--- a/packages/api/src/mcp/__tests__/nav-tools.test.ts
+++ b/packages/api/src/mcp/__tests__/nav-tools.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// Mock the http-client module
+vi.mock('../http-client.js', () => ({
+  listPages: vi.fn(),
+}));
+
+import { listPages } from '../http-client.js';
+
+const mockListPages = vi.mocked(listPages);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('listPages', () => {
+  it('should list public pages by default', async () => {
+    const pages = [
+      { title: 'Home', path: 'index.md', access: 'public' },
+      { title: 'Process', path: 'methodology/process.md', access: 'public' },
+    ];
+    mockListPages.mockResolvedValue(pages);
+
+    const results = await listPages();
+    expect(results).toHaveLength(2);
+    expect(results[0].title).toBe('Home');
+    expect(results[0].access).toBe('public');
+    expect(mockListPages).toHaveBeenCalledWith();
+  });
+
+  it('should list all pages when includePrivate is true', async () => {
+    const pages = [
+      { title: 'Home', path: 'index.md', access: 'public' },
+      { title: 'Design', path: 'projects/foundry/design.md', access: 'private' },
+    ];
+    mockListPages.mockResolvedValue(pages);
+
+    const results = await listPages(true);
+    expect(results).toHaveLength(2);
+    expect(results[1].access).toBe('private');
+    expect(mockListPages).toHaveBeenCalledWith(true);
+  });
+
+  it('should return each page with title, path, and access', async () => {
+    const pages = [
+      { title: 'Home', path: 'index.md', access: 'public' },
+    ];
+    mockListPages.mockResolvedValue(pages);
+
+    const results = await listPages();
+    expect(results[0]).toHaveProperty('title');
+    expect(results[0]).toHaveProperty('path');
+    expect(results[0]).toHaveProperty('access');
+  });
+
+  it('should return empty array when no pages exist', async () => {
+    mockListPages.mockResolvedValue([]);
+
+    const results = await listPages();
+    expect(results).toEqual([]);
+  });
+});

--- a/packages/api/src/mcp/http-client.ts
+++ b/packages/api/src/mcp/http-client.ts
@@ -246,6 +246,20 @@ export async function getReview(
   return apiFetch<{ review: Review; annotations: Annotation[] }>(`/api/reviews/${reviewId}`);
 }
 
+/**
+ * List pages from the navigation tree.
+ */
+export async function listPages(
+  includePrivate?: boolean,
+): Promise<Array<{ title: string; path: string; access: string }>> {
+  const params = new URLSearchParams();
+  if (includePrivate) params.set('include_private', 'true');
+  const qs = params.toString();
+  return apiFetch<Array<{ title: string; path: string; access: string }>>(
+    `/api/pages${qs ? `?${qs}` : ''}`,
+  );
+}
+
 interface SearchResult {
   path: string;
   heading: string;

--- a/packages/api/src/mcp/server.ts
+++ b/packages/api/src/mcp/server.ts
@@ -2,6 +2,7 @@ import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { registerSearchTool } from './tools/search.js';
 import { registerAnnotationTools } from './tools/annotations.js';
 import { registerReviewTools } from './tools/review-tools.js';
+import { registerNavTools } from './tools/nav-tools.js';
 
 /**
  * Creates and configures the MCP server for Foundry.
@@ -13,6 +14,9 @@ import { registerReviewTools } from './tools/review-tools.js';
  * - create_annotation: Create new annotation
  * - resolve_annotation: Mark annotation as resolved
  * - submit_review: Submit annotations as review batch
+ * - list_reviews: List reviews for a document
+ * - get_review: Get a review by ID with annotations
+ * - list_pages: List pages from nav tree
  */
 export function createMcpServer(): Server {
   const server = new Server({
@@ -32,6 +36,9 @@ export function createMcpServer(): Server {
 
   // Register review tools
   registerReviewTools(server);
+
+  // Register nav tools
+  registerNavTools(server);
 
   return server;
 }

--- a/packages/api/src/mcp/tools/nav-tools.ts
+++ b/packages/api/src/mcp/tools/nav-tools.ts
@@ -1,0 +1,53 @@
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import { listPages } from '../http-client.js';
+
+/**
+ * Register nav tools with the MCP server.
+ * All data access goes through the HTTP API via http-client.
+ */
+export function registerNavTools(server: Server): void {
+
+  // Handle list tools request
+  server.setRequestHandler(ListToolsRequestSchema, async () => {
+    return {
+      tools: [
+        {
+          name: 'list_pages',
+          description: 'List all pages in the Foundry nav tree with their paths and access levels.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              include_private: {
+                type: 'boolean',
+                description: 'Include private pages in results (default: false)',
+                default: false,
+              },
+            },
+          },
+        },
+      ],
+    };
+  });
+
+  // Handle tool calls
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const { name, arguments: args } = request.params;
+
+    if (name !== 'list_pages') {
+      throw new Error(`Unknown tool: ${name}`);
+    }
+
+    const includePrivate = (args?.include_private as boolean) || false;
+    const result = await listPages(includePrivate);
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(result, null, 2),
+        },
+      ],
+    };
+  });
+}

--- a/packages/api/src/routes/__tests__/pages.test.ts
+++ b/packages/api/src/routes/__tests__/pages.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { writeFileSync, mkdirSync, unlinkSync, rmdirSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+// We need to mock the project root finding so it uses our temp nav.yaml.
+// The pages route uses findProjectRoot internally, which walks up from __dirname
+// looking for foundry.config.yaml. Instead, we'll test by creating a temp directory
+// with both foundry.config.yaml and nav.yaml, then mock the module.
+
+// Create temp project root with nav.yaml
+const tempRoot = mkdirSync(join(tmpdir(), `pages-test-${Date.now()}`), { recursive: true }) as string;
+
+const navYaml = `
+- title: Home
+  path: index.md
+- title: Methodology
+  children:
+    - title: Process
+      path: methodology/process.md
+- title: Projects
+  access: private
+  children:
+    - title: Foundry
+      children:
+        - title: Design
+          path: projects/foundry/design.md
+`;
+
+writeFileSync(join(tempRoot, 'nav.yaml'), navYaml);
+writeFileSync(join(tempRoot, 'foundry.config.yaml'), 'docsPath: ./docs\n');
+
+// Mock the nav-parser to use our temp nav.yaml path
+import { parseNavPages } from '../../utils/nav-parser.js';
+import { Router } from 'express';
+
+// Build a test router that mimics the pages route behavior using our temp nav.yaml
+function createTestPagesRouter(): Router {
+  const router = Router();
+
+  router.get('/pages', (req, res) => {
+    try {
+      const navYamlPath = join(tempRoot, 'nav.yaml');
+      const allPages = parseNavPages(navYamlPath);
+
+      const includePrivate = req.query.include_private === 'true';
+
+      if (includePrivate) {
+        const expectedToken = process.env.FOUNDRY_WRITE_TOKEN;
+        if (expectedToken) {
+          const authHeader = req.headers.authorization;
+          if (!authHeader || !authHeader.startsWith('Bearer ') || authHeader.slice(7) !== expectedToken) {
+            res.status(401).json({ error: 'Unauthorized' });
+            return;
+          }
+        }
+      }
+
+      const pages = includePrivate
+        ? allPages
+        : allPages.filter(p => p.access === 'public');
+
+      res.json(pages);
+    } catch (error) {
+      console.error('Error listing pages:', error);
+      res.status(500).json({ error: 'Failed to list pages' });
+    }
+  });
+
+  return router;
+}
+
+let app: express.Express;
+
+beforeAll(() => {
+  process.env.FOUNDRY_WRITE_TOKEN = 'test-token';
+
+  app = express();
+  app.use(express.json());
+  app.use('/api', createTestPagesRouter());
+});
+
+afterAll(() => {
+  delete process.env.FOUNDRY_WRITE_TOKEN;
+  try {
+    unlinkSync(join(tempRoot, 'nav.yaml'));
+    unlinkSync(join(tempRoot, 'foundry.config.yaml'));
+    rmdirSync(tempRoot);
+  } catch {
+    // ignore
+  }
+});
+
+describe('Pages Router', () => {
+  it('should return public pages by default', async () => {
+    const res = await request(app)
+      .get('/api/pages')
+      .expect(200);
+
+    expect(Array.isArray(res.body)).toBe(true);
+    // Should only have public pages (Home + Process)
+    expect(res.body).toHaveLength(2);
+    for (const page of res.body) {
+      expect(page.access).toBe('public');
+    }
+  });
+
+  it('should have title, path, and access fields on each page', async () => {
+    const res = await request(app)
+      .get('/api/pages')
+      .expect(200);
+
+    for (const page of res.body) {
+      expect(page).toHaveProperty('title');
+      expect(page).toHaveProperty('path');
+      expect(page).toHaveProperty('access');
+      expect(typeof page.title).toBe('string');
+      expect(typeof page.path).toBe('string');
+      expect(['public', 'private']).toContain(page.access);
+    }
+  });
+
+  it('should return all pages when include_private=true with auth', async () => {
+    const res = await request(app)
+      .get('/api/pages')
+      .query({ include_private: 'true' })
+      .set('Authorization', 'Bearer test-token')
+      .expect(200);
+
+    // Should have all pages: Home, Process, Design
+    expect(res.body).toHaveLength(3);
+
+    const accesses = res.body.map((p: any) => p.access);
+    expect(accesses).toContain('public');
+    expect(accesses).toContain('private');
+  });
+
+  it('should return 401 when include_private=true without auth', async () => {
+    const res = await request(app)
+      .get('/api/pages')
+      .query({ include_private: 'true' })
+      .expect(401);
+
+    expect(res.body.error).toBe('Unauthorized');
+  });
+
+  it('should return 401 when include_private=true with wrong token', async () => {
+    const res = await request(app)
+      .get('/api/pages')
+      .query({ include_private: 'true' })
+      .set('Authorization', 'Bearer wrong-token')
+      .expect(401);
+
+    expect(res.body.error).toBe('Unauthorized');
+  });
+
+  it('should return public pages without auth even when include_private is missing', async () => {
+    const res = await request(app)
+      .get('/api/pages')
+      .expect(200);
+
+    expect(res.body.every((p: any) => p.access === 'public')).toBe(true);
+  });
+
+  it('should include correct page titles and paths', async () => {
+    const res = await request(app)
+      .get('/api/pages')
+      .query({ include_private: 'true' })
+      .set('Authorization', 'Bearer test-token')
+      .expect(200);
+
+    const titles = res.body.map((p: any) => p.title);
+    expect(titles).toContain('Home');
+    expect(titles).toContain('Process');
+    expect(titles).toContain('Design');
+
+    const paths = res.body.map((p: any) => p.path);
+    expect(paths).toContain('index.md');
+    expect(paths).toContain('methodology/process.md');
+    expect(paths).toContain('projects/foundry/design.md');
+  });
+});

--- a/packages/api/src/routes/pages.ts
+++ b/packages/api/src/routes/pages.ts
@@ -1,0 +1,69 @@
+import { Router, Request, Response } from 'express';
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+import { parseNavPages } from '../utils/nav-parser.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+/**
+ * Walks up the directory tree to find the project root containing foundry.config.yaml.
+ */
+function findProjectRoot(startDir: string): string {
+  let current = startDir;
+
+  while (current !== dirname(current)) {
+    try {
+      readFileSync(join(current, 'foundry.config.yaml'), 'utf8');
+      return current;
+    } catch {
+      current = dirname(current);
+    }
+  }
+
+  throw new Error('Could not find foundry.config.yaml in any parent directory');
+}
+
+/**
+ * Check if the request has a valid auth token.
+ */
+function isAuthenticated(req: Request): boolean {
+  const expectedToken = process.env.FOUNDRY_WRITE_TOKEN;
+  if (!expectedToken) return true; // dev mode — no token required
+
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.startsWith('Bearer ')) return false;
+
+  return authHeader.slice(7) === expectedToken;
+}
+
+export function createPagesRouter(): Router {
+  const router = Router();
+
+  router.get('/pages', (req: Request, res: Response) => {
+    try {
+      const projectRoot = findProjectRoot(__dirname);
+      const navYamlPath = join(projectRoot, 'nav.yaml');
+      const allPages = parseNavPages(navYamlPath);
+
+      const includePrivate = req.query.include_private === 'true';
+
+      if (includePrivate && !isAuthenticated(req)) {
+        res.status(401).json({ error: 'Unauthorized' });
+        return;
+      }
+
+      const pages = includePrivate
+        ? allPages
+        : allPages.filter(p => p.access === 'public');
+
+      res.json(pages);
+    } catch (error) {
+      console.error('Error listing pages:', error);
+      res.status(500).json({ error: 'Failed to list pages' });
+    }
+  });
+
+  return router;
+}

--- a/packages/api/src/utils/__tests__/nav-parser.test.ts
+++ b/packages/api/src/utils/__tests__/nav-parser.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, afterAll } from 'vitest';
+import { writeFileSync, unlinkSync, mkdtempSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { parseNavPages } from '../nav-parser.js';
+
+const tempDir = mkdtempSync(join(tmpdir(), 'nav-parser-test-'));
+
+function writeTempYaml(content: string): string {
+  const path = join(tempDir, `nav-${Date.now()}.yaml`);
+  writeFileSync(path, content, 'utf8');
+  return path;
+}
+
+afterAll(() => {
+  try {
+    const { readdirSync } = require('fs');
+    for (const f of readdirSync(tempDir)) {
+      unlinkSync(join(tempDir, f));
+    }
+    require('fs').rmdirSync(tempDir);
+  } catch {
+    // ignore cleanup errors
+  }
+});
+
+describe('parseNavPages', () => {
+  it('should parse flat pages with default public access', () => {
+    const path = writeTempYaml(`
+- title: Home
+  path: index.md
+- title: About
+  path: about.md
+`);
+
+    const pages = parseNavPages(path);
+    expect(pages).toHaveLength(2);
+    expect(pages[0]).toEqual({ title: 'Home', path: 'index.md', access: 'public' });
+    expect(pages[1]).toEqual({ title: 'About', path: 'about.md', access: 'public' });
+  });
+
+  it('should skip container nodes without paths', () => {
+    const path = writeTempYaml(`
+- title: Section
+  children:
+    - title: Page
+      path: section/page.md
+`);
+
+    const pages = parseNavPages(path);
+    expect(pages).toHaveLength(1);
+    expect(pages[0].title).toBe('Page');
+  });
+
+  it('should inherit access from parent nodes', () => {
+    const path = writeTempYaml(`
+- title: Public Page
+  path: public.md
+- title: Private Section
+  access: private
+  children:
+    - title: Secret Page
+      path: secret.md
+    - title: Inner Section
+      children:
+        - title: Deep Secret
+          path: deep-secret.md
+`);
+
+    const pages = parseNavPages(path);
+    expect(pages).toHaveLength(3);
+    expect(pages[0]).toEqual({ title: 'Public Page', path: 'public.md', access: 'public' });
+    expect(pages[1]).toEqual({ title: 'Secret Page', path: 'secret.md', access: 'private' });
+    expect(pages[2]).toEqual({ title: 'Deep Secret', path: 'deep-secret.md', access: 'private' });
+  });
+
+  it('should allow child to override parent access', () => {
+    const path = writeTempYaml(`
+- title: Private Section
+  access: private
+  children:
+    - title: Public Override
+      access: public
+      path: override.md
+    - title: Still Private
+      path: still-private.md
+`);
+
+    const pages = parseNavPages(path);
+    expect(pages).toHaveLength(2);
+    expect(pages[0]).toEqual({ title: 'Public Override', path: 'override.md', access: 'public' });
+    expect(pages[1]).toEqual({ title: 'Still Private', path: 'still-private.md', access: 'private' });
+  });
+
+  it('should handle deeply nested structures', () => {
+    const path = writeTempYaml(`
+- title: Root
+  children:
+    - title: Level 1
+      children:
+        - title: Level 2
+          children:
+            - title: Deep Page
+              path: deep/page.md
+`);
+
+    const pages = parseNavPages(path);
+    expect(pages).toHaveLength(1);
+    expect(pages[0]).toEqual({ title: 'Deep Page', path: 'deep/page.md', access: 'public' });
+  });
+
+  it('should return empty array for empty nav', () => {
+    const path = writeTempYaml(`[]`);
+    const pages = parseNavPages(path);
+    expect(pages).toEqual([]);
+  });
+});

--- a/packages/api/src/utils/nav-parser.ts
+++ b/packages/api/src/utils/nav-parser.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from 'fs';
+import yaml from 'js-yaml';
+
+export interface NavPage {
+  title: string;
+  path: string;
+  access: 'public' | 'private';
+}
+
+/**
+ * Parse nav.yaml and flatten into a list of pages with access levels.
+ * Walks the tree recursively, inheriting access from parent nodes.
+ */
+export function parseNavPages(navYamlPath: string): NavPage[] {
+  const raw = readFileSync(navYamlPath, 'utf8');
+  const tree = yaml.load(raw) as any[];
+
+  const pages: NavPage[] = [];
+
+  function walk(nodes: any[], parentAccess: 'public' | 'private') {
+    for (const node of nodes) {
+      const access = node.access || parentAccess;
+      if (node.path) {
+        pages.push({ title: node.title, path: node.path, access });
+      }
+      if (node.children) {
+        walk(node.children, access);
+      }
+    }
+  }
+
+  walk(tree, 'public');
+  return pages;
+}


### PR DESCRIPTION
## FND-E9-S8: list_pages (Nav Tree)

### What
- **nav-parser.ts** utility — parses nav.yaml into flat page list with access inheritance
- **GET /api/pages** — returns public pages by default, all pages with auth + include_private=true
- **list_pages** MCP tool with include_private boolean param
- **listPages()** in http-client.ts

### Tests
- 6 nav parser tests (flattening, inheritance, overrides, nesting, empty)
- 7 route tests (public default, field shape, auth gating)
- 4 MCP tool tests

### Design Decisions
- Distinct from Anvil's list_pages — this includes nav tree structure + public/private access levels
- Access inheritance: parent 'private' cascades to all children unless overridden