### PR TITLE
test(api): realign stale assertions with current impl

### DIFF
--- a/packages/api/src/routes/__tests__/annotations.test.ts
+++ b/packages/api/src/routes/__tests__/annotations.test.ts
@@ -154,7 +154,7 @@ describe('Annotations Router', () => {
         .expect(201);
 
       expect(res.body.id).toMatch(CUID2_REGEX);
-      expect(res.body.doc_path).toBe(body.doc_path);
+      expect(res.body.doc_path).toBe('docs/process');
       expect(res.body.heading_path).toBe(body.heading_path);
       expect(res.body.content_hash).toBe(body.content_hash);
       expect(res.body.content).toBe(body.content);
@@ -291,14 +291,14 @@ describe('Annotations Router', () => {
       expect(res.body.error).toBeDefined();
     });
 
-    it('should return 400 when content_hash is missing', async () => {
+    it('should accept empty content_hash (optional — used for drift detection)', async () => {
       const res = await request(app)
         .post('/api/annotations')
         .set("Authorization", "Bearer test-token")
         .send(validBody({ content_hash: '' }))
-        .expect(400);
+        .expect(201);
 
-      expect(res.body.error).toBeDefined();
+      expect(res.body.content_hash).toBe('');
     });
 
     it('should return 400 when content is missing', async () => {
@@ -384,7 +384,7 @@ describe('Annotations Router', () => {
 
       expect(res.body.length).toBe(3);
       for (const ann of res.body) {
-        expect(ann.doc_path).toBe('get-test/doc.md');
+        expect(ann.doc_path).toBe('get-test/doc');
       }
     });
 

--- a/packages/api/src/routes/__tests__/reviews.test.ts
+++ b/packages/api/src/routes/__tests__/reviews.test.ts
@@ -83,7 +83,7 @@ describe('Reviews Router', () => {
         .expect(201);
 
       expect(res.body.id).toMatch(CUID2_REGEX);
-      expect(res.body.doc_path).toBe('docs/process.md');
+      expect(res.body.doc_path).toBe('docs/process');
       expect(res.body.user_id).toBe('anonymous');
       expect(res.body.status).toBe('draft');
       expect(res.body.submitted_at).toBeNull();
@@ -184,7 +184,7 @@ describe('Reviews Router', () => {
 
       expect(res.body.length).toBe(2);
       for (const review of res.body) {
-        expect(review.doc_path).toBe('get-test/doc.md');
+        expect(review.doc_path).toBe('get-test/doc');
       }
     });
 
@@ -236,7 +236,7 @@ describe('Reviews Router', () => {
         .expect(200);
 
       expect(res.body.length).toBe(1);
-      expect(res.body[0].doc_path).toBe('get-test/other.md');
+      expect(res.body[0].doc_path).toBe('get-test/other');
     });
 
     it('should filter reviews by status', async () => {
@@ -304,7 +304,7 @@ describe('Reviews Router', () => {
         .expect(200);
 
       expect(res.body.review.id).toBe(created.body.id);
-      expect(res.body.review.doc_path).toBe('getbyid-test/doc.md');
+      expect(res.body.review.doc_path).toBe('getbyid-test/doc');
       expect(res.body.annotations).toEqual([]);
     });
 

--- a/packages/api/src/routes/__tests__/search.test.ts
+++ b/packages/api/src/routes/__tests__/search.test.ts
@@ -160,7 +160,7 @@ describe('POST /search', () => {
       results: [],
       query: 'no matches query',
       totalResults: 0,
-      warning: 'No results found. The Anvil index may be empty or the query did not match any content.',
+      warning: 'No results matched your query.',
     });
   });
 


### PR DESCRIPTION
## Summary

Main has been red for 8 tests across `annotations`, `reviews`, and `search` route suites. All are stale assertions — impl changes landed without updating the test expectations. No impl bugs.

## What drifted

1. **`doc_path` normalization (6 tests)** — commit `9bc5c32` (E11 Batch 2: Doc path normalization) introduced path-stripping on write. Tests asserted the input (with `.md`) roundtripped identically. Updated assertions to expect the normalized form. Inputs kept as `.md` to mirror real caller behavior.

2. **`content_hash` optionality (1 test)** — the annotations route comment states `content_hash is optional — used for drift detection`, and the impl stores empty when unset. The aspirational `should return 400 when content_hash is missing` test was wrong. Converted to a positive test documenting the intentional behavior.

3. **Search warning copy (1 test)** — route message was shortened to `"No results matched your query."`; test still asserted the old long string.

## Verification

- `cd packages/api && npm test` — **217/217 passing** (was 209/217 before this PR)
- No impl files touched; diff is test-only

## Why this before E12-S1

The `/ship` v2 pipeline uses "CI green" as the backend-QA gate. If main is already red, that gate is meaningless and every downstream wave compounds the failure. Fixing now so [foundry#138](https://github.com/danhannah94/foundry/pull/138) (E12-S1) can rebase onto a clean main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)