### PR TITLE
feat(api): add get_page, get_section, get_status, reindex MCP tools (FND-E8-F4-S2)

### DIFF
--- a/packages/api/src/mcp/http-client.ts
+++ b/packages/api/src/mcp/http-client.ts
@@ -275,6 +275,39 @@ interface SearchResponse {
 }
 
 /**
+ * Get a single page by path.
+ */
+export async function getPage(
+  path: string,
+): Promise<object> {
+  return apiFetch<object>(`/api/docs/${encodeURIComponent(path)}`);
+}
+
+/**
+ * Get a specific section from a document.
+ */
+export async function getSection(
+  path: string,
+  headingPath: string,
+): Promise<object> {
+  return apiFetch<object>(`/api/docs/${encodeURIComponent(path)}/sections/${encodeURIComponent(headingPath)}`);
+}
+
+/**
+ * Get server health/status.
+ */
+export async function getStatus(): Promise<object> {
+  return apiFetch<object>('/api/health');
+}
+
+/**
+ * Trigger a full reindex of documentation.
+ */
+export async function reindex(): Promise<object> {
+  return apiFetch<object>('/api/reindex', { method: 'POST' });
+}
+
+/**
  * Semantic search via HTTP API.
  */
 export async function searchDocs(

--- a/packages/api/src/mcp/server.ts
+++ b/packages/api/src/mcp/server.ts
@@ -13,6 +13,10 @@ import {
   getReview,
   listPages,
   searchDocs,
+  getPage,
+  getSection,
+  getStatus,
+  reindex,
 } from './http-client.js';
 
 /**
@@ -182,6 +186,47 @@ export function createMcpServer(): Server {
           required: ['query'],
         },
       },
+      // Page tools
+      {
+        name: 'get_page',
+        description: 'Get a single document page by path, including its section structure.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            path: { type: 'string', description: 'Path to the document' },
+          },
+          required: ['path'],
+        },
+      },
+      {
+        name: 'get_section',
+        description: 'Get a specific section from a document by path and heading.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            path: { type: 'string', description: 'Path to the document' },
+            heading_path: { type: 'string', description: 'Heading path of the section to retrieve' },
+          },
+          required: ['path', 'heading_path'],
+        },
+      },
+      // Status tools
+      {
+        name: 'get_status',
+        description: 'Get Foundry server health and status, including Anvil index statistics.',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+        },
+      },
+      {
+        name: 'reindex',
+        description: 'Trigger a full reindex of all documentation. Requires authentication.',
+        inputSchema: {
+          type: 'object',
+          properties: {},
+        },
+      },
     ],
   }));
 
@@ -266,6 +311,27 @@ export function createMcpServer(): Server {
           (args.top_k as number) || 10,
           args.auth_token as string | undefined,
         );
+        return json(result);
+      }
+      // ── Pages ──────────────────────────────────────────────
+      case 'get_page': {
+        const result = await getPage(args.path as string);
+        return json(result);
+      }
+      case 'get_section': {
+        const result = await getSection(
+          args.path as string,
+          args.heading_path as string,
+        );
+        return json(result);
+      }
+      // ── Status ─────────────────────────────────────────────
+      case 'get_status': {
+        const result = await getStatus();
+        return json(result);
+      }
+      case 'reindex': {
+        const result = await reindex();
         return json(result);
       }
       default:

--- a/packages/api/src/routes/docs.ts
+++ b/packages/api/src/routes/docs.ts
@@ -50,6 +50,18 @@ export function createDocsRouter(anvil: Anvil): Router {
     }
   });
 
+  // GET /docs/:path(*)/sections/:heading(*) - Get a specific section from a document
+  router.get('/docs/:path(*)/sections/:heading(*)', async (req, res) => {
+    try {
+      const section = await anvil.getSection(req.params.path, req.params.heading);
+      if (!section) return res.status(404).json({ error: 'Section not found' });
+      res.json(section);
+    } catch (error) {
+      console.error('Error fetching section:', error);
+      res.status(500).json({ error: 'Failed to fetch section' });
+    }
+  });
+
   // GET /docs/:path(*) - Get single document with section structure
   router.get('/docs/:path(*)', async (req: Request, res: Response<DocumentDetail>) => {
     try {

--- a/packages/api/src/routes/reindex.ts
+++ b/packages/api/src/routes/reindex.ts
@@ -1,0 +1,18 @@
+import { Router } from 'express';
+import type { Anvil } from '@claymore-dev/anvil';
+import { requireAuth } from '../middleware/auth.js';
+
+export function createReindexRouter(anvil: Anvil): Router {
+  const router = Router();
+
+  router.post('/reindex', requireAuth, async (req, res) => {
+    try {
+      const result = await anvil.index();
+      res.json({ status: 'complete', ...result });
+    } catch (error: any) {
+      res.status(500).json({ error: 'Reindex failed', message: error.message });
+    }
+  });
+
+  return router;
+}


### PR DESCRIPTION
## FND-E8-F4-S2: MCP Tool Expansion

Adds 4 new MCP tools to the Foundry MCP server:

- **get_page** — Retrieve a single document page by path with section structure
- **get_section** — Get a specific section from a document by path and heading
- **get_status** — Get server health/status including Anvil index stats
- **reindex** — Trigger full documentation reindex (requires auth)

### Changes
- `packages/api/src/routes/reindex.ts` — New reindex route (POST /api/reindex, auth-protected)
- `packages/api/src/routes/docs.ts` — Added section endpoint (GET /docs/:path/sections/:heading)
- `packages/api/src/mcp/http-client.ts` — Added getPage, getSection, getStatus, reindex HTTP client functions
- `packages/api/src/mcp/server.ts` — Added 4 tool definitions + dispatch cases

### Verification
- `npm run build` passes clean