### PR TITLE
feat: add error handling, status banner, and content rollback (FND-E8-F3-S3)

### DIFF
--- a/packages/api/src/content-fetcher.ts
+++ b/packages/api/src/content-fetcher.ts
@@ -56,6 +56,15 @@ export class ContentFetcher {
     }
   }
 
+  async snapshotRef(): Promise<string | null> {
+    return this.getCurrentRef();
+  }
+
+  async restoreRef(ref: string): Promise<void> {
+    await this.git(['reset', '--hard', ref]);
+    console.log(`[content-fetcher] Restored to ref: ${ref.substring(0, 8)}`);
+  }
+
   async pull(): Promise<PullResult | null> {
     // Mutex — skip if already pulling
     if (this.pulling) {

--- a/packages/api/src/routes/webhook.ts
+++ b/packages/api/src/routes/webhook.ts
@@ -7,6 +7,7 @@ interface WebhookState {
   lastRef: string | null;
   lastError: string | null;
   status: 'idle' | 'updating' | 'ok' | 'error';
+  contentRef: string | null;
 }
 
 const state: WebhookState = {
@@ -14,6 +15,7 @@ const state: WebhookState = {
   lastRef: null,
   lastError: null,
   status: 'idle',
+  contentRef: null,
 };
 
 export function getWebhookState(): WebhookState {
@@ -68,6 +70,9 @@ export function createWebhookRouter(options: {
       return;
     }
 
+    // Snapshot before pull
+    const snapshotRef = await fetcher.snapshotRef() ?? null;
+
     state.status = 'updating';
     try {
       const result = await fetcher.pull();
@@ -81,9 +86,19 @@ export function createWebhookRouter(options: {
 
       // Call the content update callback (cache invalidation, nav regen, Anvil reindex)
       if (options.onContentUpdated) {
-        await options.onContentUpdated(result.changedFiles, result.isInitialClone);
+        try {
+          await options.onContentUpdated(result.changedFiles, result.isInitialClone);
+        } catch (updateError: any) {
+          // Rollback to last-known-good
+          if (snapshotRef) {
+            await fetcher.restoreRef(snapshotRef);
+            console.error('[webhook] Content update callback failed, rolled back:', updateError);
+          }
+          throw updateError; // Re-throw to set error state
+        }
       }
 
+      state.contentRef = result.ref;
       state.status = 'ok';
       state.lastError = null;
       console.log(`[webhook] Content update complete: ${result.ref.substring(0, 8)}`);

--- a/packages/site/src/components/ContentStatusBanner.tsx
+++ b/packages/site/src/components/ContentStatusBanner.tsx
@@ -1,0 +1,55 @@
+import { useState, useEffect } from 'react';
+
+interface ContentStatus {
+  status: 'idle' | 'updating' | 'ok' | 'error';
+  lastUpdate: string | null;
+  lastError: string | null;
+}
+
+export default function ContentStatusBanner() {
+  const [status, setStatus] = useState<ContentStatus | null>(null);
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    fetch('/api/content/status')
+      .then(res => res.json())
+      .then(setStatus)
+      .catch(() => {}); // Silently fail — banner is non-critical
+  }, []);
+
+  if (!status || status.status !== 'error' || dismissed) return null;
+
+  return (
+    <div style={{
+      background: '#fef2f2',
+      border: '1px solid #fecaca',
+      borderRadius: '8px',
+      padding: '12px 16px',
+      margin: '0 0 16px 0',
+      display: 'flex',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      fontSize: '14px',
+      color: '#991b1b',
+    }}>
+      <span>
+        ⚠️ Content update failed{status.lastUpdate ? ` at ${new Date(status.lastUpdate).toLocaleString()}` : ''} 
+        {status.lastError ? ` — ${status.lastError}` : ''}
+      </span>
+      <button
+        onClick={() => setDismissed(true)}
+        style={{
+          background: 'none',
+          border: 'none',
+          cursor: 'pointer',
+          fontSize: '18px',
+          color: '#991b1b',
+          padding: '0 4px',
+        }}
+        aria-label="Dismiss"
+      >
+        ×
+      </button>
+    </div>
+  );
+}

--- a/packages/site/src/layouts/DocLayout.astro
+++ b/packages/site/src/layouts/DocLayout.astro
@@ -8,6 +8,7 @@ import PlayAllManager from '../components/PlayAllManager.tsx';
 import TtsControlsBar from '../components/TtsControlsBar.tsx';
 import AnnotationThread from '../components/AnnotationThread.tsx';
 import CommentDraft from '../components/CommentDraft.tsx';
+import ContentStatusBanner from '../components/ContentStatusBanner.tsx';
 
 import TokenModal from '../components/TokenModal.tsx';
 import AuthIndicator from '../components/AuthIndicator.tsx';
@@ -68,6 +69,7 @@ const pageTitle = title === 'Foundry' ? title : `${title} — Foundry`;
       <Breadcrumbs currentPath={currentPath} />
 
       <article class="content">
+        <ContentStatusBanner client:load />
         <slot />
         <TtsSectionManager client:load />
         <PlayAllManager client:load />


### PR DESCRIPTION
## FND-E8-F3-S3: Error Handling + Content Status

### Changes
1. **Content fetcher** — added `snapshotRef()` and `restoreRef()` methods for rollback capability
2. **Webhook route** — snapshots ref before pull, rolls back on callback failure, added `contentRef` to state
3. **ContentStatusBanner** — new React component showing dismissable error banner when content updates fail
4. **DocLayout** — integrated banner before content slot

### Verification
- `packages/api` build ✅
- `packages/site` build ✅