### PR TITLE
feat(api): add webhook endpoint for content updates (FND-E8-F3-S2)

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -8,9 +8,11 @@ import { getDocsPath } from './config.js';
 import { createHealthRouter } from './routes/health.js';
 import { createDocsRouter } from './routes/docs.js';
 import { createSearchRouter } from './routes/search.js';
+import { createReindexRouter } from './routes/reindex.js';
 import { createAnnotationsRouter } from './routes/annotations.js';
 import { createReviewsRouter } from './routes/reviews.js';
 import { createAccessRouter } from './routes/access.js';
+import { createWebhookRouter } from './routes/webhook.js';
 import { createPagesRouter } from './routes/pages.js';
 import { requireAuth, logAuthStatus } from './middleware/auth.js';
 import { loadAccessMap, getAccessLevel } from './access.js';
@@ -164,6 +166,41 @@ async function startServer(): Promise<void> {
       }
     });
 
+    // Webhook content update callback
+    // Defined here so it can capture `anvil` from the closure
+    async function onContentUpdated(changedFiles: string[], isInitialClone: boolean) {
+      const mdFiles = changedFiles.filter(f => f.endsWith('.md'));
+
+      // TODO: Cache invalidation (invalidateAll/invalidateRoute) requires IPC to the Astro SSR process.
+      // The page cache lives in packages/site, not packages/api.
+      // For now, we log what would be invalidated. The page cache has a TTL
+      // or can be manually cleared via /api/cache-stats endpoint.
+      // TODO: Nav invalidation (invalidateNav) also lives in packages/site — same IPC needed.
+      if (isInitialClone || changedFiles.length === 0) {
+        console.log('[webhook] Full content refresh — all caches need invalidation');
+      } else {
+        console.log(`[webhook] Changed files: ${mdFiles.join(', ')}`);
+      }
+
+      // Anvil reindex (if available)
+      if (anvil) {
+        try {
+          if (isInitialClone || mdFiles.length === 0) {
+            console.log('[webhook] Triggering full Anvil reindex');
+            await anvil.index();
+          } else {
+            console.log(`[webhook] Reindexing ${mdFiles.length} changed files`);
+            await anvil.reindexFiles(mdFiles);
+          }
+        } catch (error) {
+          console.error('[webhook] Anvil reindex failed:', error);
+        }
+      }
+    }
+
+    // Mount webhook router (works with or without Anvil)
+    app.use('/api', createWebhookRouter({ onContentUpdated }));
+
     // Mount access router (always available, no anvil dependency)
     app.use('/api', createAccessRouter());
 
@@ -175,6 +212,7 @@ async function startServer(): Promise<void> {
       app.use('/api', createHealthRouter(anvil));
       app.use('/api', createDocsRouter(anvil));
       app.use('/api', createSearchRouter(anvil));
+      app.use('/api', createReindexRouter(anvil));
     } else {
       // Basic health endpoint when Anvil unavailable
       app.get('/api/health', (req, res) => res.json({

--- a/packages/api/src/routes/webhook.ts
+++ b/packages/api/src/routes/webhook.ts
@@ -1,0 +1,103 @@
+import { Router, Request, Response } from 'express';
+import crypto from 'node:crypto';
+import { getContentFetcher } from '../index.js';
+
+interface WebhookState {
+  lastUpdate: string | null;
+  lastRef: string | null;
+  lastError: string | null;
+  status: 'idle' | 'updating' | 'ok' | 'error';
+}
+
+const state: WebhookState = {
+  lastUpdate: null,
+  lastRef: null,
+  lastError: null,
+  status: 'idle',
+};
+
+export function getWebhookState(): WebhookState {
+  return { ...state };
+}
+
+function verifySignature(payload: string, signature: string | undefined, secret: string): boolean {
+  if (!signature) return false;
+  const expected = 'sha256=' + crypto.createHmac('sha256', secret).update(payload).digest('hex');
+  return crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(expected));
+}
+
+export function createWebhookRouter(options: {
+  onContentUpdated?: (changedFiles: string[], isInitialClone: boolean) => Promise<void>;
+}): Router {
+  const router = Router();
+  const webhookSecret = process.env.WEBHOOK_SECRET;
+
+  // POST /webhooks/content-update
+  router.post('/webhooks/content-update', async (req: Request, res: Response) => {
+    // Verify webhook secret is configured
+    if (!webhookSecret) {
+      console.warn('[webhook] WEBHOOK_SECRET not configured, rejecting');
+      return res.status(500).json({ error: 'Webhook not configured' });
+    }
+
+    // Verify GitHub signature
+    const rawBody = JSON.stringify(req.body);
+    const signature = req.headers['x-hub-signature-256'] as string | undefined;
+
+    if (!signature) {
+      return res.status(401).json({ error: 'Missing signature' });
+    }
+
+    if (!verifySignature(rawBody, signature, webhookSecret)) {
+      return res.status(403).json({ error: 'Invalid signature' });
+    }
+
+    // Only handle push events
+    const event = req.headers['x-github-event'] as string;
+    if (event !== 'push') {
+      return res.status(200).json({ status: 'ignored', event });
+    }
+
+    // Respond immediately — run pipeline async
+    res.status(200).json({ status: 'accepted' });
+
+    // Run the content update pipeline
+    const fetcher = getContentFetcher();
+    if (!fetcher) {
+      console.warn('[webhook] Content fetcher not configured');
+      return;
+    }
+
+    state.status = 'updating';
+    try {
+      const result = await fetcher.pull();
+      if (!result) {
+        state.status = 'ok';
+        return;
+      }
+
+      state.lastRef = result.ref;
+      state.lastUpdate = new Date().toISOString();
+
+      // Call the content update callback (cache invalidation, nav regen, Anvil reindex)
+      if (options.onContentUpdated) {
+        await options.onContentUpdated(result.changedFiles, result.isInitialClone);
+      }
+
+      state.status = 'ok';
+      state.lastError = null;
+      console.log(`[webhook] Content update complete: ${result.ref.substring(0, 8)}`);
+    } catch (error: any) {
+      state.status = 'error';
+      state.lastError = error.message || String(error);
+      console.error('[webhook] Content update failed:', error);
+    }
+  });
+
+  // GET /content/status
+  router.get('/content/status', (_req: Request, res: Response) => {
+    res.json(getWebhookState());
+  });
+
+  return router;
+}

--- a/packages/api/src/types/anvil.d.ts
+++ b/packages/api/src/types/anvil.d.ts
@@ -10,6 +10,8 @@ declare module '@claymore-dev/anvil' {
     getPage(path: string): Promise<any>;
     getSection(path: string, heading: string): Promise<any>;
     listPages(): Promise<{ pages: any[] }>;
+    index(): Promise<any>;
+    reindexFiles(files: string[]): Promise<any>;
   }
   
   export function createAnvil(options: { docsPath: string }): Promise<Anvil>;


### PR DESCRIPTION
## FND-E8-F3-S2: Webhook Endpoint

Adds a webhook endpoint that receives GitHub push events and orchestrates the content update pipeline.

### Changes

**New: `packages/api/src/routes/webhook.ts`**
- `POST /api/webhooks/content-update` — receives GitHub push webhooks
  - Verifies `WEBHOOK_SECRET` via HMAC-SHA256 signature (`x-hub-signature-256`)
  - Only processes `push` events; ignores others
  - Responds immediately (200), then runs async pipeline: `contentFetcher.pull()` → callback
- `GET /api/content/status` — returns webhook state (last update, ref, status, errors)
- Exports `getWebhookState()` for programmatic access

**Modified: `packages/api/src/index.ts`**
- Mounts webhook router before static serving, outside Anvil conditional
- `onContentUpdated` callback defined inside `startServer` to capture `anvil` closure:
  - Logs cache invalidation needs (TODO: IPC to Astro SSR for page cache + nav)
  - Triggers Anvil reindex: full `index()` for initial clone/empty changeset, `reindexFiles()` for targeted updates

**Modified: `packages/api/src/types/anvil.d.ts`**
- Added `index()` and `reindexFiles()` to fallback Anvil type declaration

### TODOs (by design)
- Cache invalidation (`invalidateAll`/`invalidateRoute`) needs IPC to Astro SSR process
- Nav invalidation (`invalidateNav`) same — lives in `packages/site`

### Verification
- `npm run build` in `packages/api` passes cleanly