### PR TITLE
fix(proxy): route /oauth/* and /.well-known/* to Express

### DIFF
--- a/scripts/proxy.mjs
+++ b/scripts/proxy.mjs
@@ -1,8 +1,8 @@
 /**
  * Foundry Production Proxy
- * 
+ *
  * Single entry point on PORT (4321) that:
- * - Routes /api/* and /mcp/* to the Express API server (3001)
+ * - Routes /api/*, /mcp/*, /oauth/*, and /.well-known/* to the Express API (3001)
  * - Routes everything else through the Astro SSR handler
  */
 import http from 'node:http';
@@ -36,8 +36,13 @@ const server = http.createServer((req, res) => {
     return;
   }
 
-  // Route API and MCP requests to the Express backend
-  if (url.startsWith('/api/') || url.startsWith('/mcp/')) {
+  // Route API, MCP, OAuth, and well-known discovery requests to the Express backend
+  if (
+    url.startsWith('/api/') ||
+    url.startsWith('/mcp/') ||
+    url.startsWith('/oauth/') ||
+    url.startsWith('/.well-known/')
+  ) {
     const proxyReq = http.request(
       {
         hostname: '127.0.0.1',


### PR DESCRIPTION
## Summary

E12 wave 2 merges landed new Express routes at `/oauth/github/callback`, `/oauth/register`, and `/.well-known/oauth-*`, but **the production proxy (`scripts/proxy.mjs`) was not updated to forward those paths to Express**. The proxy only forwards `/api/*` and `/mcp/*`; everything else goes to Astro SSR — which has no such routes, so Astro returned its 404 page for all three OAuth endpoints.

## Why local smoke passed but prod smoke failed

My local smoke test hit Node directly on `localhost:3456` (Express). Prod traffic goes through the proxy on port 4321 first. The proxy's allowlist is what broke it — Express was fine, just unreachable for those paths.

## Change

Add `/oauth/` and `/.well-known/` to the Express-bound allowlist in `scripts/proxy.mjs`. No other proxy behavior changes. 7-line diff.

## Verification

After deploy:
```bash
curl https://foundry-claymore.fly.dev/.well-known/oauth-protected-resource
# expect: JSON { resource, authorization_servers, bearer_methods_supported }

curl -X POST https://foundry-claymore.fly.dev/oauth/register
# expect: 401 {"error":"invalid_token"}
```

## Iteration-log entry for /ship v2

When a PR adds new HTTP routes, `/ship`'s Phase 0 should also validate the **routing layer above Express** (proxy, CDN, ingress). "Route mounted in index.ts" is necessary but not sufficient for prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)