### PR TITLE
feat: update Dockerfile for SSR + runtime content fetching (FND-E8-F5-S1)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,16 @@
 # ============================================
-# Foundry — Multi-stage Docker Build
+# Foundry — Multi-stage Docker Build (SSR)
 # ============================================
 
-# Stage 1: Fetch content from source repos
-FROM node:22-alpine AS content-fetcher
-RUN apk add --no-cache git bash
-WORKDIR /app
-COPY package*.json ./
-COPY foundry.config.yaml nav.yaml ./
-COPY scripts/ scripts/
-COPY packages/site/package*.json packages/site/
-COPY packages/api/package*.json packages/api/
-RUN npm ci
-ARG GITHUB_TOKEN=""
-ARG CACHE_BUST=""
-ENV GITHUB_TOKEN=${GITHUB_TOKEN}
-RUN echo "cache-bust: ${CACHE_BUST}" && bash scripts/build.sh
-
-# Stage 2: Build static site
+# Stage 1: Build Astro SSR site
 FROM node:22-alpine AS site-builder
 WORKDIR /app
 COPY packages/site/ packages/site/
-COPY --from=content-fetcher /app/packages/site/content packages/site/content
-COPY nav.yaml ./
+# Create empty content directory — content is fetched at runtime
+RUN mkdir -p packages/site/content
 RUN cd packages/site && npm ci && npm run build
 
-# Stage 3: Build API
+# Stage 2: Build API
 FROM node:22-alpine AS api-builder
 WORKDIR /app/packages/api
 COPY packages/api/package.json ./
@@ -33,14 +18,16 @@ RUN npm install
 COPY packages/api/ ./
 RUN npm run build
 
-# Stage 4: Production runtime
+# Stage 3: Production runtime
 FROM node:22-slim
 WORKDIR /app
 
-# Install native dependencies required by sqlite-vss
+# Install native dependencies required by sqlite-vss + git for runtime content fetching
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libopenblas0 \
     libgomp1 \
+    git \
+    openssh-client \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy built artifacts
@@ -48,7 +35,10 @@ COPY --from=site-builder /app/packages/site/dist packages/site/dist
 COPY --from=api-builder /app/packages/api/dist packages/api/dist
 COPY --from=api-builder /app/packages/api/node_modules packages/api/node_modules
 COPY --from=api-builder /app/packages/api/package.json packages/api/
-COPY foundry.config.yaml nav.yaml ./
+
+# Copy entrypoint script
+COPY scripts/start.sh scripts/start.sh
+RUN chmod +x scripts/start.sh
 
 # Fix cross-platform native modules (Alpine build → Debian runtime)
 RUN cd packages/api && npm install --os=linux --cpu=x64 sharp
@@ -57,16 +47,21 @@ RUN cd packages/api/node_modules/sqlite-vss-linux-x64/lib && \
     ln -sf vss0.so vss0.so.so && \
     ln -sf vector0.so vector0.so.so
 
-# Create data directory for SQLite
+# Create data directory for SQLite and content directory for runtime fetching
 RUN mkdir -p /data
+RUN mkdir -p packages/site/content
 
 # Environment
-ENV PORT=3001
+ENV PORT=4321
 ENV FOUNDRY_DB_PATH=/data/foundry.db
 ENV FOUNDRY_STATIC_PATH=/app/packages/site/dist
 ENV NODE_ENV=production
+ENV CONTENT_REPO=""
+ENV CONTENT_BRANCH=main
+ENV DEPLOY_KEY_PATH=""
+ENV WEBHOOK_SECRET=""
 
-EXPOSE 3001
+EXPOSE 4321
 VOLUME ["/data"]
 
-CMD ["node", "packages/api/dist/index.js"]
+CMD ["sh", "scripts/start.sh"]

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Foundry SSR Entrypoint
+# Starts both the Express API server and the Astro SSR server
+
+# Start API server in background (port 3001)
+echo "Starting API server on port 3001..."
+node packages/api/dist/index.js &
+
+# Start Astro SSR server as main process (port 4321)
+echo "Starting Astro SSR server on port ${PORT:-4321}..."
+HOST=0.0.0.0 PORT=${PORT:-4321} exec node packages/site/dist/server/entry.mjs


### PR DESCRIPTION
## FND-E8-F5-S1: Dockerfile Updates for SSR

### Changes
- **Removed Stage 1 (content-fetcher)** — content is now pulled at runtime by ContentFetcher class
- **Updated site-builder stage** — builds Astro in SSR mode (produces `dist/server/entry.mjs`), creates empty `content/` dir, removed `nav.yaml` copy
- **Updated production runtime:**
  - Added `git` and `openssh-client` packages for runtime content fetching with deploy keys
  - Removed `foundry.config.yaml` and `nav.yaml` copies (auto-nav at runtime)
  - Removed `CACHE_BUST` and `GITHUB_TOKEN` build args
  - Added env vars: `CONTENT_REPO`, `CONTENT_BRANCH`, `DEPLOY_KEY_PATH`, `WEBHOOK_SECRET`
  - Exposed port 4321 (Astro SSR) instead of 3001
  - New entrypoint runs both Express API (port 3001, background) and Astro SSR (port 4321, foreground)
- **Added `scripts/start.sh`** — entrypoint script that starts both servers
- **Kept** sqlite-vss native module fixes, `/data` volume, existing env vars