### PR TITLE
feat(oauth): dynamic client registration endpoint (FND-E12-S4)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2878,6 +2878,13 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/bcryptjs": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@types/bcryptjs/-/bcryptjs-2.4.6.tgz",
+      "integrity": "sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/better-sqlite3": {
       "version": "7.6.13",
       "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
@@ -3790,6 +3797,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bcryptjs": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
+      "integrity": "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
       }
     },
     "node_modules/better-sqlite3": {
@@ -11760,6 +11776,7 @@
         "@claymore-dev/anvil": "^0.1.12",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@paralleldrive/cuid2": "^3.3.0",
+        "bcryptjs": "^3.0.3",
         "better-sqlite3": "^12.8.0",
         "cors": "^2.8.5",
         "express": "^4.18.2",
@@ -11770,6 +11787,7 @@
         "foundry": "dist/cli.js"
       },
       "devDependencies": {
+        "@types/bcryptjs": "^2.4.6",
         "@types/better-sqlite3": "^7.6.13",
         "@types/cors": "^2.8.17",
         "@types/express": "^4.17.21",

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -16,6 +16,7 @@ import { createPagesRouter } from './routes/pages.js';
 import { createImportRouter } from './routes/import.js';
 import { createDocCrudRouter } from './routes/doc-crud.js';
 import { createSyncRouter } from './routes/sync.js';
+import { createOauthRegisterRouter } from './routes/oauth-register.js';
 import { requireAuth, logAuthStatus } from './middleware/auth.js';
 import { loadAccessMap, getAccessLevel } from './access.js';
 import { generateAccessMap } from './access-map-generator.js';
@@ -257,6 +258,9 @@ async function startServer(): Promise<void> {
 
     // Mount sync router (auth-protected internally via requireAuth in route)
     app.use('/api', createSyncRouter());
+
+    // Mount OAuth DCR router at app root (RFC 7591: /oauth/register is host-root)
+    app.use('/', createOauthRegisterRouter());
 
     // Access control for docs:
     // - Static HTML pages: client-side nav filtering hides private docs (no server gate)

--- a/packages/api/src/routes/__tests__/oauth-register.test.ts
+++ b/packages/api/src/routes/__tests__/oauth-register.test.ts
@@ -1,0 +1,303 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { unlinkSync } from 'fs';
+import { getDb, closeDb } from '../../db.js';
+import { createOauthRegisterRouter } from '../oauth-register.js';
+
+// ─── DB helpers ───────────────────────────────────────────────────────────────
+
+const testDbPath = join(tmpdir(), `foundry-oauth-register-test-${process.pid}-${Date.now()}.db`);
+
+// Token used in all happy-path / wrong-token tests
+const DCR_TOKEN = 'test-dcr-token-48-chars-long-xxxxxxxxxxxxxxxxxxxx';
+
+let app: express.Express;
+
+beforeEach(() => {
+  process.env.FOUNDRY_DB_PATH = testDbPath;
+  process.env.FOUNDRY_DCR_TOKEN = DCR_TOKEN;
+  closeDb();
+  getDb(); // trigger schema creation
+
+  app = express();
+  app.use(express.json());
+  app.use('/', createOauthRegisterRouter());
+
+  // Minimal error handler so 500s from thrown errors return JSON
+  app.use((err: any, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+    res.status(err.status ?? 500).json({ error: err.message ?? 'Internal server error' });
+  });
+});
+
+afterEach(() => {
+  closeDb();
+  try {
+    unlinkSync(testDbPath);
+  } catch {
+    // ignore
+  }
+  delete process.env.FOUNDRY_DB_PATH;
+  delete process.env.FOUNDRY_DCR_TOKEN;
+});
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function validBody() {
+  return {
+    client_name: 'Claude.ai Connector',
+    redirect_uris: ['https://claude.ai/oauth/callback'],
+    client_type: 'autonomous',
+  };
+}
+
+function authed() {
+  return request(app)
+    .post('/oauth/register')
+    .set('Authorization', `Bearer ${DCR_TOKEN}`)
+    .set('Content-Type', 'application/json');
+}
+
+// ─── Bearer gate ──────────────────────────────────────────────────────────────
+
+describe('POST /oauth/register — bearer gate', () => {
+  it('returns 401 invalid_token when Authorization header is missing', async () => {
+    const res = await request(app)
+      .post('/oauth/register')
+      .send(validBody())
+      .expect(401);
+
+    expect(res.body.error).toBe('invalid_token');
+  });
+
+  it('returns 401 invalid_token when bearer token is wrong', async () => {
+    const res = await request(app)
+      .post('/oauth/register')
+      .set('Authorization', 'Bearer wrong-token')
+      .send(validBody())
+      .expect(401);
+
+    expect(res.body.error).toBe('invalid_token');
+  });
+
+  it('returns 401 for a token that is the right length but wrong value', async () => {
+    // Same length, different content
+    const sameLength = 'X'.repeat(DCR_TOKEN.length);
+    const res = await request(app)
+      .post('/oauth/register')
+      .set('Authorization', `Bearer ${sameLength}`)
+      .send(validBody())
+      .expect(401);
+
+    expect(res.body.error).toBe('invalid_token');
+  });
+
+  it('returns 500 when FOUNDRY_DCR_TOKEN is unset (misconfiguration)', async () => {
+    delete process.env.FOUNDRY_DCR_TOKEN;
+
+    const res = await request(app)
+      .post('/oauth/register')
+      .set('Authorization', `Bearer ${DCR_TOKEN}`)
+      .send(validBody())
+      .expect(500);
+
+    // Error body shouldn't leak the internal message to production, but our
+    // test error handler does echo it — just assert it's a 500, not an RFC code
+    expect(res.body.error).toBeTruthy();
+  });
+});
+
+// ─── Happy path ───────────────────────────────────────────────────────────────
+
+describe('POST /oauth/register — happy path', () => {
+  it('returns 201 with client_id, client_secret, and echoed fields', async () => {
+    const res = await authed().send(validBody()).expect(201);
+
+    expect(res.body.client_id).toBeTruthy();
+    expect(res.body.client_secret).toBeTruthy();
+    expect(res.body.client_name).toBe('Claude.ai Connector');
+    expect(res.body.redirect_uris).toEqual(['https://claude.ai/oauth/callback']);
+    expect(res.body.client_type).toBe('autonomous');
+    expect(res.body.registration_access_token).toBeNull();
+  });
+
+  it('client_id is a non-empty string', async () => {
+    const res = await authed().send(validBody()).expect(201);
+    expect(typeof res.body.client_id).toBe('string');
+    expect(res.body.client_id.length).toBeGreaterThan(0);
+  });
+
+  it('client_secret is a non-empty string', async () => {
+    const res = await authed().send(validBody()).expect(201);
+    expect(typeof res.body.client_secret).toBe('string');
+    expect(res.body.client_secret.length).toBeGreaterThan(0);
+  });
+
+  it('two registrations produce different credentials', async () => {
+    const res1 = await authed().send(validBody()).expect(201);
+    const res2 = await authed().send(validBody()).expect(201);
+
+    expect(res1.body.client_id).not.toBe(res2.body.client_id);
+    expect(res1.body.client_secret).not.toBe(res2.body.client_secret);
+  });
+
+  it('accepts http://localhost:3000/callback as a valid redirect_uri', async () => {
+    const body = {
+      ...validBody(),
+      redirect_uris: ['http://localhost:3000/callback'],
+    };
+    const res = await authed().send(body).expect(201);
+    expect(res.body.redirect_uris).toEqual(['http://localhost:3000/callback']);
+  });
+
+  it('accepts http://localhost (no port, no path)', async () => {
+    const body = { ...validBody(), redirect_uris: ['http://localhost'] };
+    const res = await authed().send(body).expect(201);
+    expect(res.body.redirect_uris).toEqual(['http://localhost']);
+  });
+
+  it('accepts multiple redirect_uris', async () => {
+    const uris = ['https://example.com/cb', 'https://other.example.com/cb'];
+    const body = { ...validBody(), redirect_uris: uris };
+    const res = await authed().send(body).expect(201);
+    expect(res.body.redirect_uris).toEqual(uris);
+  });
+
+  it('accepts optional grant_types when authorization_code is included', async () => {
+    const body = { ...validBody(), grant_types: ['authorization_code', 'refresh_token'] };
+    const res = await authed().send(body).expect(201);
+    expect(res.body.client_id).toBeTruthy();
+  });
+
+  it('accepts optional response_types without error', async () => {
+    const body = { ...validBody(), response_types: ['code'] };
+    const res = await authed().send(body).expect(201);
+    expect(res.body.client_id).toBeTruthy();
+  });
+
+  it('accepts optional token_endpoint_auth_method without error', async () => {
+    const body = { ...validBody(), token_endpoint_auth_method: 'client_secret_basic' };
+    const res = await authed().send(body).expect(201);
+    expect(res.body.client_id).toBeTruthy();
+  });
+});
+
+// ─── client_name validation ───────────────────────────────────────────────────
+
+describe('POST /oauth/register — client_name validation', () => {
+  it('returns 400 invalid_client_metadata when client_name is missing', async () => {
+    const { client_name: _, ...body } = validBody();
+    const res = await authed().send(body).expect(400);
+
+    expect(res.body.error).toBe('invalid_client_metadata');
+    expect(res.body.error_description).toMatch(/client_name/);
+  });
+
+  it('returns 400 invalid_client_metadata when client_name exceeds 100 chars', async () => {
+    const body = { ...validBody(), client_name: 'A'.repeat(101) };
+    const res = await authed().send(body).expect(400);
+
+    expect(res.body.error).toBe('invalid_client_metadata');
+    expect(res.body.error_description).toMatch(/client_name/);
+  });
+
+  it('accepts client_name at exactly 100 chars', async () => {
+    const body = { ...validBody(), client_name: 'B'.repeat(100) };
+    const res = await authed().send(body).expect(201);
+    expect(res.body.client_name).toBe('B'.repeat(100));
+  });
+});
+
+// ─── redirect_uris validation ─────────────────────────────────────────────────
+
+describe('POST /oauth/register — redirect_uris validation', () => {
+  it('returns 400 invalid_client_metadata when redirect_uris is missing', async () => {
+    const { redirect_uris: _, ...body } = validBody();
+    const res = await authed().send(body).expect(400);
+
+    expect(res.body.error).toBe('invalid_client_metadata');
+    expect(res.body.error_description).toMatch(/redirect_uris/);
+  });
+
+  it('returns 400 invalid_redirect_uri when redirect_uris is empty array', async () => {
+    const body = { ...validBody(), redirect_uris: [] };
+    const res = await authed().send(body).expect(400);
+
+    expect(res.body.error).toBe('invalid_redirect_uri');
+  });
+
+  it('returns 400 invalid_redirect_uri for http://evil.com (non-https, non-localhost)', async () => {
+    const body = { ...validBody(), redirect_uris: ['http://evil.com'] };
+    const res = await authed().send(body).expect(400);
+
+    expect(res.body.error).toBe('invalid_redirect_uri');
+  });
+
+  it('returns 400 invalid_redirect_uri for ftp:// URI', async () => {
+    const body = { ...validBody(), redirect_uris: ['ftp://example.com/cb'] };
+    const res = await authed().send(body).expect(400);
+
+    expect(res.body.error).toBe('invalid_redirect_uri');
+  });
+
+  it('returns 400 invalid_redirect_uri if any URI in the array is invalid', async () => {
+    const body = {
+      ...validBody(),
+      redirect_uris: ['https://ok.example.com/cb', 'http://not-localhost.com/cb'],
+    };
+    const res = await authed().send(body).expect(400);
+
+    expect(res.body.error).toBe('invalid_redirect_uri');
+  });
+});
+
+// ─── client_type validation ───────────────────────────────────────────────────
+
+describe('POST /oauth/register — client_type validation', () => {
+  it('returns 400 invalid_client_metadata when client_type is missing', async () => {
+    const { client_type: _, ...body } = validBody();
+    const res = await authed().send(body).expect(400);
+
+    expect(res.body.error).toBe('invalid_client_metadata');
+    expect(res.body.error_description).toMatch(/client_type/);
+  });
+
+  it('returns 400 invalid_client_metadata for unsupported client_type "bot"', async () => {
+    const body = { ...validBody(), client_type: 'bot' };
+    const res = await authed().send(body).expect(400);
+
+    expect(res.body.error).toBe('invalid_client_metadata');
+  });
+
+  it('accepts client_type "interactive"', async () => {
+    const body = { ...validBody(), client_type: 'interactive' };
+    const res = await authed().send(body).expect(201);
+    expect(res.body.client_type).toBe('interactive');
+  });
+
+  it('accepts client_type "autonomous"', async () => {
+    const body = { ...validBody(), client_type: 'autonomous' };
+    const res = await authed().send(body).expect(201);
+    expect(res.body.client_type).toBe('autonomous');
+  });
+});
+
+// ─── grant_types validation ───────────────────────────────────────────────────
+
+describe('POST /oauth/register — grant_types validation', () => {
+  it('returns 400 invalid_client_metadata when grant_types lacks authorization_code', async () => {
+    const body = { ...validBody(), grant_types: ['client_credentials'] };
+    const res = await authed().send(body).expect(400);
+
+    expect(res.body.error).toBe('invalid_client_metadata');
+  });
+
+  it('returns 400 when grant_types is an empty array', async () => {
+    const body = { ...validBody(), grant_types: [] };
+    const res = await authed().send(body).expect(400);
+
+    expect(res.body.error).toBe('invalid_client_metadata');
+  });
+});

--- a/packages/api/src/routes/oauth-register.ts
+++ b/packages/api/src/routes/oauth-register.ts
@@ -1,0 +1,149 @@
+import crypto from 'crypto';
+import { Router, Request, Response } from 'express';
+import { clientsDao } from '../oauth/dao.js';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface RegisterBody {
+  client_name?: unknown;
+  redirect_uris?: unknown;
+  client_type?: unknown;
+  grant_types?: unknown;
+  response_types?: unknown;
+  token_endpoint_auth_method?: unknown;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const HTTPS_RE = /^https:\/\/.+/;
+const LOCALHOST_RE = /^http:\/\/localhost(:\d+)?(\/.*)?$/;
+
+function isValidRedirectUri(uri: string): boolean {
+  return HTTPS_RE.test(uri) || LOCALHOST_RE.test(uri);
+}
+
+// ─── Router factory ───────────────────────────────────────────────────────────
+
+export function createOauthRegisterRouter(): Router {
+  const router = Router();
+
+  router.post('/oauth/register', (req: Request<{}, {}, RegisterBody>, res: Response) => {
+    // ── Bearer gate ──────────────────────────────────────────────────────────
+    //
+    // Fail loud if the env var is missing — this is a misconfiguration, not a
+    // client error. The error propagates to Express's global error handler and
+    // returns 500; no RFC 7591 body is appropriate here.
+    const dcrToken = process.env.FOUNDRY_DCR_TOKEN;
+    if (!dcrToken) {
+      throw new Error('FOUNDRY_DCR_TOKEN is not set — server misconfiguration');
+    }
+
+    const authHeader = req.headers.authorization ?? '';
+    const match = authHeader.match(/^Bearer (.+)$/);
+    const provided = match ? match[1] : '';
+
+    // Timing-safe comparison — lengths must match to avoid short-circuit leaks
+    if (
+      provided.length !== dcrToken.length ||
+      !crypto.timingSafeEqual(Buffer.from(provided), Buffer.from(dcrToken))
+    ) {
+      return res.status(401).json({ error: 'invalid_token' });
+    }
+
+    // ── Body validation ──────────────────────────────────────────────────────
+
+    const { client_name, redirect_uris, client_type, grant_types } = req.body;
+
+    // client_name: required, string, max 100 chars
+    if (client_name === undefined || client_name === null) {
+      return res.status(400).json({
+        error: 'invalid_client_metadata',
+        error_description: 'client_name is required',
+      });
+    }
+    if (typeof client_name !== 'string' || client_name.trim() === '') {
+      return res.status(400).json({
+        error: 'invalid_client_metadata',
+        error_description: 'client_name must be a non-empty string',
+      });
+    }
+    if (client_name.length > 100) {
+      return res.status(400).json({
+        error: 'invalid_client_metadata',
+        error_description: 'client_name must not exceed 100 characters',
+      });
+    }
+
+    // redirect_uris: required, non-empty array
+    if (redirect_uris === undefined || redirect_uris === null) {
+      return res.status(400).json({
+        error: 'invalid_client_metadata',
+        error_description: 'redirect_uris is required',
+      });
+    }
+    if (!Array.isArray(redirect_uris)) {
+      return res.status(400).json({
+        error: 'invalid_client_metadata',
+        error_description: 'redirect_uris must be an array',
+      });
+    }
+    if (redirect_uris.length === 0) {
+      return res.status(400).json({
+        error: 'invalid_redirect_uri',
+        error_description: 'redirect_uris must contain at least one URI',
+      });
+    }
+    for (const uri of redirect_uris) {
+      if (typeof uri !== 'string' || !isValidRedirectUri(uri)) {
+        return res.status(400).json({
+          error: 'invalid_redirect_uri',
+          error_description: `redirect_uri must be https:// or http://localhost: got "${uri}"`,
+        });
+      }
+    }
+
+    // client_type: required, 'interactive' | 'autonomous'
+    if (client_type === undefined || client_type === null) {
+      return res.status(400).json({
+        error: 'invalid_client_metadata',
+        error_description: 'client_type is required',
+      });
+    }
+    if (client_type !== 'interactive' && client_type !== 'autonomous') {
+      return res.status(400).json({
+        error: 'invalid_client_metadata',
+        error_description: 'client_type must be "interactive" or "autonomous"',
+      });
+    }
+
+    // grant_types: optional; if present must include 'authorization_code'
+    if (grant_types !== undefined && grant_types !== null) {
+      if (!Array.isArray(grant_types) || !grant_types.includes('authorization_code')) {
+        return res.status(400).json({
+          error: 'invalid_client_metadata',
+          error_description: 'grant_types must include "authorization_code"',
+        });
+      }
+    }
+
+    // ── Registration ─────────────────────────────────────────────────────────
+
+    // The DAO takes redirect_uris as a string (joins with space per OAuth convention)
+    const { id: client_id, secret: client_secret } = clientsDao.register({
+      name: client_name,
+      redirect_uris: (redirect_uris as string[]).join(' '),
+      client_type: client_type as string,
+    });
+
+    return res.status(201).json({
+      client_id,
+      client_secret,
+      client_name,
+      redirect_uris,
+      client_type,
+      registration_access_token: null,
+    });
+  });
+
+  return router;
+}


### PR DESCRIPTION
## Summary
- Implements **FND-E12-S4** (E12: MCP Authorization)
- `POST /oauth/register` — RFC 7591 DCR with initial-access-token gate (`FOUNDRY_DCR_TOKEN`)
- Full validation: client_name/redirect_uris/client_type required; redirect_uris HTTPS or localhost only; grant_types must include authorization_code if present
- Uses `clientsDao.register` (S1) for persistence; bcrypt handled internally

## Why
Unblocks Claude.ai's hosted connector and any other MCP client that needs to dynamically register. Without this, OAuth clients cannot onboard.

## Acceptance Criteria
- [x] Valid Bearer + body → 201 + credentials
- [x] Missing/wrong Bearer → 401 `invalid_token` (timing-safe)
- [x] All validation error paths return the correct RFC 7591 error code
- [x] `client_secret` returned only at registration
- [x] Tests cover the matrix

## QA hints
- Key files: `packages/api/src/routes/oauth-register.ts`, test file, single-line additions to `index.ts`
- Env var `FOUNDRY_DCR_TOKEN` required at runtime — must be set in Fly secrets (noted in S12 pre-deploy)
- Token rotation = regenerate the secret; documented for S12 runbook

🤖 Generated with [Claude Code](https://claude.com/claude-code)