### PR TITLE
feat(test-env): dockerized foundry test env + FOUNDRY_DISABLE_ANVIL flag

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -292,29 +292,37 @@ async function startServer(): Promise<void> {
       console.log(`🌐 CORS enabled for GitHub Pages and localhost`);
       logAuthStatus();
 
-      // Kick off Anvil init in the background (non-blocking)
-      console.log('🔧 Starting deferred Anvil initialization...');
-      anvilHolder.init(docsPath)
-        .then(() => {
-          const anvil = anvilHolder.get();
-          if (anvil) {
-            console.log('📇 Running initial Anvil index (background)...');
-            return anvil.index()
-              .then((result: any) => {
-                console.log('✅ Anvil index complete:', result);
+      // Kick off Anvil init in the background (non-blocking).
+      // Opt out with FOUNDRY_DISABLE_ANVIL=1 — useful for constrained
+      // environments (e.g., emulated/QEMU builds that can't load the ONNX
+      // embedding model) where semantic search isn't needed. Anvil-dependent
+      // endpoints (health, search, reindex) already tolerate a null holder.
+      if (process.env.FOUNDRY_DISABLE_ANVIL === '1') {
+        console.log('🔇 Anvil disabled via FOUNDRY_DISABLE_ANVIL=1 (semantic search unavailable)');
+      } else {
+        console.log('🔧 Starting deferred Anvil initialization...');
+        anvilHolder.init(docsPath)
+          .then(() => {
+            const anvil = anvilHolder.get();
+            if (anvil) {
+              console.log('📇 Running initial Anvil index (background)...');
+              return anvil.index()
+                .then((result: any) => {
+                  console.log('✅ Anvil index complete:', result);
 
-                // Start file watcher after index completes (dev mode only)
-                if (process.env.NODE_ENV !== 'production') {
-                  import('./file-watcher.js')
-                    .then(({ startFileWatcher }) => startFileWatcher(docsPath, anvil))
-                    .catch((err: any) => console.warn('⚠️ File watcher failed to start:', err));
-                }
-              });
-          } else {
-            console.warn('⚠️ Anvil not available:', anvilHolder.error);
-          }
-        })
-        .catch((error: any) => console.error('⚠️ Anvil background init failed:', error));
+                  // Start file watcher after index completes (dev mode only)
+                  if (process.env.NODE_ENV !== 'production') {
+                    import('./file-watcher.js')
+                      .then(({ startFileWatcher }) => startFileWatcher(docsPath, anvil))
+                      .catch((err: any) => console.warn('⚠️ File watcher failed to start:', err));
+                  }
+                });
+            } else {
+              console.warn('⚠️ Anvil not available:', anvilHolder.error);
+            }
+          })
+          .catch((error: any) => console.error('⚠️ Anvil background init failed:', error));
+      }
     });
   } catch (error) {
     console.error('❌ Failed to start server:', error);

--- a/test-env/README.md
+++ b/test-env/README.md
@@ -1,0 +1,114 @@
+# test-env — Dockerized Foundry for Local QA
+
+A reproducible, parallel-safe Docker test environment for foundry. Boots a fresh foundry instance with deterministic seed data in about a minute (after the first build), on any port, isolated from your real dev state and from other running test instances.
+
+Built for:
+
+- **Manual QA** — click around a known-good foundry instance without polluting your real dev data
+- **Sub-agent QA pipelines** — give a QA agent (future: Crucible) a clean, deterministic target to screenshot and diff against
+- **Parallel testing** — run multiple sub-agents on different branches simultaneously without state collisions
+
+## Quick start
+
+```bash
+# Boot a new instance — random id + random port
+test-env/scripts/up.sh
+
+# Boot with an explicit instance id and port (for scripting)
+test-env/scripts/up.sh alpha 54321
+
+# Tear it down (use the id that up.sh printed)
+test-env/scripts/down.sh alpha
+
+# Reset in place (down + up with the same id)
+test-env/scripts/reset.sh alpha 54321
+```
+
+`up.sh` prints the URL and the exact `down.sh` command to tear it back down. Copy-paste friendly.
+
+## What gets seeded
+
+Every boot produces the same known state:
+
+- **One sample doc** at `projects/sample/design.md` (copied from `test-env/seed/fixtures/content/`)
+- **Five annotations** created via the real API:
+  - Two top-level comments on different sections
+  - A reply threaded under one of them
+  - A reply-to-a-reply (exercises flattened-descendant rendering)
+  - One resolved comment (exercises collapsed-resolved state)
+
+Because the seed runs through the actual API endpoints, the seed script is also a living integration test for the `/api/annotations` routes.
+
+## Parallel safety
+
+Multiple instances can run concurrently without collisions. Each gets:
+
+- Its own Docker containers, volumes, and network (namespaced via `COMPOSE_PROJECT_NAME=foundry-test-<id>`)
+- Its own SQLite database (lives in the namespaced named volume)
+- Its own host port (passed via the `PORT` env var)
+
+Example:
+
+```bash
+# Terminal 1
+test-env/scripts/up.sh alpha 54321
+
+# Terminal 2 (simultaneously, different id + different port)
+test-env/scripts/up.sh beta 54322
+```
+
+Both boot independently. Neither can see the other's annotations, docs, or DB. Teardown is per-instance — `down.sh alpha` leaves `beta` running.
+
+## How it works
+
+- **`compose.test.yml`** is a thin override of the production `docker-compose.yml`. It sets environment variables that disable the GitHub sync path, enable dev-mode auth, and add a healthcheck. The production `Dockerfile` is **not touched** — tests run the exact same image that ships to production.
+- **Markdown fixtures** live in `seed/fixtures/content/` and are copied into the container's `/data/docs` via `docker cp` after the container passes its healthcheck. The API's file watcher picks them up.
+- **Annotations + reviews** are created by `seed/fixture.mjs`, a plain Node script that calls the real API via `fetch()`. No TypeScript build step — it's ~80 lines of straight ESM.
+
+## First build will be slow
+
+The production `Dockerfile` is a multi-stage build with native module recompilation (`better-sqlite3`, `sqlite-vss`). Your first `up.sh` will take several minutes while Docker builds the image. **Subsequent runs hit the Docker layer cache and finish in ~30-60 seconds** — most of that is waiting for the API + Astro SSR to warm up.
+
+If you're using this for sub-agent pipelines, pre-building the image once (`docker compose -f docker-compose.yml -f test-env/compose.test.yml build`) before the first agent run amortizes the cost.
+
+## Customizing the seed
+
+- **Add markdown fixtures**: drop files into `seed/fixtures/content/` at the path they should appear in the app. Example: `seed/fixtures/content/projects/myproject/design.md` becomes available at `projects/myproject/design.md` inside the test env.
+- **Add annotations**: edit `seed/fixture.mjs`. It's plain ESM, uses `fetch()`, and each block is documented.
+
+Because the seed script runs against the real API, any valid request is fair game — annotations, reviews, edits, resolves. The only constraint is that the API must be healthy (which the up script guarantees before calling the seed).
+
+## Debugging
+
+### Container won't become healthy
+
+`up.sh` dumps the last 100 lines of container logs before exiting if the healthcheck doesn't pass within 90 seconds. Common causes:
+
+- **Port already in use** — try again with a different port
+- **Stale volume from a previous instance** — `down.sh <id>` first
+- **First build still going** — the 90s timer starts *after* the build completes, so this shouldn't happen on second runs
+
+### Watch logs on a running instance
+
+```bash
+COMPOSE_PROJECT_NAME=foundry-test-<id> \
+  docker compose -f docker-compose.yml -f test-env/compose.test.yml logs -f
+```
+
+### Inspect the container directly
+
+```bash
+docker exec -it $(docker compose \
+  -f docker-compose.yml -f test-env/compose.test.yml \
+  --project-name foundry-test-<id> \
+  ps -q foundry) sh
+```
+
+## Known limitations
+
+- **macOS / Linux only** — the scripts are bash. Windows: run through WSL.
+- **No CI integration yet** — this is for local dev and local sub-agents. CI wiring is a separate concern.
+- **Initial build is slow** — see above.
+- **Seed is static** — one fixture set for now. If you need alternate states, fork `fixture.mjs` into `fixture-<name>.mjs` and pass the filename to the up script (future enhancement).
+- **Anvil (semantic search) is disabled** — set via `FOUNDRY_DISABLE_ANVIL=1` in the compose override. The ONNX embedding model Anvil loads crashes under QEMU amd64 emulation on arm64 hosts, and search isn't needed for visual QA of the review panel. Health, docs, annotations, and reviews all work without it. If you need to exercise search specifically, this test env isn't the right tool — use the real dev server (`npm run dev`) against your local DB instead.
+- **Platform pinned to `linux/amd64`** — the production `Dockerfile` hard-codes a `sqlite-vss-linux-x64` path that doesn't exist on arm64 builds. Until that's fixed upstream, the test env runs through QEMU on Apple Silicon. Slower but correct. Tracked as a follow-up.

--- a/test-env/compose.test.yml
+++ b/test-env/compose.test.yml
@@ -1,0 +1,36 @@
+# Foundry test environment — Docker Compose override
+#
+# Use via test-env/scripts/up.sh — the wrapper handles COMPOSE_PROJECT_NAME and
+# PORT for parallel-safe multi-instance support. Don't invoke docker compose
+# with this file directly unless you know what you're doing.
+
+services:
+  foundry:
+    # Pin to linux/amd64 so the production Dockerfile's native-module setup
+    # works on Apple Silicon hosts. The Dockerfile hard-codes a
+    # sqlite-vss-linux-x64 path that doesn't exist on arm64 builds; until that
+    # is fixed upstream, we force amd64 here and pay the QEMU emulation tax.
+    platform: linux/amd64
+    environment:
+      - PORT=4321
+      - FOUNDRY_DB_PATH=/data/foundry.db
+      - CONTENT_DIR=/data/docs
+      - NODE_ENV=development
+      # Explicit unsets — prevents GitHub sync attempts and enables dev-mode auth
+      - DEPLOY_KEY_B64=
+      - SYNC_REMOTE_URL=
+      - FOUNDRY_WRITE_TOKEN=
+      - FOUNDRY_READ_TOKEN=
+      # Disable Anvil (semantic search) in the test env. The ONNX embedding
+      # model it loads aborts under QEMU amd64 emulation on arm64 hosts
+      # (std::bad_alloc), killing the API. Visual QA of the review panel
+      # doesn't need semantic search — health, docs, annotations, and
+      # reviews all work without it.
+      - FOUNDRY_DISABLE_ANVIL=1
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:4321/api/health || exit 1"]
+      interval: 2s
+      timeout: 2s
+      retries: 30
+      start_period: 10s
+    restart: "no"

--- a/test-env/scripts/down.sh
+++ b/test-env/scripts/down.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Tear down a foundry test env instance and remove its volume.
+#
+# Usage:
+#   test-env/scripts/down.sh <instance-id>
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <instance-id>"
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+cd "${REPO_ROOT}"
+
+INSTANCE_ID="$1"
+export COMPOSE_PROJECT_NAME="foundry-test-${INSTANCE_ID}"
+
+docker compose -f docker-compose.yml -f test-env/compose.test.yml down -v
+
+echo "✓ Torn down: ${INSTANCE_ID}"

--- a/test-env/scripts/reset.sh
+++ b/test-env/scripts/reset.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Convenience: tear down an instance and bring it back up with the same id.
+#
+# Usage:
+#   test-env/scripts/reset.sh <instance-id> [port]
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <instance-id> [port]"
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INSTANCE_ID="$1"
+PORT="${2:-}"
+
+"${SCRIPT_DIR}/down.sh" "${INSTANCE_ID}" || true
+
+if [[ -n "${PORT}" ]]; then
+  "${SCRIPT_DIR}/up.sh" "${INSTANCE_ID}" "${PORT}"
+else
+  "${SCRIPT_DIR}/up.sh" "${INSTANCE_ID}"
+fi

--- a/test-env/scripts/up.sh
+++ b/test-env/scripts/up.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Boot a foundry test env instance. Parallel-safe.
+#
+# Usage:
+#   test-env/scripts/up.sh                 # random id + random port
+#   test-env/scripts/up.sh alpha           # explicit id, random port
+#   test-env/scripts/up.sh alpha 54321     # explicit id and port
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+cd "${REPO_ROOT}"
+
+INSTANCE_ID="${1:-$(openssl rand -hex 4)}"
+PORT="${2:-$((40000 + RANDOM % 10000))}"
+
+export COMPOSE_PROJECT_NAME="foundry-test-${INSTANCE_ID}"
+export PORT
+
+COMPOSE_ARGS=(-f docker-compose.yml -f test-env/compose.test.yml)
+
+echo "→ Booting foundry test env"
+echo "  instance: ${INSTANCE_ID}"
+echo "  port:     ${PORT}"
+echo "  project:  ${COMPOSE_PROJECT_NAME}"
+
+docker compose "${COMPOSE_ARGS[@]}" up -d --build
+
+echo "→ Waiting for /api/health..."
+for i in $(seq 1 90); do
+  if curl -sf "http://localhost:${PORT}/api/health" >/dev/null 2>&1; then
+    echo "  healthy after ${i}s"
+    break
+  fi
+  if [[ $i -eq 90 ]]; then
+    echo "FAIL: container did not become healthy within 90s"
+    echo "─── last 100 log lines ───"
+    docker compose "${COMPOSE_ARGS[@]}" logs --tail 100 || true
+    exit 1
+  fi
+  sleep 1
+done
+
+echo "→ Copying fixture markdown into container..."
+CID=$(docker compose "${COMPOSE_ARGS[@]}" ps -q foundry)
+if [[ -z "${CID}" ]]; then
+  echo "FAIL: could not resolve container id"
+  exit 1
+fi
+docker cp "${REPO_ROOT}/test-env/seed/fixtures/content/." "${CID}:/data/docs/"
+
+echo "→ Triggering reindex..."
+if curl -sf -X POST "http://localhost:${PORT}/api/reindex" >/dev/null 2>&1; then
+  echo "  reindex accepted"
+else
+  echo "  (reindex call returned non-zero, continuing — file watcher may cover it)"
+fi
+
+echo "→ Running seed script..."
+FOUNDRY_BASE_URL="http://localhost:${PORT}" node "${REPO_ROOT}/test-env/seed/fixture.mjs"
+
+echo ""
+echo "✓ foundry test env ready"
+echo "  URL:      http://localhost:${PORT}"
+echo "  instance: ${INSTANCE_ID}"
+echo "  logs:     COMPOSE_PROJECT_NAME=${COMPOSE_PROJECT_NAME} docker compose ${COMPOSE_ARGS[*]} logs -f"
+echo "  teardown: test-env/scripts/down.sh ${INSTANCE_ID}"

--- a/test-env/seed/fixture.mjs
+++ b/test-env/seed/fixture.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+// Foundry test env seed script.
+//
+// Populates a fresh test instance with deterministic annotations via the real
+// API. Assumes markdown fixtures have already been copied into /data/docs and
+// the container is healthy. Dev-mode auth (no tokens) is required — set by the
+// test-env compose override.
+//
+// Required env:
+//   FOUNDRY_BASE_URL — e.g., http://localhost:54321
+
+const BASE = process.env.FOUNDRY_BASE_URL;
+if (!BASE) {
+  console.error('FOUNDRY_BASE_URL is required');
+  process.exit(1);
+}
+
+const DOC_PATH = 'projects/sample/design.md';
+
+async function api(method, path, body) {
+  const res = await fetch(`${BASE}${path}`, {
+    method,
+    headers: { 'Content-Type': 'application/json' },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`${method} ${path} → ${res.status}: ${text}`);
+  }
+  return res.json();
+}
+
+async function createAnnotation(fields) {
+  return api('POST', '/api/annotations', {
+    doc_path: DOC_PATH,
+    author_type: 'human',
+    ...fields,
+  });
+}
+
+async function main() {
+  console.log(`  base: ${BASE}`);
+  console.log(`  doc:  ${DOC_PATH}`);
+
+  // 1. Top-level on Overview — exercises the "single top-level comment" state
+  const a1 = await createAnnotation({
+    heading_path: '## Overview',
+    content: 'This section sets the stage. Consider adding a **one-line pitch** at the top for scannability.',
+    quoted_text: 'Sample Design Doc',
+    status: 'submitted',
+  });
+  console.log(`  ✓ a1 (top-level on Overview):      ${a1.id}`);
+
+  // 2. Top-level on Architecture — will become the root of a reply thread
+  const a2 = await createAnnotation({
+    heading_path: '## Architecture',
+    content: 'What are the *boundaries* between the layers here? The current prose is a bit hand-wavy.',
+    quoted_text: 'Architecture',
+    status: 'submitted',
+  });
+  console.log(`  ✓ a2 (top-level on Architecture):  ${a2.id}`);
+
+  // 3. Reply to a2 — AI author, exercises the threaded-reply render path
+  const a3 = await createAnnotation({
+    author_type: 'ai',
+    heading_path: '## Architecture',
+    parent_id: a2.id,
+    content:
+      'Good question. The architecture has three layers:\n\n' +
+      '- **Frontend**: site + review panel\n' +
+      '- **API**: Express + SQLite\n' +
+      '- **MCP**: stdio protocol for agent access',
+    status: 'submitted',
+  });
+  console.log(`  ✓ a3 (reply to a2):                ${a3.id}`);
+
+  // 4. Reply-to-reply — exercises the flattened-descendant render path we
+  //    intentionally designed for in PR #124's grouping code
+  const a4 = await createAnnotation({
+    heading_path: '## Architecture',
+    parent_id: a3.id,
+    content: 'Thanks — that helps. Where does auth fit into the API layer?',
+    status: 'submitted',
+  });
+  console.log(`  ✓ a4 (reply to a3):                ${a4.id}`);
+
+  // 5. Resolved — exercises the collapsed-resolved render path
+  const a5 = await createAnnotation({
+    heading_path: '## Open Questions',
+    content: 'I figured this one out on my own — resolving.',
+    status: 'resolved',
+  });
+  console.log(`  ✓ a5 (resolved on Open Questions): ${a5.id}`);
+
+  console.log('');
+  console.log('  seeded 5 annotations on', DOC_PATH);
+}
+
+main().catch((err) => {
+  console.error('SEED FAILED:', err.message);
+  process.exit(1);
+});

--- a/test-env/seed/fixtures/content/projects/sample/design.md
+++ b/test-env/seed/fixtures/content/projects/sample/design.md
@@ -1,0 +1,35 @@
+# Sample Design Doc
+
+> A deterministic fixture for the foundry test environment.
+
+This document exists purely to give the foundry API something to anchor test annotations on. The content is intentionally minimal — what matters is that the sections below exist so the seed script can create deterministic comments against known heading paths.
+
+## Overview
+
+This section sets the stage. It's short on purpose. A real design doc would include a one-line pitch, the problem statement, the proposed approach, and a rough scope. This one does not — it's a fixture, not a real doc.
+
+The test env's seed script attaches a top-level comment to this section. If you're manually QAing the review panel, you should see a single comment here with the text *"This section sets the stage. Consider adding a one-line pitch at the top for scannability."*
+
+## Architecture
+
+The architecture of this fixture is deliberately trivial:
+
+- **One layer**: this document
+- **No dependencies**: it doesn't reference anything
+- **No implementation**: just words
+
+This section is the **root of a reply thread** in the seeded state. It has:
+
+1. A top-level comment asking about layer boundaries
+2. An AI reply that lists three layers (frontend, API, MCP)
+3. A human reply-to-reply asking where auth fits
+
+The reply-to-reply is the important one — it exercises the flattened-descendant rendering path in `AnnotationThread.tsx` that was fixed in PR #124. If you expand the thread and see three nested-looking comments under the top-level, the render path is working.
+
+## Open Questions
+
+- What color should the example button be?
+- How many fields does the example form need?
+- Does the example section need a subsection?
+
+These are intentionally trivial. **One of them has a resolved comment attached in the seeded state** — exercising the collapsed-resolved rendering. Click to expand to see the comment text.


### PR DESCRIPTION
## Summary
Adds \`test-env/\` — a **reusable, parallel-safe Docker test environment** for foundry. One command boots a deterministic foundry instance isolated from dev state and from other concurrent test instances. The seed runs through the real API, so it doubles as a living integration test of the annotations routes.

Also adds a \`FOUNDRY_DISABLE_ANVIL=1\` opt-out for Anvil (semantic search) initialization — required for the test env to boot under QEMU amd64 emulation on Apple Silicon hosts.

## What lands

### \`test-env/\` (new)
- **\`compose.test.yml\`** — thin override of production \`docker-compose.yml\`. Pins \`platform: linux/amd64\` (see limitations), sets dev-mode env vars (auth off, no GitHub sync), disables Anvil, adds healthcheck. Production \`Dockerfile\` is **not touched** — tests run the same image that ships.
- **\`scripts/up.sh\`** — boot a parallel-safe instance. Handles \`COMPOSE_PROJECT_NAME\`, port allocation, healthcheck wait, fixture copy via \`docker cp\`, reindex trigger, and seed script. Supports explicit \`<id> <port>\` args or random defaults.
- **\`scripts/down.sh\`** / **\`scripts/reset.sh\`** — teardown with volume removal / down-then-up in place.
- **\`seed/fixture.mjs\`** — plain ESM Node script. Creates 5 annotations via the real API: two top-level, a reply, a reply-to-a-reply (exercises flattened-descendant rendering from PR #124), and one resolved (exercises collapsed-resolved state). Also serves as a smoke test for the annotations routes.
- **\`seed/fixtures/content/projects/sample/design.md\`** — minimal fixture doc with the three sections the seed script anchors on.
- **\`README.md\`** — quickstart, parallel-safety explanation, how it works, customization, debugging, known limitations.

### \`packages/api/src/index.ts\` (modified)
- Adds \`FOUNDRY_DISABLE_ANVIL=1\` env gate around the deferred Anvil init block. When set, Anvil init is skipped entirely; \`AnvilHolder.get()\` returns null; routes that depend on Anvil (health, docs, search, reindex) already tolerate that null via existing code paths.
- 31 insertions, 23 deletions — the diff is larger than the logical change because the existing block gets re-indented inside the new \`if\`. Logic is unchanged except for the gate.

## Parallel-safety (verified)

Two instances booted simultaneously as the smoke test:

\`\`\`
test-env/scripts/up.sh smoketest 54321    # → http://localhost:54321
test-env/scripts/up.sh parallel  54322    # → http://localhost:54322
\`\`\`

Verified independently:
- Separate containers (\`foundry-test-smoketest-foundry-1\`, \`foundry-test-parallel-foundry-1\`)
- Separate named volumes (\`foundry-test-smoketest_foundry-data\`, \`foundry-test-parallel_foundry-data\`)
- Separate networks
- Separate SQLite DBs — each instance had 5 annotations with completely different IDs, neither visible to the other
- Teardown of one instance leaves the other running

Mechanism: \`COMPOSE_PROJECT_NAME=foundry-test-<id>\` namespaces all resources; dynamic \`PORT\` env var parameterizes the host port. Both are set by \`up.sh\` before invoking compose.

## Known limitations (documented in README)

- **macOS / Linux only** — scripts are bash.
- **Platform pinned to \`linux/amd64\`** — the production Dockerfile hard-codes a \`sqlite-vss-linux-x64\` path that doesn't exist on arm64 builds. Until that's fixed, Apple Silicon hosts run the test env through QEMU (slower but correct). See follow-up issue in test plan.
- **Anvil disabled** — \`FOUNDRY_DISABLE_ANVIL=1\` is set by default in the test env because the ONNX embedding model aborts under QEMU amd64 emulation (\`std::bad_alloc\`), killing the API. Visual QA of the review panel doesn't need semantic search. Health, docs, annotations, and reviews all work.
- **No CI integration yet** — invoked by humans and sub-agents locally.
- **Static seed** — one fixture set for now.

## Test plan

- [x] \`test-env/scripts/up.sh smoketest 54321\` — container boots, healthy in ~7s, 5 annotations seeded, \`GET /api/annotations\` returns them
- [x] Second instance \`test-env/scripts/up.sh parallel 54322\` running concurrently — no collisions, independent state, separate volumes
- [x] \`test-env/scripts/down.sh smoketest\` — tears down only the smoketest instance, parallel still running
- [x] \`test-env/scripts/down.sh parallel\` — final teardown, zero leaked volumes
- [x] API stable after seed (previous run had Anvil crashing the process post-seed — confirmed fixed by \`FOUNDRY_DISABLE_ANVIL=1\`)
- [ ] **Manual visual QA on next session**: point a browser at \`http://localhost:<port>\` after \`up.sh\` and confirm the seeded annotations render correctly in the review panel — the reply-to-reply exercises the flattened-descendant rendering that was the focus of PR #124

## Follow-ups to file after merge

1. **Dockerfile arm64 support** — the current \`Dockerfile\` hard-codes \`sqlite-vss-linux-x64\`, which breaks local builds on Apple Silicon without the \`platform: linux/amd64\` workaround. Real fix is a conditional or a multi-arch installation of the right sqlite-vss package. Not blocking this PR; worth its own investigation.
2. **Anvil-under-QEMU investigation** — confirm the \`std::bad_alloc\` is specifically a QEMU/ONNX-runtime interaction rather than a genuine resource issue. If it's the former, it'd be unblocked by the Dockerfile fix above (native arm64 → no QEMU). If the latter, Anvil needs an investigation for memory-constrained environments.
3. **Anvil-dependent route graceful degradation** — verify that \`/api/search\` and \`/api/reindex\` return sensible errors (not 500s) when Anvil is disabled. Health already handles it correctly.