### PR TITLE
feat(site): add in-memory page cache with route-level invalidation (FND-E8-F1-S2)

### DIFF
--- a/packages/site/src/pages/api/cache-stats.json.ts
+++ b/packages/site/src/pages/api/cache-stats.json.ts
@@ -1,0 +1,8 @@
+import type { APIRoute } from 'astro';
+import { getCacheStats } from '../../utils/page-cache';
+
+export const GET: APIRoute = () => {
+  return new Response(JSON.stringify(getCacheStats()), {
+    headers: { 'Content-Type': 'application/json' }
+  });
+};

--- a/packages/site/src/pages/docs/[...slug].astro
+++ b/packages/site/src/pages/docs/[...slug].astro
@@ -1,5 +1,6 @@
 ---
 import { renderMarkdown } from '../../utils/markdown';
+import { getCachedPage, setCachedPage } from '../../utils/page-cache';
 import DocLayout from '../../layouts/DocLayout.astro';
 import path from 'node:path';
 import fs from 'node:fs';
@@ -13,7 +14,21 @@ if (!fs.existsSync(filePath)) {
   return Astro.redirect('/404');
 }
 
-const { html, frontmatter } = await renderMarkdown(filePath);
+// Check cache first, render on miss
+let html: string;
+let frontmatter: Record<string, any>;
+
+const cached = getCachedPage(slug!);
+if (cached) {
+  html = cached.html;
+  frontmatter = cached.frontmatter;
+} else {
+  const rendered = await renderMarkdown(filePath);
+  html = rendered.html;
+  frontmatter = rendered.frontmatter;
+  setCachedPage(slug!, html, frontmatter);
+}
+
 const title = frontmatter.title || slug;
 ---
 

--- a/packages/site/src/utils/page-cache.ts
+++ b/packages/site/src/utils/page-cache.ts
@@ -1,0 +1,27 @@
+interface CacheEntry {
+  html: string;
+  frontmatter: Record<string, any>;
+  cachedAt: number;
+}
+
+const cache = new Map<string, CacheEntry>();
+
+export function getCachedPage(slug: string): CacheEntry | undefined {
+  return cache.get(slug);
+}
+
+export function setCachedPage(slug: string, html: string, frontmatter: Record<string, any>): void {
+  cache.set(slug, { html, frontmatter, cachedAt: Date.now() });
+}
+
+export function invalidateRoute(slug: string): boolean {
+  return cache.delete(slug);
+}
+
+export function invalidateAll(): void {
+  cache.clear();
+}
+
+export function getCacheStats(): { size: number; routes: string[] } {
+  return { size: cache.size, routes: Array.from(cache.keys()) };
+}


### PR DESCRIPTION
## FND-E8-F1-S2: In-Memory Page Cache

Adds a module-level in-memory cache for rendered markdown pages so they aren't re-rendered on every SSR request.

### Changes
- **`packages/site/src/utils/page-cache.ts`** — Cache module with `getCachedPage`, `setCachedPage`, `invalidateRoute`, `invalidateAll`, and `getCacheStats`
- **`packages/site/src/pages/docs/[...slug].astro`** — Check cache before calling `renderMarkdown()`; store result on miss
- **`packages/site/src/pages/api/cache-stats.json.ts`** — Astro SSR endpoint returning cache size and cached routes as JSON

### Not touched
- `packages/api/`, `markdown.ts`, components, tests, Dockerfile

### Verification
- `npm run build` passes ✅
- Cache will be invalidated by webhook pipeline (F3, future story)