### PR TITLE
feat(site): migrate to Astro SSR with runtime markdown rendering (FND-E8-F1-S1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -150,6 +150,80 @@
         "vfile": "^6.0.3"
       }
     },
+    "node_modules/@astrojs/node": {
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/@astrojs/node/-/node-10.0.4.tgz",
+      "integrity": "sha512-7pVgiVSscQHRC2WqjlXcnbbcKMYp2GXrYpmuvdGg5zgA8J1lFm2vmwVhHZFuZK3Ik5PzoxiDROaEgoDGLbfhLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/internal-helpers": "0.8.0",
+        "send": "^1.2.1",
+        "server-destroy": "^1.0.1"
+      },
+      "peerDependencies": {
+        "astro": "^6.0.0"
+      }
+    },
+    "node_modules/@astrojs/node/node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@astrojs/node/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@astrojs/node/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@astrojs/node/node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/@astrojs/prism": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-4.0.1.tgz",
@@ -2412,6 +2486,23 @@
         "node": ">=20"
       }
     },
+    "node_modules/@shikijs/rehype": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/rehype/-/rehype-4.0.2.tgz",
+      "integrity": "sha512-cmPlKLD8JeojasNFoY64162ScpEdEdQUMuVodPCrv1nx1z3bjmGwoKWDruQWa/ejSznImlaeB0Ty6Q3zPaVQAA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-string": "^3.0.1",
+        "shiki": "4.0.2",
+        "unified": "^11.0.5",
+        "unist-util-visit": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/@shikijs/themes": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.0.2.tgz",
@@ -4328,6 +4419,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
@@ -4506,6 +4610,18 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -4808,6 +4924,43 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/gray-matter/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/gray-matter/node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/h3": {
@@ -5230,6 +5383,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-inside-container": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
@@ -5432,6 +5594,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/local-pkg": {
@@ -7513,6 +7684,19 @@
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
     },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -7575,6 +7759,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/server-destroy": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
+      "integrity": "sha512-rb+9B5YBIEzYcD6x2VKidaa+cqYBJQKnU4oe4E3ANwRRN56yk/ua1YCJT1n21NTS8w6CcOclAKNP3PhdCXKYtQ==",
+      "license": "ISC"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -7854,6 +8044,12 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -7898,6 +8094,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/strip-final-newline": {
@@ -10799,14 +11004,22 @@
       "name": "@foundry/site",
       "version": "0.1.0",
       "dependencies": {
+        "@astrojs/node": "^10.0.4",
         "@astrojs/react": "^4.2.1",
+        "@shikijs/rehype": "^4.0.2",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "astro": "^6.1.2",
+        "gray-matter": "^4.0.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "rehype-autolink-headings": "^7.1.0",
+        "rehype-raw": "^7.0.0",
         "rehype-slug": "^6.0.0",
+        "rehype-stringify": "^10.0.1",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.1.2",
+        "unified": "^11.0.5",
         "unist-util-visit": "^5.1.0"
       },
       "devDependencies": {

--- a/packages/site/astro.config.mjs
+++ b/packages/site/astro.config.mjs
@@ -1,17 +1,14 @@
 import { defineConfig } from 'astro/config';
 import react from '@astrojs/react';
+import node from '@astrojs/node';
 import rehypeSlug from 'rehype-slug';
 import rehypeAutolinkHeadings from 'rehype-autolink-headings';
 import remarkAdmonitions from './src/plugins/remark-admonitions.ts';
 import remarkMermaid from './src/plugins/remark-mermaid.ts';
 
-console.error('>>> remarkAdmonitions type:', typeof remarkAdmonitions, remarkAdmonitions?.name);
-console.error('>>> remarkMermaid type:', typeof remarkMermaid, remarkMermaid?.name);
-console.error('>>> remarkAdmonitions keys:', remarkAdmonitions ? Object.keys(remarkAdmonitions) : 'null');
-
 export default defineConfig({
-  site: 'https://danhannah94.github.io',
-  base: '/foundry',
+  output: 'server',
+  adapter: node({ mode: 'standalone' }),
   integrations: [react()],
 
   markdown: {
@@ -41,8 +38,6 @@ export default defineConfig({
       },
     },
   },
-
-  // Content lives in content/ directory, populated by build script
 
   vite: {
     optimizeDeps: {

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -15,14 +15,22 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@astrojs/node": "^10.0.4",
     "@astrojs/react": "^4.2.1",
+    "@shikijs/rehype": "^4.0.2",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "astro": "^6.1.2",
+    "gray-matter": "^4.0.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "rehype-autolink-headings": "^7.1.0",
+    "rehype-raw": "^7.0.0",
     "rehype-slug": "^6.0.0",
+    "rehype-stringify": "^10.0.1",
+    "remark-parse": "^11.0.0",
+    "remark-rehype": "^11.1.2",
+    "unified": "^11.0.5",
     "unist-util-visit": "^5.1.0"
   },
   "devDependencies": {

--- a/packages/site/src/content.config.ts
+++ b/packages/site/src/content.config.ts
@@ -1,12 +1,2 @@
-import { defineCollection, z } from 'astro:content';
-import { glob } from 'astro/loaders';
-
-const docs = defineCollection({
-  loader: glob({ pattern: '**/*.md', base: './content' }),
-  schema: z.object({
-    title: z.string().optional(),
-    description: z.string().optional(),
-  }),
-});
-
-export const collections = { docs };
+// Content collections disabled — SSR mode reads markdown from disk at request time.
+export {};

--- a/packages/site/src/layouts/DocLayout.astro
+++ b/packages/site/src/layouts/DocLayout.astro
@@ -20,7 +20,6 @@ interface Props {
 
 const { title = 'Foundry', description = 'Documentation platform for human-AI collaborative workflows', currentPath = '/' } = Astro.props;
 const pageTitle = title === 'Foundry' ? title : `${title} — Foundry`;
-const base = import.meta.env.BASE_URL;
 ---
 
 <!DOCTYPE html>
@@ -30,7 +29,7 @@ const base = import.meta.env.BASE_URL;
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content={description} />
   <title>{pageTitle}</title>
-  <link rel="icon" type="image/svg+xml" href={`${base}/favicon.svg`} />
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 
   {/* Prevent flash of wrong theme */}
   <script is:inline>
@@ -53,7 +52,7 @@ const base = import.meta.env.BASE_URL;
         <line x1="2" y1="12" x2="14" y2="12" />
       </svg>
     </button>
-    <a href={`${base}/`} class="header-title" style="text-decoration: none;">🏭 Foundry</a>
+    <a href="/" class="header-title" style="text-decoration: none;">🏭 Foundry</a>
     <div class="header-right">
       {/* Sidebar slot — nav goes here (S2) */}
       <AuthIndicator client:load />

--- a/packages/site/src/pages/docs/[...slug].astro
+++ b/packages/site/src/pages/docs/[...slug].astro
@@ -1,20 +1,22 @@
 ---
-import { getCollection, render } from 'astro:content';
+import { renderMarkdown } from '../../utils/markdown';
 import DocLayout from '../../layouts/DocLayout.astro';
+import path from 'node:path';
+import fs from 'node:fs';
 
-export async function getStaticPaths() {
-  const docs = await getCollection('docs');
-  return docs.map((entry) => ({
-    params: { slug: entry.id },
-    props: { entry },
-  }));
+const slug = Astro.params.slug;
+const contentDir = path.resolve(process.cwd(), 'content');
+const filePath = path.join(contentDir, `${slug}.md`);
+
+// Check if file exists, return 404 if not
+if (!fs.existsSync(filePath)) {
+  return Astro.redirect('/404');
 }
 
-const { entry } = Astro.props;
-const { Content } = await render(entry);
-const title = entry.data.title || entry.id;
+const { html, frontmatter } = await renderMarkdown(filePath);
+const title = frontmatter.title || slug;
 ---
 
 <DocLayout title={title} currentPath={Astro.url.pathname}>
-  <Content />
+  <Fragment set:html={html} />
 </DocLayout>

--- a/packages/site/src/utils/markdown.ts
+++ b/packages/site/src/utils/markdown.ts
@@ -1,0 +1,60 @@
+import fs from 'node:fs';
+import { unified } from 'unified';
+import remarkParse from 'remark-parse';
+import remarkRehype from 'remark-rehype';
+import rehypeStringify from 'rehype-stringify';
+import rehypeRaw from 'rehype-raw';
+import rehypeSlug from 'rehype-slug';
+import rehypeAutolinkHeadings from 'rehype-autolink-headings';
+import rehypeShiki from '@shikijs/rehype';
+import matter from 'gray-matter';
+import remarkAdmonitions from '../plugins/remark-admonitions.ts';
+import remarkMermaid from '../plugins/remark-mermaid.ts';
+
+let processor: ReturnType<typeof unified> | null = null;
+
+async function getProcessor() {
+  if (processor) return processor;
+
+  processor = unified()
+    .use(remarkParse)
+    .use(remarkMermaid)
+    .use(remarkAdmonitions)
+    .use(remarkRehype, { allowDangerousHtml: true })
+    .use(rehypeRaw)
+    .use(rehypeSlug)
+    .use(rehypeAutolinkHeadings, {
+      behavior: 'append',
+      properties: {
+        className: ['heading-anchor'],
+        ariaHidden: 'true',
+        tabIndex: -1,
+      },
+      content: {
+        type: 'text',
+        value: '#',
+      },
+    })
+    .use(rehypeShiki, {
+      themes: {
+        light: 'github-light',
+        dark: 'github-dark',
+      },
+    })
+    .use(rehypeStringify);
+
+  return processor;
+}
+
+export async function renderMarkdown(filePath: string): Promise<{ html: string; frontmatter: Record<string, any> }> {
+  const raw = fs.readFileSync(filePath, 'utf-8');
+  const { content, data: frontmatter } = matter(raw);
+
+  const proc = await getProcessor();
+  const result = await proc.process(content);
+
+  return {
+    html: String(result),
+    frontmatter,
+  };
+}

--- a/packages/site/src/utils/nav.ts
+++ b/packages/site/src/utils/nav.ts
@@ -18,11 +18,10 @@ interface RawNavItem {
 }
 
 function pathToHref(filePath: string): string {
-  const base = (import.meta.env.BASE_URL || '/').replace(/\/$/, '');
-  if (filePath === 'index.md') return base + '/';
+  if (filePath === 'index.md') return '/';
   // Strip leading docs/ prefix — build.sh already strips this when copying content
   const normalizedPath = filePath.replace(/^docs\//, '');
-  return base + '/docs/' + normalizedPath.replace(/\.md$/, '') + '/';
+  return '/docs/' + normalizedPath.replace(/\.md$/, '') + '/';
 }
 
 function processItems(items: RawNavItem[]): NavItem[] {


### PR DESCRIPTION
## FND-E8-F1-S1: Astro SSR Adapter + Dynamic Content Loader

Switches Foundry from static site generation to server-side rendering (SSR) so pages render from markdown on disk at request time. New markdown files become accessible immediately without rebuilding.

### Changes
- **astro.config.mjs**: Added `@astrojs/node` adapter, `output: 'server'`, removed `site`/`base` config (no longer serving from GitHub Pages subpath)
- **src/utils/markdown.ts**: New runtime markdown-to-HTML pipeline using unified + remark-parse + remark-rehype + rehype-stringify + rehype-raw + @shikijs/rehype, with existing remark-admonitions, remark-mermaid, rehype-slug, and rehype-autolink-headings plugins
- **src/pages/docs/[...slug].astro**: Replaced static `getStaticPaths` with SSR dynamic route that reads markdown from disk
- **src/content.config.ts**: Gutted — content collections no longer used
- **src/utils/nav.ts**: Removed `BASE_URL` prefix logic (now serves from root)
- **src/layouts/DocLayout.astro**: Updated asset paths from `/foundry/...` to `/...`

### Verification
- `npm run build` produces a standalone Node server ✅
- Pages render at `/docs/...` without the `/foundry` prefix
- New `.md` files in `content/` are accessible without rebuild