### PR TITLE
fix(api): default annotation replies to submitted status

### DIFF
--- a/packages/api/src/routes/__tests__/annotations.test.ts
+++ b/packages/api/src/routes/__tests__/annotations.test.ts
@@ -208,6 +208,39 @@ describe('Annotations Router', () => {
       expect(res.body.status).toBe('submitted');
     });
 
+    it('should default status to submitted for human reply with parent_id', async () => {
+      const parent = await request(app)
+        .post('/api/annotations')
+        .set("Authorization", "Bearer test-token")
+        .send(validBody({ author_type: 'human' }))
+        .expect(201);
+
+      const reply = await request(app)
+        .post('/api/annotations')
+        .set("Authorization", "Bearer test-token")
+        .send(validBody({ author_type: 'human', parent_id: parent.body.id, content: 'human reply' }))
+        .expect(201);
+
+      expect(reply.body.parent_id).toBe(parent.body.id);
+      expect(reply.body.status).toBe('submitted');
+    });
+
+    it('should default status to submitted for ai reply with parent_id', async () => {
+      const parent = await request(app)
+        .post('/api/annotations')
+        .set("Authorization", "Bearer test-token")
+        .send(validBody({ author_type: 'human' }))
+        .expect(201);
+
+      const reply = await request(app)
+        .post('/api/annotations')
+        .set("Authorization", "Bearer test-token")
+        .send(validBody({ author_type: 'ai', parent_id: parent.body.id, content: 'ai reply' }))
+        .expect(201);
+
+      expect(reply.body.status).toBe('submitted');
+    });
+
     it('should use explicit status when provided, regardless of author_type', async () => {
       const res = await request(app)
         .post('/api/annotations')

--- a/packages/api/src/routes/annotations.ts
+++ b/packages/api/src/routes/annotations.ts
@@ -165,11 +165,13 @@ export function createAnnotationsRouter(): Router {
 
       const normalizedDocPath = normalizeDocPath(doc_path);
 
-      // Determine status: explicit body value wins; otherwise default by author_type
+      // Determine status: explicit body value wins; otherwise replies (parent_id set)
+      // and AI-authored annotations auto-submit. Top-level human annotations start
+      // as drafts awaiting explicit submit.
       const effectiveStatus: AnnotationStatus =
         bodyStatus !== undefined
           ? bodyStatus
-          : author_type === 'ai'
+          : parent_id || author_type === 'ai'
           ? 'submitted'
           : 'draft';
 


### PR DESCRIPTION
## Summary

- Replies (annotations with `parent_id` set) from human authors were defaulting to `status: 'draft'` instead of `'submitted'`
- This made UI-created replies invisible to the `/reply` and `/update` skills, which filter by `submitted`/`replied` status
- Fix: default any annotation with `parent_id` set to `'submitted'`, regardless of `author_type`

## Root cause

[packages/api/src/routes/annotations.ts:169-174](https://github.com/danhannah94/foundry/blob/fix/annotation-reply-status/packages/api/src/routes/annotations.ts#L169-L174) — the status default only checked `author_type`, not `parent_id`:

```typescript
// Before
const effectiveStatus = bodyStatus !== undefined
  ? bodyStatus
  : author_type === 'ai' ? 'submitted' : 'draft';

// After
const effectiveStatus = bodyStatus !== undefined
  ? bodyStatus
  : parent_id || author_type === 'ai' ? 'submitted' : 'draft';
```

The MCP path accidentally worked because the MCP client defaults `author_type: 'ai'`. UI replies (human author, parent_id set) were getting stuck as drafts.

## Test plan

- [x] New test: human reply with `parent_id` → `status: 'submitted'`
- [x] New test: ai reply with `parent_id` → `status: 'submitted'`
- [x] Existing tests for top-level human → draft and explicit-status-override still pass
- [x] Typecheck clean
- [x] 3 pre-existing test failures in the file are unrelated (doc_path normalization — touches `.md` suffix handling, not status)

## Followup

~10 annotation rows in Foundry prod are already stuck as drafts from before this fix. Not migrated here — the orchestrator will promote them via `edit_annotation` separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)