### PR TITLE
feat(annotations): render review comments as GFM markdown

### DIFF
--- a/packages/site/src/components/AnnotationThread.tsx
+++ b/packages/site/src/components/AnnotationThread.tsx
@@ -2,6 +2,29 @@ import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { authFetch, isAuthenticated } from '../utils/api.js';
 import { getCleanHeadingText } from '../utils/heading-text.js';
 import { getDrafts, clearDrafts, deleteDraft, type DraftComment } from '../utils/draft-storage.js';
+import { unified } from 'unified';
+import remarkParse from 'remark-parse';
+import remarkGfm from 'remark-gfm';
+import remarkRehype from 'remark-rehype';
+import rehypeStringify from 'rehype-stringify';
+
+const markdownProcessor = unified()
+  .use(remarkParse)
+  .use(remarkGfm)
+  .use(remarkRehype) // IMPORTANT: do NOT pass { allowDangerousHtml: true } — default drops raw HTML nodes, which is our sanitization
+  .use(rehypeStringify);
+
+function renderMarkdown(content: string): string {
+  try {
+    return String(markdownProcessor.processSync(content));
+  } catch {
+    // Fallback to escaped plain text on parse error so we never break the panel
+    return content
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+  }
+}
 
 // Types (copied from API package)
 type AnnotationStatus = "draft" | "submitted" | "replied" | "resolved" | "orphaned";
@@ -970,9 +993,10 @@ export default function AnnotationThread({ docPath }: Props) {
               </blockquote>
             )}
 
-            <div className="thread-comment-content">
-              {annotation.content}
-            </div>
+            <div
+              className="thread-comment-content"
+              dangerouslySetInnerHTML={{ __html: renderMarkdown(annotation.content) }}
+            />
 
             {authenticated && !isResolved && !isOrphaned && (
               <button


### PR DESCRIPTION
## Summary
- Renders `annotation.content` in the review thread panel as GitHub-flavored markdown
- Uses the existing unified/remark/rehype stack already in `packages/site/package.json` — no new dependencies
- Raw HTML is dropped by `remark-rehype`'s default behavior, so comments cannot inject `<script>` or event-handler tags
- Applies to both top-level comments and flattened reply descendants
- Quoted text in the `thread-comment-quote` blockquote remains plain text

## Not in scope
- No changes to the draft editor in `CommentDraft.tsx` — markdown is render-only for now
- No preview pane in the editor
- No syntax highlighting for code blocks (can come later via `@shikijs/rehype` which is already a dep)

## Test plan
- [ ] Visual QA: bold, italic, inline code, links, bullet lists, numbered lists, code blocks, blockquotes render correctly
- [ ] Visual QA: raw HTML in a comment (e.g. `<script>alert(1)</script>`) renders as nothing (dropped) — NOT as escaped text and NOT as executed HTML
- [ ] Visual QA: task lists (`- [ ] thing`) render as checkboxes
- [ ] Regression: plain-text comments still render correctly (wrapped in `<p>` now)
- [ ] Regression: reply, resolve, submit, jump-to-annotation all still work