### PR TITLE
feat(api): add runtime content fetcher with git pull + mutex (FND-E8-F3-S1)

### DIFF
--- a/packages/api/src/content-fetcher.ts
+++ b/packages/api/src/content-fetcher.ts
@@ -1,0 +1,117 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const execFileAsync = promisify(execFile);
+
+export interface PullResult {
+  ref: string;
+  changedFiles: string[];
+  isInitialClone: boolean;
+}
+
+export class ContentFetcher {
+  private contentDir: string;
+  private repoUrl: string;
+  private branch: string;
+  private deployKeyPath: string | null;
+  private pulling: boolean = false;
+
+  constructor(options: {
+    contentDir: string;
+    repoUrl: string;
+    branch: string;
+    deployKeyPath?: string;
+  }) {
+    this.contentDir = options.contentDir;
+    this.repoUrl = options.repoUrl;
+    this.branch = options.branch;
+    this.deployKeyPath = options.deployKeyPath || null;
+  }
+
+  private gitEnv(): Record<string, string> {
+    const env = { ...process.env } as Record<string, string>;
+    if (this.deployKeyPath) {
+      env.GIT_SSH_COMMAND = `ssh -i ${this.deployKeyPath} -o StrictHostKeyChecking=no`;
+    }
+    return env;
+  }
+
+  private async git(args: string[], cwd?: string): Promise<string> {
+    const { stdout } = await execFileAsync('git', args, {
+      cwd: cwd || this.contentDir,
+      env: this.gitEnv(),
+      maxBuffer: 10 * 1024 * 1024,
+    });
+    return stdout.trim();
+  }
+
+  async getCurrentRef(): Promise<string | null> {
+    if (!existsSync(join(this.contentDir, '.git'))) return null;
+    try {
+      return await this.git(['rev-parse', 'HEAD']);
+    } catch {
+      return null;
+    }
+  }
+
+  async pull(): Promise<PullResult | null> {
+    // Mutex — skip if already pulling
+    if (this.pulling) {
+      console.log('[content-fetcher] Pull already in progress, skipping');
+      return null;
+    }
+
+    this.pulling = true;
+    try {
+      const isGitRepo = existsSync(join(this.contentDir, '.git'));
+
+      if (!isGitRepo) {
+        // Initial clone
+        console.log(`[content-fetcher] Cloning ${this.repoUrl} (branch: ${this.branch})`);
+        await execFileAsync('git', [
+          'clone', '--depth', '1', '--branch', this.branch,
+          this.repoUrl, this.contentDir
+        ], { env: this.gitEnv(), maxBuffer: 10 * 1024 * 1024 });
+
+        const ref = await this.git(['rev-parse', 'HEAD']);
+        console.log(`[content-fetcher] Clone complete: ${ref.substring(0, 8)}`);
+
+        return { ref, changedFiles: [], isInitialClone: true };
+      }
+
+      // Already cloned — fetch and diff
+      const oldRef = await this.git(['rev-parse', 'HEAD']);
+
+      await this.git(['fetch', 'origin', this.branch, '--depth', '1']);
+      await this.git(['reset', '--hard', 'FETCH_HEAD']);
+
+      const newRef = await this.git(['rev-parse', 'HEAD']);
+
+      if (oldRef === newRef) {
+        console.log('[content-fetcher] No changes');
+        return { ref: newRef, changedFiles: [], isInitialClone: false };
+      }
+
+      // Get changed files
+      let changedFiles: string[] = [];
+      try {
+        const diff = await this.git(['diff', '--name-only', oldRef, newRef]);
+        changedFiles = diff.split('\n').filter(f => f.length > 0);
+      } catch {
+        // If diff fails (shallow clone), treat as full change
+        changedFiles = [];
+      }
+
+      console.log(`[content-fetcher] Updated: ${oldRef.substring(0, 8)} → ${newRef.substring(0, 8)} (${changedFiles.length} files changed)`);
+
+      return { ref: newRef, changedFiles, isInitialClone: false };
+    } catch (error) {
+      console.error('[content-fetcher] Pull failed:', error);
+      throw error;
+    } finally {
+      this.pulling = false;
+    }
+  }
+}

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -3,6 +3,7 @@ import cors from 'cors';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 import { loadAnvil } from './anvil-loader.js';
+import { ContentFetcher } from './content-fetcher.js';
 import { getDocsPath } from './config.js';
 import { createHealthRouter } from './routes/health.js';
 import { createDocsRouter } from './routes/docs.js';
@@ -21,6 +22,17 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const PORT = process.env.FOUNDRY_PORT ? parseInt(process.env.FOUNDRY_PORT, 10) : 3001;
 const STATIC_PATH = process.env.FOUNDRY_STATIC_PATH || join(__dirname, '../../site/dist');
+
+// Content fetcher singleton (initialized if CONTENT_REPO is set)
+let contentFetcher: ContentFetcher | null = null;
+
+/**
+ * Returns the ContentFetcher instance, or null if not configured.
+ * Used by webhook endpoint (F3-S2) to trigger pulls.
+ */
+export function getContentFetcher(): ContentFetcher | null {
+  return contentFetcher;
+}
 
 interface ErrorWithStatus extends Error {
   status?: number;
@@ -75,6 +87,30 @@ async function startServer(): Promise<void> {
     // Get docs path from configuration
     const docsPath = getDocsPath();
     console.log(`📁 Using docs path: ${docsPath}`);
+
+    // Initialize content fetcher (runtime git clone/pull)
+    const contentRepo = process.env.CONTENT_REPO;
+    if (contentRepo) {
+      const contentBranch = process.env.CONTENT_BRANCH || 'main';
+      const deployKeyPath = process.env.DEPLOY_KEY_PATH;
+      contentFetcher = new ContentFetcher({
+        contentDir: docsPath,
+        repoUrl: contentRepo,
+        branch: contentBranch,
+        deployKeyPath: deployKeyPath,
+      });
+      console.log(`📦 Content fetcher enabled: ${contentRepo} (branch: ${contentBranch})`);
+      try {
+        const result = await contentFetcher.pull();
+        if (result) {
+          console.log(`✅ Content ${result.isInitialClone ? 'cloned' : 'updated'}: ${result.ref.substring(0, 8)}`);
+        }
+      } catch (error) {
+        console.error('⚠️ Initial content fetch failed (continuing without content):', error);
+      }
+    } else {
+      console.log('📦 Content fetcher disabled (no CONTENT_REPO set)');
+    }
 
     // Initialize Anvil (dynamic import — handles missing package gracefully)
     const anvil = await loadAnvil(docsPath);


### PR DESCRIPTION
## FND-E8-F3-S1: Runtime Content Fetcher

Adds a `ContentFetcher` class that clones/pulls content from a git repo at runtime, replacing build-time content fetch for production.

### What's new
- **`packages/api/src/content-fetcher.ts`** — `ContentFetcher` class with:
  - Shallow clone on first run, fetch+reset on subsequent pulls
  - Mutex to prevent concurrent pulls
  - Deploy key support via `GIT_SSH_COMMAND`
  - Changed file detection via `git diff`
- **`packages/api/src/index.ts`** — Integration:
  - Reads `CONTENT_REPO`, `CONTENT_BRANCH`, `DEPLOY_KEY_PATH` env vars
  - Creates fetcher and runs initial pull at startup (if configured)
  - Exports `getContentFetcher()` for webhook endpoint (F3-S2)
  - Gracefully skips if `CONTENT_REPO` not set (local dev)

### Env vars
| Variable | Required | Default | Description |
|----------|----------|---------|-------------|
| `CONTENT_REPO` | No | — | Git repo URL to clone content from |
| `CONTENT_BRANCH` | No | `main` | Branch to track |
| `DEPLOY_KEY_PATH` | No | — | Path to SSH deploy key |

### Verification
- `npm run build` compiles cleanly
- No changes to site, Dockerfile, or build scripts