### PR TITLE
chore(deps): bump @claymore-dev/anvil to ^0.1.12 (closes #109)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -685,9 +685,9 @@
       }
     },
     "node_modules/@claymore-dev/anvil": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/@claymore-dev/anvil/-/anvil-0.1.11.tgz",
-      "integrity": "sha512-1rHOv6EC5bTdtVZnrGRd/KjWoCBq6KJThUgWNmn2HT3bagpT/4EiPa5JCJPQZIx8wLkNidhc8qy752CW8wtK1A==",
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/@claymore-dev/anvil/-/anvil-0.1.12.tgz",
+      "integrity": "sha512-en2KccgSe0i6HHMl+KlxvywshtapyyfKKtP5l59MOY6M18V9i2l453plG8FVVk8GHqWa+rc/mPhUh1dXcMQi9g==",
       "license": "MIT",
       "dependencies": {
         "@huggingface/transformers": "^3.8.1",
@@ -11688,7 +11688,7 @@
       "name": "@foundry/api",
       "version": "0.2.0",
       "dependencies": {
-        "@claymore-dev/anvil": "^0.1.11",
+        "@claymore-dev/anvil": "^0.1.12",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@paralleldrive/cuid2": "^3.3.0",
         "better-sqlite3": "^12.8.0",
@@ -11696,6 +11696,9 @@
         "express": "^4.18.2",
         "gray-matter": "^4.0.3",
         "js-yaml": "^4.1.0"
+      },
+      "bin": {
+        "foundry": "dist/cli.js"
       },
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.13",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -15,7 +15,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@claymore-dev/anvil": "^0.1.11",
+    "@claymore-dev/anvil": "^0.1.12",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@paralleldrive/cuid2": "^3.3.0",
     "better-sqlite3": "^12.8.0",


### PR DESCRIPTION
## Summary

Bumps `@claymore-dev/anvil` from `^0.1.11` to `^0.1.12`. The new release contains the indexer ordinal-staleness fix from [danhannah94/anvil#19](https://github.com/danhannah94/anvil/pull/19), which is the actual root cause of #109.

## What this fixes

#109's original repro: bulk-pushing a multi-section markdown doc through `insert_section` produced documents whose section trees, viewed via `get_page`, looked structurally wrong — sections re-parented under the wrong parents, headings showing in the wrong order. The original issue body confidently blamed Foundry's `section-parser.ts`. **That diagnosis was wrong.**

Real root cause: Anvil's `Indexer.indexFile` was skipping `upsertChunk` for chunks whose `chunk_id` and `content_hash` were unchanged, leaving them with stale `ordinal` values from the previous indexing pass. After mid-document inserts the DB had chunks with colliding ordinals, and `getChunksByFile`'s `ORDER BY ordinal` returned them in the wrong display order. **The file on disk was always correct** — only the cached chunk ordering was off.

The anvil fix re-syncs the ordinal even when content is unchanged (no re-embedding required). Foundry gets the fix transparently via the version bump.

## Companion PR

[foundry#113](https://github.com/danhannah94/foundry/pull/113) is a separate latent bug surfaced during the same investigation: `delete_section` was leaving descendant sections orphaned when their parent was deleted. Independent of this PR — can land in either order.

## Test plan

- [x] `npm install` clean against the published 0.1.12 release
- [x] Targeted parser + doc-crud tests pass against the new version (20 tests)
- [ ] Post-deploy: verify on prod foundry that `insert_section` produces correct `get_page` output for mid-document inserts
- [ ] After verification, comment on issue #109 with the corrected root cause and close

## New observability field

Anvil 0.1.12 adds `chunks_reordered` to `IndexResult`. The `reindex` MCP tool now returns this field. Useful for spot-checking that the fix is doing work in production.

## Notes

- One pre-existing extraneous lockfile entry (`../anvil` path ref from earlier local-link development) was left in place. Harmless but worth a separate cleanup pass at some point
- Anvil 0.1.12 was published manually because anvil's CI publish pipeline is currently broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)