### PR TITLE
fix: update docker-compose, .env.example, and README for SSR architecture

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,16 +1,33 @@
 # Foundry Environment Variables
 # Copy to .env and fill in values
 
-# GitHub token for fetching private repos during build
-GITHUB_TOKEN=
+# --- Runtime Content Fetching ---
+# Git repo URL for docs content (SSH or HTTPS)
+# e.g. git@github.com:danhannah94/csdlc-docs.git (SSH w/ deploy key)
+# e.g. https://github.com/danhannah94/csdlc-docs.git (HTTPS, public only)
+CONTENT_REPO=
 
+# Branch to track (default: main)
+CONTENT_BRANCH=main
+
+# Base64-encoded SSH deploy key for private repo access
+# Generate with: cat ~/.ssh/deploy_key | base64 -w0
+DEPLOY_KEY_B64=
+
+# --- GitHub Webhook ---
+# Secret for verifying GitHub webhook signatures
+# Generate with: openssl rand -hex 32
+WEBHOOK_SECRET=
+
+# --- Auth ---
 # Bearer token for API write protection (annotations/reviews)
 # Generate with: openssl rand -hex 32
 # If unset, auth is disabled (dev mode)
 FOUNDRY_WRITE_TOKEN=
 
-# Server port (default: 3001)
-# PORT=3001
+# --- Server ---
+# Proxy port (default: 4321)
+# PORT=4321
 
-# Database path (default: ./foundry.db)
+# Database path (default: /data/foundry.db in Docker, ./foundry.db local)
 # FOUNDRY_DB_PATH=./foundry.db

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ A documentation platform built for human-AI collaborative workflows. One source 
 
 ## Features
 
-- **Multi-repo content sourcing** — pull markdown from any GitHub repo at build time
+- **Runtime content fetching** — clones docs from GitHub at startup, updates via webhook on push
+- **SSR rendering** — Astro server-side rendering for dynamic markdown pages
+- **Filesystem-based navigation** — sidebar auto-generated from content directory structure and frontmatter
 - **Public/private access control** — open methodology docs, gated project docs
 - **Annotations + unified review thread** — highlight text, comment, threaded replies
 - **Bearer token auth** — protects write operations and private content
@@ -12,6 +14,23 @@ A documentation platform built for human-AI collaborative workflows. One source 
 - **MCP server** — AI agents can search, read, and annotate docs via Model Context Protocol
 - **TTS playback** — read docs aloud via Web Speech API
 - **Dark/light theme** — system-aware with manual toggle
+
+## Architecture
+
+Foundry runs two processes behind a single port:
+
+```
+Port 4321 (proxy)
+├── /api/*  → Express API (port 3001, internal)
+├── /mcp/*  → Express API (MCP endpoints)
+└── /*      → Astro SSR (dynamic page rendering)
+```
+
+On startup:
+1. Express API starts on port 3001, clones the configured content repo via `ContentFetcher`
+2. Anvil indexes the markdown for semantic search
+3. Node proxy starts on port 4321, routing requests to API or Astro SSR
+4. GitHub webhook triggers pull + reindex on push events — no rebuild needed
 
 ## Quick Start
 
@@ -23,13 +42,35 @@ cd foundry
 npm install
 ```
 
-### 2. Configure content sources
+### 2. Configure environment
 
 ```bash
-cp foundry.config.example.yaml foundry.config.yaml
+cp .env.example .env
 ```
 
-Edit `foundry.config.yaml` to point at your doc repos:
+Edit `.env` with your values:
+
+```env
+# Content source — your docs repo
+CONTENT_REPO=https://github.com/your-org/your-docs.git
+CONTENT_BRANCH=main
+
+# For private repos, use SSH + deploy key:
+# CONTENT_REPO=git@github.com:your-org/your-docs.git
+# DEPLOY_KEY_B64=<base64-encoded private key>
+
+# GitHub webhook secret (for auto-updates on push)
+WEBHOOK_SECRET=<openssl rand -hex 32>
+
+# API write protection (annotations/reviews)
+FOUNDRY_WRITE_TOKEN=<openssl rand -hex 32>
+```
+
+**Private repo setup** — see [Deploy Key Setup](#deploy-key-setup-private-repos) below.
+
+### 3. Configure content sources (optional)
+
+Edit `foundry.config.yaml` to define access control per path:
 
 ```yaml
 sources:
@@ -39,97 +80,148 @@ sources:
       - "docs/public/"
     access: public
 
-  - repo: your-org/internal-docs
+  - repo: your-org/docs-repo
     branch: main
     paths:
       - "docs/projects/"
     access: private
 ```
 
-For private repos, set `GITHUB_TOKEN`:
-```bash
-export GITHUB_TOKEN=$(gh auth token)
-```
+### 4. Run with Docker (recommended)
 
-### 3. Configure navigation
-
-Edit `nav.yaml` to define your sidebar structure. See the existing file for format.
-
-### 4. Set up environment
-
-```bash
-cp .env.example .env
-# Generate a write token for auth:
-echo "FOUNDRY_WRITE_TOKEN=$(openssl rand -hex 32)" >> .env
-```
-
-### 5. Run locally
-
-**Dev mode (hot reload):**
-```bash
-# Terminal 1: API server
-cd packages/api && npm run dev
-
-# Terminal 2: Site
-cd packages/site && npm run dev
-```
-Site: `http://localhost:4321/foundry` | API: `http://localhost:3001`
-
-**Docker:**
 ```bash
 docker compose up --build -d
 ```
-Everything on `http://localhost:3001/foundry/`
+
+Site available at `http://localhost:4321`
+
+### 5. Run locally (dev mode)
+
+```bash
+# Terminal 1: API server (port 3001)
+cd packages/api && npm run dev
+
+# Terminal 2: Astro site (port 4321, proxies /api to 3001)
+cd packages/site && npm run dev
+```
+
+Site: `http://localhost:4321` | API: `http://localhost:3001`
 
 ### 6. Deploy to Fly.io
 
 ```bash
 fly launch
+fly secrets set CONTENT_REPO=git@github.com:your-org/docs.git
+fly secrets set CONTENT_BRANCH=main
+fly secrets set DEPLOY_KEY_B64=$(cat ~/.ssh/foundry_deploy_key | base64 -w0)
+fly secrets set WEBHOOK_SECRET=$(openssl rand -hex 32)
 fly secrets set FOUNDRY_WRITE_TOKEN=$(openssl rand -hex 32)
-fly deploy --remote-only --build-arg GITHUB_TOKEN=$(gh auth token)
+fly deploy --remote-only
 ```
+
+## Deploy Key Setup (Private Repos)
+
+If your content repo is private, Foundry uses an SSH deploy key to clone it at runtime.
+
+**1. Generate the key:**
+```bash
+ssh-keygen -t ed25519 -C "foundry-deploy-key" -f ~/.ssh/foundry_deploy_key -N ""
+```
+
+**2. Add the public key to your docs repo:**
+
+Go to your docs repo → Settings → Deploy keys → Add deploy key:
+- **Title:** `Foundry content fetcher`
+- **Key:** contents of `~/.ssh/foundry_deploy_key.pub`
+- **Allow write access:** unchecked (read-only)
+
+**3. Base64-encode the private key:**
+```bash
+cat ~/.ssh/foundry_deploy_key | base64 -w0
+```
+
+**4. Add to `.env`:**
+```env
+CONTENT_REPO=git@github.com:your-org/your-docs.git
+DEPLOY_KEY_B64=<paste base64 string>
+```
+
+## GitHub Webhook Setup (Auto-Updates)
+
+When you push to the docs repo, Foundry can automatically pull changes and reindex.
+
+Go to your docs repo → Settings → Webhooks → Add webhook:
+- **Payload URL:** `https://<your-foundry-url>/api/webhooks/content-update`
+- **Content type:** `application/json`
+- **Secret:** same value as `WEBHOOK_SECRET` in your `.env`
+- **Events:** Just the push event
+
+## Content Structure
+
+Foundry expects your docs repo to have a `docs/` directory at the root:
+
+```
+your-docs-repo/
+├── docs/
+│   ├── index.md              # Root page
+│   ├── getting-started.md    # Top-level page
+│   ├── guides/
+│   │   ├── index.md          # Section landing page
+│   │   └── first-guide.md
+│   └── reference/
+│       └── api.md
+└── mkdocs.yml                # (ignored by Foundry)
+```
+
+**Navigation** is auto-generated from the filesystem. Control ordering and titles with frontmatter:
+
+```yaml
+---
+title: My Page Title
+nav_title: Short Nav Title   # Optional: shorter title for sidebar
+order: 1                     # Optional: sort order (lower = higher)
+---
+```
+
+Pages without `order` are sorted alphabetically after ordered pages.
 
 ## Project Structure
 
 ```
 foundry/
 ├── packages/
-│   ├── site/               # Astro static site (React islands)
+│   ├── site/                 # Astro SSR site (React islands)
 │   │   ├── src/
-│   │   │   ├── layouts/    # Page layouts
-│   │   │   ├── pages/      # Route pages
-│   │   │   ├── components/ # UI components (auth, comments, TTS)
-│   │   │   └── styles/     # Global CSS
-│   │   └── content/        # Markdown docs (populated at build time)
-│   └── api/                # Express API server
+│   │   │   ├── layouts/      # Page layouts
+│   │   │   ├── pages/        # Route pages (dynamic [...slug].astro)
+│   │   │   ├── components/   # UI components (auth, comments, TTS)
+│   │   │   ├── utils/        # Nav builder, page cache, markdown renderer
+│   │   │   └── styles/       # Global CSS
+│   │   └── content/          # Docs cloned here at runtime
+│   └── api/                  # Express API server
 │       └── src/
-│           ├── routes/     # REST endpoints
-│           ├── middleware/  # Auth middleware
-│           └── mcp/        # MCP server + tools
-├── foundry.config.yaml     # Content source repos (your config)
-├── nav.yaml                # Sidebar navigation tree
+│           ├── routes/       # REST endpoints (docs, search, webhook, etc.)
+│           ├── middleware/    # Auth middleware
+│           ├── mcp/          # MCP server + tools
+│           └── content-fetcher.ts  # Git clone/pull manager
 ├── scripts/
-│   └── build.sh            # Multi-repo content fetcher
-├── Dockerfile              # Multi-stage production build
-├── docker-compose.yml      # Local Docker setup
-└── fly.toml                # Fly.io deployment config
+│   ├── start.sh              # Container entrypoint (API + proxy)
+│   └── proxy.mjs             # Production proxy (port 4321)
+├── foundry.config.yaml       # Content access control config
+├── Dockerfile                # Multi-stage production build
+├── docker-compose.yml        # Local Docker setup
+└── fly.toml                  # Fly.io deployment config
 ```
-
-## How It Works
-
-1. **Build time:** `scripts/build.sh` reads `foundry.config.yaml`, clones repos, copies specified paths into `packages/site/content/`, and generates `.access.json` for access control
-2. **Astro** builds the markdown into static HTML pages
-3. **Express** serves the static site + REST API + MCP endpoints
-4. **Anvil** indexes the markdown for semantic search (local embeddings via ONNX)
-5. **Auth** gates private docs in the nav sidebar and protects write endpoints
 
 ## API Endpoints
 
 | Endpoint | Auth | Description |
 |----------|------|-------------|
+| `GET /api/content/status` | No | Content fetch status + current ref |
 | `GET /api/health` | No | Server status + Anvil stats |
 | `GET /api/access` | No | Access level map |
 | `GET /api/search?q=...` | Optional | Semantic search (private results need token) |
+| `POST /api/webhooks/content-update` | Webhook secret | GitHub push webhook |
 | `GET /api/annotations?doc_path=...` | Yes | List annotations for a doc |
 | `POST /api/annotations` | Yes | Create annotation |
 | `PATCH /api/annotations/:id` | Yes | Update annotation status/content |
@@ -142,7 +234,7 @@ Auth: `Authorization: Bearer <FOUNDRY_WRITE_TOKEN>`
 
 | Layer | Choice |
 |-------|--------|
-| Site | Astro 6 + React 19 islands |
+| Site | Astro 6 (SSR) + React 19 islands |
 | API | Express + TypeScript |
 | Search | Anvil (sqlite-vss + ONNX embeddings) |
 | AI Integration | Model Context Protocol (MCP) |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,16 +2,23 @@ services:
   foundry:
     build:
       context: .
-      args:
-        GITHUB_TOKEN: ${GITHUB_TOKEN:-}
     ports:
-      - "${PORT:-3001}:3001"
+      - "${PORT:-4321}:4321"
     volumes:
       - foundry-data:/data
     environment:
-      - PORT=3001
+      # Proxy serves on 4321 (Astro SSR + API routing)
+      - PORT=4321
       - FOUNDRY_DB_PATH=/data/foundry.db
       - NODE_ENV=production
+      # Runtime content fetching from GitHub
+      - CONTENT_REPO=${CONTENT_REPO:-}
+      - CONTENT_BRANCH=${CONTENT_BRANCH:-main}
+      # Deploy key for private repo access (base64-encoded)
+      - DEPLOY_KEY_B64=${DEPLOY_KEY_B64:-}
+      - DEPLOY_KEY_PATH=/root/.ssh/deploy_key
+      # GitHub webhook secret for content updates
+      - WEBHOOK_SECRET=${WEBHOOK_SECRET:-}
       # Bearer token for API write protection (annotations/reviews)
       # If unset, auth is disabled (dev mode)
       - FOUNDRY_WRITE_TOKEN=${FOUNDRY_WRITE_TOKEN:-}


### PR DESCRIPTION
## Summary

Updates the local dev/deploy config files to match the SSR + runtime content fetching architecture introduced in the FND-E8 epic.

## Changes

### `docker-compose.yml`
- Port mapping: `3001:3001` → `4321:4321` (proxy is the entry point)
- Removed stale `GITHUB_TOKEN` build arg
- Added env vars: `CONTENT_REPO`, `CONTENT_BRANCH`, `DEPLOY_KEY_B64`, `DEPLOY_KEY_PATH`, `WEBHOOK_SECRET`

### `.env.example`
- Removed stale `GITHUB_TOKEN` and `PORT=3001`
- Added all runtime content fetching vars with inline documentation
- Added webhook and deploy key config sections

### `README.md`
- Full rewrite reflecting current SSR architecture
- Architecture diagram: single-port proxy → API + Astro SSR
- Deploy key setup guide (private repo access)
- GitHub webhook setup guide (auto-updates on push)
- Content structure documentation (frontmatter, nav generation)
- Updated project structure, API endpoints, and Quick Start

Closes #62