### PR TITLE
Right-align reply buttons in thread review panel

### DIFF
--- a/packages/site/src/styles/global.css
+++ b/packages/site/src/styles/global.css
@@ -1305,6 +1305,7 @@ pre.mermaid {
   gap: 4px;
   padding: 4px 8px;
   margin-top: 4px;
+  margin-left: auto;
   font-size: var(--font-size-xs);
   color: var(--color-text-muted);
   background: none;
@@ -1324,6 +1325,7 @@ pre.mermaid {
   gap: 4px;
   padding: 4px 8px;
   margin-top: 4px;
+  margin-left: auto;
   background: transparent;
   color: var(--color-text-muted);
   font-size: 0.75rem;


### PR DESCRIPTION
## Summary
- Adds `margin-left: auto` to `.thread-reply-btn-bottom` and `.thread-comment-reply-btn` in global.css
- Pushes reply buttons to the right side of the annotation thread panel, creating clear visual separation from the "Reply to thread" button

## Test plan
- [ ] Open an annotation thread with multiple comments
- [ ] Verify per-comment reply buttons are right-aligned
- [ ] Verify the bottom "Reply to thread" button is right-aligned
- [ ] Confirm no layout regressions in the thread panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)