### PR TITLE
feat(oauth): github callback + session cookies (FND-E12-S2)

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -17,6 +17,7 @@ import { createImportRouter } from './routes/import.js';
 import { createDocCrudRouter } from './routes/doc-crud.js';
 import { createSyncRouter } from './routes/sync.js';
 import { createOauthRegisterRouter } from './routes/oauth-register.js';
+import { createOauthGithubRouter } from './routes/oauth-github.js';
 import { requireAuth, logAuthStatus } from './middleware/auth.js';
 import { loadAccessMap, getAccessLevel } from './access.js';
 import { generateAccessMap } from './access-map-generator.js';
@@ -261,6 +262,9 @@ async function startServer(): Promise<void> {
 
     // Mount OAuth DCR router at app root (RFC 7591: /oauth/register is host-root)
     app.use('/', createOauthRegisterRouter());
+
+    // Mount GitHub OAuth callback router (S2: /oauth/github/callback)
+    app.use('/', createOauthGithubRouter());
 
     // Access control for docs:
     // - Static HTML pages: client-side nav filtering hides private docs (no server gate)

--- a/packages/api/src/oauth/github.ts
+++ b/packages/api/src/oauth/github.ts
@@ -1,0 +1,115 @@
+/**
+ * GitHub OAuth helpers — pure functions, no side effects, no module-load env checks.
+ * Fail loud at call time if required env vars are absent.
+ */
+
+// ─── buildAuthorizeUrl ────────────────────────────────────────────────────────
+
+/**
+ * Returns the GitHub OAuth authorization URL with all required params.
+ * Throws if FOUNDRY_OAUTH_ISSUER is unset at call time.
+ */
+export function buildAuthorizeUrl(state: string): string {
+  const issuer = process.env.FOUNDRY_OAUTH_ISSUER;
+  if (!issuer) {
+    throw new Error('FOUNDRY_OAUTH_ISSUER is required but not set');
+  }
+  const clientId = process.env.GITHUB_OAUTH_CLIENT_ID;
+  if (!clientId) {
+    throw new Error('GITHUB_OAUTH_CLIENT_ID is required but not set');
+  }
+
+  const redirectUri = `${issuer}/oauth/github/callback`;
+  const params = new URLSearchParams({
+    client_id: clientId,
+    scope: 'read:user',
+    state,
+    redirect_uri: redirectUri,
+  });
+
+  return `https://github.com/login/oauth/authorize?${params.toString()}`;
+}
+
+// ─── exchangeCode ─────────────────────────────────────────────────────────────
+
+/**
+ * Exchange a GitHub OAuth code for an access token.
+ * Throws on non-200 response or missing access_token in the response.
+ */
+export async function exchangeCode(code: string): Promise<{ access_token: string }> {
+  const clientId = process.env.GITHUB_OAUTH_CLIENT_ID;
+  if (!clientId) {
+    throw new Error('GITHUB_OAUTH_CLIENT_ID is required but not set');
+  }
+  const clientSecret = process.env.GITHUB_OAUTH_CLIENT_SECRET;
+  if (!clientSecret) {
+    throw new Error('GITHUB_OAUTH_CLIENT_SECRET is required but not set');
+  }
+
+  const res = await fetch('https://github.com/login/oauth/access_token', {
+    method: 'POST',
+    headers: {
+      'Accept': 'application/json',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      client_id: clientId,
+      client_secret: clientSecret,
+      code,
+    }),
+  });
+
+  if (!res.ok) {
+    throw new Error(`GitHub token exchange failed: ${res.status} ${res.statusText}`);
+  }
+
+  const data = await res.json() as Record<string, unknown>;
+  if (typeof data.access_token !== 'string' || !data.access_token) {
+    throw new Error(`GitHub token exchange returned no access_token: ${JSON.stringify(data)}`);
+  }
+
+  return { access_token: data.access_token };
+}
+
+// ─── fetchUser ────────────────────────────────────────────────────────────────
+
+/**
+ * Fetch the authenticated GitHub user's login and id.
+ * Throws on non-200 response.
+ */
+export async function fetchUser(token: string): Promise<{ login: string; id: number }> {
+  const res = await fetch('https://api.github.com/user', {
+    headers: {
+      'Authorization': `Bearer ${token}`,
+      'Accept': 'application/vnd.github+json',
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error(`GitHub user fetch failed: ${res.status} ${res.statusText}`);
+  }
+
+  const data = await res.json() as Record<string, unknown>;
+  return {
+    login: data.login as string,
+    id: data.id as number,
+  };
+}
+
+// ─── resolveScopes ────────────────────────────────────────────────────────────
+
+/**
+ * Resolve OAuth scopes for a given GitHub login.
+ * Reads FOUNDRY_PRIVATE_DOC_USERS (comma-separated logins) at call time — no caching.
+ */
+export function resolveScopes(github_login: string): string[] {
+  const privateUsers = (process.env.FOUNDRY_PRIVATE_DOC_USERS ?? '')
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean);
+
+  if (privateUsers.includes(github_login)) {
+    return ['docs:read', 'docs:write', 'docs:read:private'];
+  }
+  return ['docs:read', 'docs:write'];
+}

--- a/packages/api/src/oauth/session.ts
+++ b/packages/api/src/oauth/session.ts
@@ -1,0 +1,88 @@
+/**
+ * Signed-cookie helpers using HMAC-SHA256.
+ * Fail loud at call time if FOUNDRY_OAUTH_SESSION_SECRET is unset.
+ *
+ * Cookie format: base64url(JSON(payload)) + '.' + base64url(HMAC)
+ */
+
+import crypto from 'crypto';
+
+// ─── Internal helpers ─────────────────────────────────────────────────────────
+
+function getSecret(): Buffer {
+  const secret = process.env.FOUNDRY_OAUTH_SESSION_SECRET;
+  if (!secret) {
+    throw new Error('FOUNDRY_OAUTH_SESSION_SECRET is required but not set');
+  }
+  return Buffer.from(secret, 'utf8');
+}
+
+function toBase64url(buf: Buffer): string {
+  return buf.toString('base64url');
+}
+
+function fromBase64url(str: string): Buffer {
+  return Buffer.from(str, 'base64url');
+}
+
+function computeHmac(payloadB64: string, secret: Buffer): Buffer {
+  return crypto.createHmac('sha256', secret).update(payloadB64).digest();
+}
+
+// ─── signCookie ───────────────────────────────────────────────────────────────
+
+/**
+ * Serialize an object into a signed cookie string.
+ * The object should include an `exp` field (Unix timestamp in seconds) for TTL.
+ */
+export function signCookie(value: object): string {
+  const secret = getSecret();
+  const payloadB64 = toBase64url(Buffer.from(JSON.stringify(value), 'utf8'));
+  const hmac = computeHmac(payloadB64, secret);
+  const hmacB64 = toBase64url(hmac);
+  return `${payloadB64}.${hmacB64}`;
+}
+
+// ─── verifyCookie ─────────────────────────────────────────────────────────────
+
+/**
+ * Verify a signed cookie string. Returns the payload object or null if:
+ * - HMAC is invalid (timing-safe comparison)
+ * - Cookie is expired (payload.exp < now)
+ * - Cookie is malformed
+ */
+export function verifyCookie(raw: string): Record<string, unknown> | null {
+  const secret = getSecret();
+
+  const dotIndex = raw.lastIndexOf('.');
+  if (dotIndex === -1) return null;
+
+  const payloadB64 = raw.slice(0, dotIndex);
+  const hmacB64 = raw.slice(dotIndex + 1);
+
+  let expectedHmac: Buffer;
+  let actualHmac: Buffer;
+  try {
+    expectedHmac = computeHmac(payloadB64, secret);
+    actualHmac = fromBase64url(hmacB64);
+  } catch {
+    return null;
+  }
+
+  // Constant-time comparison — ensure buffers are same length before comparing
+  if (expectedHmac.length !== actualHmac.length) return null;
+  if (!crypto.timingSafeEqual(expectedHmac, actualHmac)) return null;
+
+  let payload: Record<string, unknown>;
+  try {
+    payload = JSON.parse(fromBase64url(payloadB64).toString('utf8')) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+
+  // Check expiry
+  const exp = payload.exp;
+  if (typeof exp !== 'number' || Date.now() / 1000 > exp) return null;
+
+  return payload;
+}

--- a/packages/api/src/routes/__tests__/oauth-github.test.ts
+++ b/packages/api/src/routes/__tests__/oauth-github.test.ts
@@ -1,0 +1,387 @@
+import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { unlinkSync } from 'fs';
+
+// ─── Setup: env vars ──────────────────────────────────────────────────────────
+// Must be set before importing anything that reads them at module load.
+process.env.FOUNDRY_OAUTH_ISSUER = 'https://foundry.example.com';
+process.env.FOUNDRY_OAUTH_SESSION_SECRET = 'test-session-secret-at-least-32-chars!!';
+process.env.GITHUB_OAUTH_CLIENT_ID = 'test-gh-client-id';
+process.env.GITHUB_OAUTH_CLIENT_SECRET = 'test-gh-client-secret';
+process.env.FOUNDRY_PRIVATE_DOC_USERS = 'privileged-user,another-admin';
+
+// ─── Import modules under test ─────────────────────────────────────────────
+import { createOauthGithubRouter } from '../oauth-github.js';
+import { signCookie, verifyCookie } from '../../oauth/session.js';
+import { buildAuthorizeUrl, resolveScopes } from '../../oauth/github.js';
+import { getDb, closeDb } from '../../db.js';
+
+// ─── Test DB setup ─────────────────────────────────────────────────────────
+const testDbPath = join(tmpdir(), `foundry-test-oauth-github-${Date.now()}.db`);
+let app: express.Express;
+
+beforeAll(() => {
+  process.env.FOUNDRY_DB_PATH = testDbPath;
+
+  app = express();
+  app.use(express.json());
+  app.use('/', createOauthGithubRouter());
+});
+
+afterAll(() => {
+  closeDb();
+  try {
+    unlinkSync(testDbPath);
+  } catch {
+    // ignore
+  }
+});
+
+// ─── Helper: build a valid signed state cookie ────────────────────────────
+function makeStateCookie(state: string, ttlSeconds = 600): string {
+  const exp = Math.floor(Date.now() / 1000) + ttlSeconds;
+  return signCookie({ state, exp });
+}
+
+// ─── Helper: mock fetch ───────────────────────────────────────────────────
+function mockFetch(responses: Array<{ ok: boolean; status?: number; json?: object }>) {
+  let callIndex = 0;
+  return vi.spyOn(global, 'fetch').mockImplementation(async () => {
+    const resp = responses[callIndex++] ?? responses[responses.length - 1];
+    return {
+      ok: resp.ok,
+      status: resp.status ?? (resp.ok ? 200 : 500),
+      statusText: resp.ok ? 'OK' : 'Error',
+      json: async () => resp.json ?? {},
+    } as Response;
+  });
+}
+
+// ─── signCookie / verifyCookie unit tests ─────────────────────────────────
+
+describe('signCookie / verifyCookie', () => {
+  it('round-trips a payload', () => {
+    const payload = { state: 'abc123', exp: Math.floor(Date.now() / 1000) + 300 };
+    const raw = signCookie(payload);
+    const result = verifyCookie(raw);
+    expect(result).not.toBeNull();
+    expect(result!.state).toBe('abc123');
+  });
+
+  it('returns null when HMAC is tampered', () => {
+    const payload = { state: 'abc123', exp: Math.floor(Date.now() / 1000) + 300 };
+    const raw = signCookie(payload);
+    // Tamper: flip last char of HMAC part
+    const tampered = raw.slice(0, -1) + (raw.endsWith('a') ? 'b' : 'a');
+    expect(verifyCookie(tampered)).toBeNull();
+  });
+
+  it('returns null when payload has been modified', () => {
+    const payload = { state: 'abc123', exp: Math.floor(Date.now() / 1000) + 300 };
+    const raw = signCookie(payload);
+    const [_payloadPart, hmacPart] = raw.split('.');
+    // Swap in a different payload but keep the same HMAC
+    const fakePayload = Buffer.from(JSON.stringify({ state: 'hacked', exp: Math.floor(Date.now() / 1000) + 300 })).toString('base64url');
+    const forged = `${fakePayload}.${hmacPart}`;
+    expect(verifyCookie(forged)).toBeNull();
+  });
+
+  it('returns null when cookie is expired', () => {
+    const payload = { state: 'abc123', exp: Math.floor(Date.now() / 1000) - 1 };
+    const raw = signCookie(payload);
+    expect(verifyCookie(raw)).toBeNull();
+  });
+
+  it('returns null for malformed cookie (no dot separator)', () => {
+    expect(verifyCookie('notacookieatall')).toBeNull();
+  });
+
+  it('returns null for empty string', () => {
+    expect(verifyCookie('')).toBeNull();
+  });
+});
+
+// ─── buildAuthorizeUrl unit tests ─────────────────────────────────────────
+
+describe('buildAuthorizeUrl', () => {
+  it('includes client_id, scope, state, and redirect_uri', () => {
+    const url = buildAuthorizeUrl('test-state-value');
+    expect(url).toContain('https://github.com/login/oauth/authorize');
+    expect(url).toContain('client_id=test-gh-client-id');
+    expect(url).toContain('scope=read%3Auser');
+    expect(url).toContain('state=test-state-value');
+    expect(url).toContain('redirect_uri=https%3A%2F%2Ffoundry.example.com%2Foauth%2Fgithub%2Fcallback');
+  });
+
+  it('throws if FOUNDRY_OAUTH_ISSUER is unset', () => {
+    const orig = process.env.FOUNDRY_OAUTH_ISSUER;
+    delete process.env.FOUNDRY_OAUTH_ISSUER;
+    expect(() => buildAuthorizeUrl('s')).toThrow('FOUNDRY_OAUTH_ISSUER');
+    process.env.FOUNDRY_OAUTH_ISSUER = orig;
+  });
+});
+
+// ─── resolveScopes unit tests ─────────────────────────────────────────────
+
+describe('resolveScopes', () => {
+  it('returns private scope for allowlisted user', () => {
+    const scopes = resolveScopes('privileged-user');
+    expect(scopes).toContain('docs:read:private');
+    expect(scopes).toContain('docs:read');
+    expect(scopes).toContain('docs:write');
+  });
+
+  it('does not return private scope for non-allowlisted user', () => {
+    const scopes = resolveScopes('regular-user');
+    expect(scopes).not.toContain('docs:read:private');
+    expect(scopes).toContain('docs:read');
+    expect(scopes).toContain('docs:write');
+  });
+
+  it('handles empty FOUNDRY_PRIVATE_DOC_USERS gracefully', () => {
+    const orig = process.env.FOUNDRY_PRIVATE_DOC_USERS;
+    process.env.FOUNDRY_PRIVATE_DOC_USERS = '';
+    expect(resolveScopes('anyone')).not.toContain('docs:read:private');
+    process.env.FOUNDRY_PRIVATE_DOC_USERS = orig;
+  });
+});
+
+// ─── GET /oauth/github/callback integration tests ────────────────────────
+
+describe('GET /oauth/github/callback', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // ── Missing params ─────────────────────────────────────────────────────
+
+  it('returns 400 when code is missing', async () => {
+    const res = await request(app)
+      .get('/oauth/github/callback?state=some-state')
+      .expect(400);
+    expect(res.body.error).toMatch(/code/i);
+  });
+
+  it('returns 400 when state is missing', async () => {
+    const res = await request(app)
+      .get('/oauth/github/callback?code=some-code')
+      .expect(400);
+    expect(res.body.error).toMatch(/state/i);
+  });
+
+  it('returns 400 when both code and state are missing', async () => {
+    await request(app)
+      .get('/oauth/github/callback')
+      .expect(400);
+  });
+
+  // ── State cookie validation ─────────────────────────────────────────────
+
+  it('returns 400 when state cookie is absent', async () => {
+    const res = await request(app)
+      .get('/oauth/github/callback?code=abc&state=xyz')
+      .expect(400);
+    expect(res.body.error).toMatch(/state cookie/i);
+  });
+
+  it('returns 400 when state cookie has been tampered (HMAC check)', async () => {
+    const rawCookie = makeStateCookie('good-state');
+    const tampered = rawCookie.slice(0, -1) + (rawCookie.endsWith('a') ? 'b' : 'a');
+    const res = await request(app)
+      .get('/oauth/github/callback?code=abc&state=good-state')
+      .set('Cookie', `foundry_oauth_state=${encodeURIComponent(tampered)}`)
+      .expect(400);
+    expect(res.body.error).toMatch(/invalid|expired/i);
+  });
+
+  it('returns 400 when state cookie is expired', async () => {
+    const rawCookie = makeStateCookie('my-state', -1); // already expired
+    const res = await request(app)
+      .get('/oauth/github/callback?code=abc&state=my-state')
+      .set('Cookie', `foundry_oauth_state=${encodeURIComponent(rawCookie)}`)
+      .expect(400);
+    expect(res.body.error).toMatch(/invalid|expired/i);
+  });
+
+  it('returns 400 when state in query does not match cookie state', async () => {
+    const rawCookie = makeStateCookie('correct-state');
+    const res = await request(app)
+      .get('/oauth/github/callback?code=abc&state=wrong-state')
+      .set('Cookie', `foundry_oauth_state=${encodeURIComponent(rawCookie)}`)
+      .expect(400);
+    expect(res.body.error).toMatch(/mismatch/i);
+  });
+
+  // ── GitHub API errors ──────────────────────────────────────────────────
+
+  it('returns 502 when GitHub token exchange returns non-200', async () => {
+    mockFetch([{ ok: false, status: 400, json: { error: 'bad_verification_code' } }]);
+    const rawCookie = makeStateCookie('state-abc');
+    const res = await request(app)
+      .get('/oauth/github/callback?code=bad-code&state=state-abc')
+      .set('Cookie', `foundry_oauth_state=${encodeURIComponent(rawCookie)}`)
+      .expect(502);
+    expect(res.body.error).toMatch(/token exchange/i);
+  });
+
+  it('returns 502 when GitHub token exchange returns no access_token', async () => {
+    mockFetch([{ ok: true, json: { error: 'incorrect_client_credentials' } }]);
+    const rawCookie = makeStateCookie('state-def');
+    const res = await request(app)
+      .get('/oauth/github/callback?code=bad-creds&state=state-def')
+      .set('Cookie', `foundry_oauth_state=${encodeURIComponent(rawCookie)}`)
+      .expect(502);
+    expect(res.body.error).toMatch(/token exchange/i);
+  });
+
+  it('returns 502 when GitHub user fetch returns non-200', async () => {
+    mockFetch([
+      { ok: true, json: { access_token: 'gho_test' } },
+      { ok: false, status: 401, json: { message: 'Bad credentials' } },
+    ]);
+    const rawCookie = makeStateCookie('state-ghi');
+    const res = await request(app)
+      .get('/oauth/github/callback?code=validcode&state=state-ghi')
+      .set('Cookie', `foundry_oauth_state=${encodeURIComponent(rawCookie)}`)
+      .expect(502);
+    expect(res.body.error).toMatch(/user fetch/i);
+  });
+
+  // ── Successful flow: non-allowlisted user ──────────────────────────────
+
+  it('redirects to /oauth/consent and sets session cookie for a regular user', async () => {
+    mockFetch([
+      { ok: true, json: { access_token: 'gho_regular_token' } },
+      { ok: true, json: { login: 'regular-user', id: 99001 } },
+    ]);
+    const rawCookie = makeStateCookie('state-regular');
+    const res = await request(app)
+      .get('/oauth/github/callback?code=validcode&state=state-regular')
+      .set('Cookie', `foundry_oauth_state=${encodeURIComponent(rawCookie)}`)
+      .expect(302);
+
+    expect(res.headers.location).toBe('/oauth/consent');
+
+    // Session cookie should be present
+    const setCookieHeader = res.headers['set-cookie'];
+    expect(setCookieHeader).toBeDefined();
+    const sessionCookieStr = (Array.isArray(setCookieHeader) ? setCookieHeader : [setCookieHeader])
+      .find((c: string) => c.startsWith('foundry_oauth_session='));
+    expect(sessionCookieStr).toBeDefined();
+
+    // Parse and verify the session cookie payload
+    const match = sessionCookieStr!.match(/foundry_oauth_session=([^;]+)/);
+    expect(match).not.toBeNull();
+    const sessionPayload = verifyCookie(decodeURIComponent(match![1]));
+    expect(sessionPayload).not.toBeNull();
+    expect(sessionPayload!.scopes).toContain('docs:read');
+    expect(sessionPayload!.scopes).toContain('docs:write');
+    expect((sessionPayload!.scopes as string[])).not.toContain('docs:read:private');
+    expect(typeof sessionPayload!.user_id).toBe('string');
+  });
+
+  // ── Successful flow: allowlisted user ─────────────────────────────────
+
+  it('redirects to /oauth/consent and sets session cookie with private scope for allowlisted user', async () => {
+    mockFetch([
+      { ok: true, json: { access_token: 'gho_privileged_token' } },
+      { ok: true, json: { login: 'privileged-user', id: 99002 } },
+    ]);
+    const rawCookie = makeStateCookie('state-privileged');
+    const res = await request(app)
+      .get('/oauth/github/callback?code=validcode&state=state-privileged')
+      .set('Cookie', `foundry_oauth_state=${encodeURIComponent(rawCookie)}`)
+      .expect(302);
+
+    expect(res.headers.location).toBe('/oauth/consent');
+
+    const setCookieHeader = res.headers['set-cookie'];
+    const sessionCookieStr = (Array.isArray(setCookieHeader) ? setCookieHeader : [setCookieHeader])
+      .find((c: string) => c.startsWith('foundry_oauth_session='));
+    expect(sessionCookieStr).toBeDefined();
+
+    // Session should include docs:read:private
+    const match = sessionCookieStr!.match(/foundry_oauth_session=([^;]+)/);
+    const sessionPayload = verifyCookie(decodeURIComponent(match![1]));
+    expect(sessionPayload).not.toBeNull();
+    expect((sessionPayload!.scopes as string[])).toContain('docs:read:private');
+    expect((sessionPayload!.scopes as string[])).toContain('docs:read');
+    expect((sessionPayload!.scopes as string[])).toContain('docs:write');
+  });
+
+  // ── usersDao.upsert is called ──────────────────────────────────────────
+
+  it('upserts the user into the database', async () => {
+    mockFetch([
+      { ok: true, json: { access_token: 'gho_upsert_test' } },
+      { ok: true, json: { login: 'upsert-test-user', id: 77777 } },
+    ]);
+    const rawCookie = makeStateCookie('state-upsert');
+    await request(app)
+      .get('/oauth/github/callback?code=validcode&state=state-upsert')
+      .set('Cookie', `foundry_oauth_state=${encodeURIComponent(rawCookie)}`)
+      .expect(302);
+
+    // Verify the user was written to the DB
+    const db = getDb();
+    const user = db.prepare('SELECT * FROM users WHERE github_id = ?').get(77777) as any;
+    expect(user).toBeDefined();
+    expect(user.github_login).toBe('upsert-test-user');
+    expect(user.github_id).toBe(77777);
+  });
+
+  it('upserts an existing user (updates github_login)', async () => {
+    // First call — create user
+    mockFetch([
+      { ok: true, json: { access_token: 'gho_update_test1' } },
+      { ok: true, json: { login: 'original-login', id: 88888 } },
+    ]);
+    const cookie1 = makeStateCookie('state-upd1');
+    await request(app)
+      .get('/oauth/github/callback?code=validcode&state=state-upd1')
+      .set('Cookie', `foundry_oauth_state=${encodeURIComponent(cookie1)}`)
+      .expect(302);
+
+    vi.restoreAllMocks();
+
+    // Second call — same github_id, new login (rename scenario)
+    mockFetch([
+      { ok: true, json: { access_token: 'gho_update_test2' } },
+      { ok: true, json: { login: 'renamed-login', id: 88888 } },
+    ]);
+    const cookie2 = makeStateCookie('state-upd2');
+    await request(app)
+      .get('/oauth/github/callback?code=validcode&state=state-upd2')
+      .set('Cookie', `foundry_oauth_state=${encodeURIComponent(cookie2)}`)
+      .expect(302);
+
+    const db = getDb();
+    const user = db.prepare('SELECT * FROM users WHERE github_id = ?').get(88888) as any;
+    expect(user.github_login).toBe('renamed-login');
+  });
+
+  // ── Cookie attributes ──────────────────────────────────────────────────
+
+  it('sets HttpOnly, SameSite=Lax, Path=/ on the session cookie', async () => {
+    mockFetch([
+      { ok: true, json: { access_token: 'gho_attr_test' } },
+      { ok: true, json: { login: 'attr-user', id: 99999 } },
+    ]);
+    const rawCookie = makeStateCookie('state-attr');
+    const res = await request(app)
+      .get('/oauth/github/callback?code=validcode&state=state-attr')
+      .set('Cookie', `foundry_oauth_state=${encodeURIComponent(rawCookie)}`)
+      .expect(302);
+
+    const setCookieHeader = res.headers['set-cookie'];
+    const sessionCookieStr = (Array.isArray(setCookieHeader) ? setCookieHeader : [setCookieHeader])
+      .find((c: string) => c.startsWith('foundry_oauth_session='));
+    expect(sessionCookieStr).toBeDefined();
+    expect(sessionCookieStr).toContain('HttpOnly');
+    expect(sessionCookieStr).toContain('SameSite=Lax');
+    expect(sessionCookieStr).toContain('Path=/');
+  });
+});

--- a/packages/api/src/routes/oauth-github.ts
+++ b/packages/api/src/routes/oauth-github.ts
@@ -1,0 +1,133 @@
+/**
+ * GitHub OAuth callback route.
+ *
+ * GET /oauth/github/callback
+ *   - Validates signed state cookie (set by S5 /oauth/authorize)
+ *   - Exchanges code for access token via GitHub
+ *   - Fetches user profile from GitHub
+ *   - Upserts user into DB
+ *   - Resolves scopes
+ *   - Issues signed session cookie
+ *   - Redirects to /oauth/consent
+ */
+
+import { Router, Request, Response } from 'express';
+import { exchangeCode, fetchUser, resolveScopes } from '../oauth/github.js';
+import { signCookie, verifyCookie } from '../oauth/session.js';
+import { usersDao } from '../oauth/dao.js';
+
+// Cookie names (must match what S5 /oauth/authorize sets)
+const STATE_COOKIE = 'foundry_oauth_state';
+const SESSION_COOKIE = 'foundry_oauth_session';
+
+// TTLs in seconds
+const SESSION_TTL_SECONDS = 60 * 60; // 1 hour
+
+/**
+ * Determine if we're in a production environment where Secure cookies should be set.
+ */
+function isProduction(): boolean {
+  return process.env.NODE_ENV === 'production';
+}
+
+/**
+ * Parse cookies from the Cookie header string.
+ */
+function parseCookies(cookieHeader: string): Record<string, string> {
+  const cookies: Record<string, string> = {};
+  for (const part of cookieHeader.split(';')) {
+    const eqIdx = part.indexOf('=');
+    if (eqIdx === -1) continue;
+    const name = part.slice(0, eqIdx).trim();
+    const value = part.slice(eqIdx + 1).trim();
+    cookies[name] = decodeURIComponent(value);
+  }
+  return cookies;
+}
+
+export function createOauthGithubRouter(): Router {
+  const router = Router();
+
+  router.get('/oauth/github/callback', async (req: Request, res: Response) => {
+    const { code, state } = req.query as { code?: string; state?: string };
+
+    // 1. Validate required query params
+    if (!code || !state) {
+      return res.status(400).json({ error: 'Missing required query parameters: code, state' });
+    }
+
+    // 2. Read and verify the state cookie
+    const cookieHeader = req.headers.cookie ?? '';
+    const cookies = parseCookies(cookieHeader);
+    const rawStateCookie = cookies[STATE_COOKIE];
+
+    if (!rawStateCookie) {
+      return res.status(400).json({ error: 'Missing state cookie' });
+    }
+
+    const statePaylod = verifyCookie(rawStateCookie);
+    if (!statePaylod) {
+      return res.status(400).json({ error: 'Invalid or expired state cookie' });
+    }
+
+    // Compare state from query param to state from cookie
+    if (statePaylod.state !== state) {
+      return res.status(400).json({ error: 'State mismatch' });
+    }
+
+    // 3. Exchange code for access token
+    let accessToken: string;
+    try {
+      const tokenResponse = await exchangeCode(code);
+      accessToken = tokenResponse.access_token;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error('[oauth/github] Token exchange failed:', message);
+      return res.status(502).json({ error: `GitHub token exchange failed: ${message}` });
+    }
+
+    // 4. Fetch GitHub user
+    let githubUser: { login: string; id: number };
+    try {
+      githubUser = await fetchUser(accessToken);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error('[oauth/github] User fetch failed:', message);
+      return res.status(502).json({ error: `GitHub user fetch failed: ${message}` });
+    }
+
+    // 5. Upsert user
+    const user = usersDao.upsert({
+      github_login: githubUser.login,
+      github_id: githubUser.id,
+    });
+
+    // 6. Resolve scopes
+    const scopes = resolveScopes(githubUser.login);
+
+    // 7. Issue signed session cookie
+    const sessionExp = Math.floor(Date.now() / 1000) + SESSION_TTL_SECONDS;
+    const sessionCookieValue = signCookie({
+      user_id: user.id,
+      scopes,
+      exp: sessionExp,
+    });
+
+    const secure = isProduction();
+    const cookieAttrs = [
+      `${SESSION_COOKIE}=${encodeURIComponent(sessionCookieValue)}`,
+      'HttpOnly',
+      secure ? 'Secure' : '',
+      'SameSite=Lax',
+      'Path=/',
+      `Max-Age=${SESSION_TTL_SECONDS}`,
+    ].filter(Boolean).join('; ');
+
+    res.setHeader('Set-Cookie', cookieAttrs);
+
+    // 8. Redirect to consent page (S5 placeholder)
+    return res.redirect(302, '/oauth/consent');
+  });
+
+  return router;
+}


### PR DESCRIPTION
## Summary
- Implements **FND-E12-S2** (E12: MCP Authorization)
- `GET /oauth/github/callback` exchanges GitHub code, upserts user, issues signed session cookie
- New helpers: `packages/api/src/oauth/github.ts` (buildAuthorizeUrl / exchangeCode / fetchUser / resolveScopes)
- Signed cookie helpers via HMAC-SHA256 keyed on `FOUNDRY_OAUTH_SESSION_SECRET` in `packages/api/src/oauth/session.ts`
- Scope resolution reads `FOUNDRY_PRIVATE_DOC_USERS` on every call (no caching)

## Why
Upstream IdP integration. S5 will redirect into GitHub; this handles the return leg: exchange code → fetch user → upsert → session → redirect to consent page (S5 placeholder).

## Acceptance Criteria
- [x] Round-trip with mocked GitHub user
- [x] Invalid/missing state → 400
- [x] Allowlist → private scope; non-allowlist → public only
- [x] All fetches mocked in tests
- [x] Env vars required at runtime: `GITHUB_OAUTH_CLIENT_ID`, `GITHUB_OAUTH_CLIENT_SECRET`, `FOUNDRY_OAUTH_SESSION_SECRET`, `FOUNDRY_OAUTH_ISSUER`, `FOUNDRY_PRIVATE_DOC_USERS`

## QA hints
- Key files: `packages/api/src/oauth/github.ts`, `packages/api/src/oauth/session.ts`, `packages/api/src/routes/oauth-github.ts`, test file
- Cookie helpers — review HMAC comparison (`timingSafeEqual`), base64url encoding
- State cookie is issued by S5 (not yet built); tests simulate by setting the cookie in the request
- `index.ts` changes: import added at line 19 (after `createSyncRouter` import), mount added at line 261 (after sync router `app.use()`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)