### PR TITLE
feat(oauth): RFC 8414 + 9728 discovery endpoints (FND-E12-S3)

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -23,6 +23,7 @@ import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { createMcpServer } from './mcp/server.js';
 import { invalidateNavCache } from './utils/nav-generator.js';
+import { createOauthDiscoveryRouter } from './routes/oauth-discovery.js';
 
 // Environment configuration
 const __filename = fileURLToPath(import.meta.url);
@@ -265,6 +266,9 @@ async function startServer(): Promise<void> {
     // Server-side static gating removed — browser navigation doesn't send Bearer headers.
     // TODO: Add cookie-based auth if server-side HTML gating is needed later.
 
+    // Mount OAuth discovery endpoints at app root (/.well-known/*) — spec requires host root
+    app.use('/', createOauthDiscoveryRouter());
+
     // Static file serving — serve the Astro build output
     // Mount at /foundry to match Astro's base path, and at / for API/root access
     app.use('/foundry', express.static(STATIC_PATH));
@@ -281,6 +285,11 @@ async function startServer(): Promise<void> {
 
     // Global error handler (must be last)
     app.use(errorHandler);
+
+    // Fail-loud startup check: OAuth discovery endpoints require FOUNDRY_OAUTH_ISSUER
+    if (!process.env.FOUNDRY_OAUTH_ISSUER) {
+      throw new Error('FOUNDRY_OAUTH_ISSUER env var is required for OAuth discovery endpoints');
+    }
 
     // Start the server
     app.listen(PORT, () => {

--- a/packages/api/src/routes/__tests__/oauth-discovery.test.ts
+++ b/packages/api/src/routes/__tests__/oauth-discovery.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { createOauthDiscoveryRouter } from '../oauth-discovery.js';
+
+const TEST_ISSUER = 'https://test.foundry.example';
+
+describe('OAuth Discovery Endpoints', () => {
+  let app: express.Application;
+
+  beforeEach(() => {
+    process.env.FOUNDRY_OAUTH_ISSUER = TEST_ISSUER;
+    app = express();
+    app.use('/', createOauthDiscoveryRouter());
+  });
+
+  describe('GET /.well-known/oauth-protected-resource (RFC 9728)', () => {
+    it('should return 200', async () => {
+      await request(app)
+        .get('/.well-known/oauth-protected-resource')
+        .expect(200);
+    });
+
+    it('should return Content-Type application/json', async () => {
+      const response = await request(app)
+        .get('/.well-known/oauth-protected-resource')
+        .expect(200);
+
+      expect(response.headers['content-type']).toMatch(/application\/json/);
+    });
+
+    it('should return resource equal to FOUNDRY_OAUTH_ISSUER', async () => {
+      const response = await request(app)
+        .get('/.well-known/oauth-protected-resource')
+        .expect(200);
+
+      expect(response.body.resource).toBe(TEST_ISSUER);
+    });
+
+    it('should return authorization_servers containing FOUNDRY_OAUTH_ISSUER', async () => {
+      const response = await request(app)
+        .get('/.well-known/oauth-protected-resource')
+        .expect(200);
+
+      expect(response.body.authorization_servers).toEqual([TEST_ISSUER]);
+    });
+
+    it('should return bearer_methods_supported: ["header"]', async () => {
+      const response = await request(app)
+        .get('/.well-known/oauth-protected-resource')
+        .expect(200);
+
+      expect(response.body.bearer_methods_supported).toEqual(['header']);
+    });
+
+    it('should return the full expected RFC 9728 shape', async () => {
+      const response = await request(app)
+        .get('/.well-known/oauth-protected-resource')
+        .expect(200);
+
+      expect(response.body).toEqual({
+        resource: TEST_ISSUER,
+        authorization_servers: [TEST_ISSUER],
+        bearer_methods_supported: ['header'],
+      });
+    });
+  });
+
+  describe('GET /.well-known/oauth-authorization-server (RFC 8414)', () => {
+    it('should return 200', async () => {
+      await request(app)
+        .get('/.well-known/oauth-authorization-server')
+        .expect(200);
+    });
+
+    it('should return Content-Type application/json', async () => {
+      const response = await request(app)
+        .get('/.well-known/oauth-authorization-server')
+        .expect(200);
+
+      expect(response.headers['content-type']).toMatch(/application\/json/);
+    });
+
+    it('should return issuer equal to FOUNDRY_OAUTH_ISSUER', async () => {
+      const response = await request(app)
+        .get('/.well-known/oauth-authorization-server')
+        .expect(200);
+
+      expect(response.body.issuer).toBe(TEST_ISSUER);
+    });
+
+    it('should return correct authorization_endpoint', async () => {
+      const response = await request(app)
+        .get('/.well-known/oauth-authorization-server')
+        .expect(200);
+
+      expect(response.body.authorization_endpoint).toBe(`${TEST_ISSUER}/oauth/authorize`);
+    });
+
+    it('should return correct token_endpoint', async () => {
+      const response = await request(app)
+        .get('/.well-known/oauth-authorization-server')
+        .expect(200);
+
+      expect(response.body.token_endpoint).toBe(`${TEST_ISSUER}/oauth/token`);
+    });
+
+    it('should return correct registration_endpoint', async () => {
+      const response = await request(app)
+        .get('/.well-known/oauth-authorization-server')
+        .expect(200);
+
+      expect(response.body.registration_endpoint).toBe(`${TEST_ISSUER}/oauth/register`);
+    });
+
+    it('should return code_challenge_methods_supported: ["S256"] (PKCE mandatory)', async () => {
+      const response = await request(app)
+        .get('/.well-known/oauth-authorization-server')
+        .expect(200);
+
+      expect(response.body.code_challenge_methods_supported).toEqual(['S256']);
+    });
+
+    it('should return grant_types_supported including authorization_code and refresh_token', async () => {
+      const response = await request(app)
+        .get('/.well-known/oauth-authorization-server')
+        .expect(200);
+
+      expect(response.body.grant_types_supported).toContain('authorization_code');
+      expect(response.body.grant_types_supported).toContain('refresh_token');
+    });
+
+    it('should return all three required scopes', async () => {
+      const response = await request(app)
+        .get('/.well-known/oauth-authorization-server')
+        .expect(200);
+
+      expect(response.body.scopes_supported).toContain('docs:read');
+      expect(response.body.scopes_supported).toContain('docs:write');
+      expect(response.body.scopes_supported).toContain('docs:read:private');
+    });
+
+    it('should return the full expected RFC 8414 shape', async () => {
+      const response = await request(app)
+        .get('/.well-known/oauth-authorization-server')
+        .expect(200);
+
+      expect(response.body).toEqual({
+        issuer: TEST_ISSUER,
+        authorization_endpoint: `${TEST_ISSUER}/oauth/authorize`,
+        token_endpoint: `${TEST_ISSUER}/oauth/token`,
+        registration_endpoint: `${TEST_ISSUER}/oauth/register`,
+        response_types_supported: ['code'],
+        grant_types_supported: ['authorization_code', 'refresh_token'],
+        code_challenge_methods_supported: ['S256'],
+        scopes_supported: ['docs:read', 'docs:write', 'docs:read:private'],
+        token_endpoint_auth_methods_supported: ['client_secret_post', 'client_secret_basic'],
+      });
+    });
+  });
+});

--- a/packages/api/src/routes/oauth-discovery.ts
+++ b/packages/api/src/routes/oauth-discovery.ts
@@ -1,0 +1,44 @@
+import { Router } from 'express';
+
+/**
+ * Creates the OAuth discovery router.
+ *
+ * Implements RFC 9728 (oauth-protected-resource) and RFC 8414
+ * (oauth-authorization-server) metadata endpoints. These are static JSON
+ * documents mounted at the app root so MCP clients and generic OAuth clients
+ * can discover AS capabilities without prior configuration.
+ *
+ * No auth required — discovery endpoints must be publicly accessible per spec.
+ * No DB access — all values are derived from the FOUNDRY_OAUTH_ISSUER env var.
+ */
+export function createOauthDiscoveryRouter(): Router {
+  const router = Router();
+
+  // RFC 9728 — OAuth 2.0 Protected Resource Metadata
+  router.get('/.well-known/oauth-protected-resource', (_req, res) => {
+    const issuer = process.env.FOUNDRY_OAUTH_ISSUER!;
+    res.json({
+      resource: issuer,
+      authorization_servers: [issuer],
+      bearer_methods_supported: ['header'],
+    });
+  });
+
+  // RFC 8414 — OAuth 2.0 Authorization Server Metadata
+  router.get('/.well-known/oauth-authorization-server', (_req, res) => {
+    const issuer = process.env.FOUNDRY_OAUTH_ISSUER!;
+    res.json({
+      issuer,
+      authorization_endpoint: `${issuer}/oauth/authorize`,
+      token_endpoint: `${issuer}/oauth/token`,
+      registration_endpoint: `${issuer}/oauth/register`,
+      response_types_supported: ['code'],
+      grant_types_supported: ['authorization_code', 'refresh_token'],
+      code_challenge_methods_supported: ['S256'],
+      scopes_supported: ['docs:read', 'docs:write', 'docs:read:private'],
+      token_endpoint_auth_methods_supported: ['client_secret_post', 'client_secret_basic'],
+    });
+  });
+
+  return router;
+}


### PR DESCRIPTION
## Summary
- Implements **FND-E12-S3** (E12: MCP Authorization)
- Adds `.well-known/oauth-protected-resource` (RFC 9728) + `.well-known/oauth-authorization-server` (RFC 8414)
- Mounted at app root (required by spec — `/.well-known/*`, not under `/api`)
- Fail-loud startup check for `FOUNDRY_OAUTH_ISSUER`

## Why
OAuth discovery is how Claude.ai and other MCP clients bootstrap capability discovery before DCR. Static metadata, no DB, no auth.

## Acceptance Criteria
- [x] Both endpoints return valid JSON (RFC shape)
- [x] `issuer` = `FOUNDRY_OAUTH_ISSUER`
- [x] `code_challenge_methods_supported: ["S256"]`
- [x] `grant_types_supported: ["authorization_code", "refresh_token"]`
- [x] `scopes_supported: ["docs:read", "docs:write", "docs:read:private"]`
- [x] Startup fails if `FOUNDRY_OAUTH_ISSUER` unset
- [x] Tests pass

## QA hints
- Key files: `packages/api/src/routes/oauth-discovery.ts`, test file, single-line additions to `index.ts`
- Verify `FOUNDRY_OAUTH_ISSUER` is set in Fly secrets before S3 deploys (noted in S12 pre-deploy checklist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)