### PR TITLE
feat(oauth): dual-auth requireAuth middleware (FND-E12-S7)

### DIFF
--- a/packages/api/src/middleware/__tests__/auth.oauth.test.ts
+++ b/packages/api/src/middleware/__tests__/auth.oauth.test.ts
@@ -1,0 +1,534 @@
+/**
+ * Tests for FND-E12-S7: dual-auth requireAuth + requireScope middleware.
+ *
+ * Covers:
+ *   - OAuth happy path (valid token → req.user / req.client populated)
+ *   - Expired token → 401 with WWW-Authenticate
+ *   - Revoked token → 401 with WWW-Authenticate
+ *   - Deleted user → 401 invalid_token
+ *   - Deleted client → 401 invalid_token
+ *   - WWW-Authenticate header shape on no-token 401
+ *   - requireScope 403 insufficient_scope
+ *   - requireScope 200 when scope granted
+ *   - requireScope dev-mode passthrough (no req.user → next())
+ *   - Dev-mode passthrough preserved (no env + no header → 200)
+ *   - FOUNDRY_OAUTH_ISSUER fail-loud
+ *
+ * The existing legacy-path tests live in auth.test.ts and must pass
+ * unchanged — this file does not duplicate them.
+ */
+
+// Module-top env: matches the convention used by OAuth test suites.
+process.env.FOUNDRY_OAUTH_ISSUER = 'https://foundry.test';
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
+import express from 'express';
+import request from 'supertest';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { unlinkSync } from 'fs';
+import crypto from 'crypto';
+
+import { requireAuth, requireScope } from '../auth.js';
+import { getDb, closeDb } from '../../db.js';
+import { clientsDao, tokensDao, usersDao } from '../../oauth/dao.js';
+
+// ─── DB setup ─────────────────────────────────────────────────────────────────
+
+const testDbPath = join(
+  tmpdir(),
+  `foundry-auth-oauth-test-${process.pid}-${Date.now()}.db`
+);
+
+let userId: string;
+let clientId: string;
+
+function sha256Hex(s: string): string {
+  return crypto.createHash('sha256').update(s).digest('hex');
+}
+
+beforeAll(() => {
+  process.env.FOUNDRY_DB_PATH = testDbPath;
+  closeDb();
+  getDb(); // creates schema
+
+  const user = usersDao.upsert({ github_login: 'alice', github_id: 10101 });
+  userId = user.id;
+
+  const { id } = clientsDao.register({
+    name: 'Test Connector',
+    redirect_uris: 'https://example.com/cb',
+    client_type: 'autonomous',
+  });
+  clientId = id;
+});
+
+afterAll(() => {
+  closeDb();
+  try {
+    unlinkSync(testDbPath);
+  } catch {
+    /* ignore */
+  }
+  delete process.env.FOUNDRY_DB_PATH;
+});
+
+// ─── App helpers ──────────────────────────────────────────────────────────────
+
+/**
+ * Build a fresh app that exposes req.user / req.client / scopes on the
+ * response so assertions can verify the middleware populated them.
+ */
+function makeApp(): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.get('/protected', requireAuth, (req, res) => {
+    res.json({
+      success: true,
+      user: req.user,
+      client: req.client,
+    });
+  });
+  app.get(
+    '/read-private',
+    requireAuth,
+    requireScope('docs:read:private'),
+    (req, res) => {
+      res.json({ success: true, user: req.user });
+    }
+  );
+  // Generic error handler so thrown errors don't silently 500 with no body
+  app.use(
+    (
+      err: any,
+      _req: express.Request,
+      res: express.Response,
+      _next: express.NextFunction
+    ) => {
+      res.status(500).json({ error: err.message ?? 'internal error' });
+    }
+  );
+  return app;
+}
+
+/**
+ * Save and restore process.env.FOUNDRY_WRITE_TOKEN between tests.
+ */
+function withLegacyToken(value: string | undefined, fn: () => Promise<void>): () => Promise<void> {
+  return async () => {
+    const prev = process.env.FOUNDRY_WRITE_TOKEN;
+    if (value === undefined) {
+      delete process.env.FOUNDRY_WRITE_TOKEN;
+    } else {
+      process.env.FOUNDRY_WRITE_TOKEN = value;
+    }
+    try {
+      await fn();
+    } finally {
+      if (prev === undefined) {
+        delete process.env.FOUNDRY_WRITE_TOKEN;
+      } else {
+        process.env.FOUNDRY_WRITE_TOKEN = prev;
+      }
+    }
+  };
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// OAuth happy path
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('requireAuth — OAuth happy path (AC1)', () => {
+  it(
+    'populates req.user and req.client from a valid access token',
+    withLegacyToken(undefined, async () => {
+      const { access_token } = tokensDao.mint({
+        client_id: clientId,
+        user_id: userId,
+        scope: 'docs:read docs:write',
+      });
+
+      const app = makeApp();
+      const res = await request(app)
+        .get('/protected')
+        .set('Authorization', `Bearer ${access_token}`)
+        .expect(200);
+
+      expect(res.body.success).toBe(true);
+      expect(res.body.user.id).toBe(userId);
+      expect(res.body.user.github_login).toBe('alice');
+      expect(res.body.user.scopes).toEqual(['docs:read', 'docs:write']);
+      expect(res.body.client.id).toBe(clientId);
+      expect(res.body.client.name).toBe('Test Connector');
+      expect(res.body.client.client_type).toBe('autonomous');
+    })
+  );
+
+  it(
+    'splits scope string on whitespace and filters empties',
+    withLegacyToken(undefined, async () => {
+      const { access_token } = tokensDao.mint({
+        client_id: clientId,
+        user_id: userId,
+        scope: 'docs:read   docs:read:private',
+      });
+
+      const app = makeApp();
+      const res = await request(app)
+        .get('/protected')
+        .set('Authorization', `Bearer ${access_token}`)
+        .expect(200);
+
+      expect(res.body.user.scopes).toEqual(['docs:read', 'docs:read:private']);
+    })
+  );
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Legacy happy path — verify req.user / req.client populated (AC2 extension)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('requireAuth — legacy token populates req.user/req.client (AC2)', () => {
+  it(
+    'legacy FOUNDRY_WRITE_TOKEN match → req.user.id = legacy and all docs scopes',
+    withLegacyToken('the-legacy-break-glass-token', async () => {
+      const app = makeApp();
+      const res = await request(app)
+        .get('/protected')
+        .set('Authorization', 'Bearer the-legacy-break-glass-token')
+        .expect(200);
+
+      expect(res.body.user.id).toBe('legacy');
+      expect(res.body.user.github_login).toBe('legacy');
+      expect(res.body.user.scopes).toEqual(
+        expect.arrayContaining(['docs:read', 'docs:write', 'docs:read:private'])
+      );
+      expect(res.body.client.id).toBe('legacy');
+      expect(res.body.client.name).toBe('legacy-bearer');
+      expect(res.body.client.client_type).toBe('autonomous');
+    })
+  );
+
+  it(
+    'legacy match is tried before OAuth introspect — no DB lookup needed',
+    withLegacyToken('legacy-token-value', async () => {
+      // Present the legacy token. Even though OAuth DB lookups would
+      // fail, the request succeeds via the legacy path.
+      const app = makeApp();
+      await request(app)
+        .get('/protected')
+        .set('Authorization', 'Bearer legacy-token-value')
+        .expect(200);
+    })
+  );
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Expired / revoked (AC3, AC4)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('requireAuth — expired/revoked OAuth tokens', () => {
+  it(
+    'AC3 — expired access token → 401 with WWW-Authenticate',
+    withLegacyToken(undefined, async () => {
+      const { access_token } = tokensDao.mint({
+        client_id: clientId,
+        user_id: userId,
+        scope: 'docs:read',
+        access_ttl_seconds: -1, // already expired
+      });
+
+      const app = makeApp();
+      const res = await request(app)
+        .get('/protected')
+        .set('Authorization', `Bearer ${access_token}`)
+        .expect(401);
+
+      expect(res.headers['www-authenticate']).toMatch(/^Bearer /);
+      expect(res.headers['www-authenticate']).toContain('realm="foundry"');
+      expect(res.headers['www-authenticate']).toContain(
+        'resource_metadata="https://foundry.test/.well-known/oauth-protected-resource"'
+      );
+      expect(res.headers['www-authenticate']).toContain('error="invalid_token"');
+    })
+  );
+
+  it(
+    'AC4 — revoked access token → 401 with WWW-Authenticate',
+    withLegacyToken(undefined, async () => {
+      const { access_token } = tokensDao.mint({
+        client_id: clientId,
+        user_id: userId,
+        scope: 'docs:read',
+      });
+      tokensDao.revoke(access_token);
+
+      const app = makeApp();
+      const res = await request(app)
+        .get('/protected')
+        .set('Authorization', `Bearer ${access_token}`)
+        .expect(401);
+
+      expect(res.headers['www-authenticate']).toContain('error="invalid_token"');
+    })
+  );
+
+  it(
+    'introspect-miss keeps legacy-compat body { error: "Unauthorized" }',
+    withLegacyToken(undefined, async () => {
+      // A well-formed but unknown Bearer token — legacy isn't set, and
+      // introspect returns null. Body should remain Unauthorized per
+      // backwards-compat with the pre-E12 test contract.
+      const app = makeApp();
+      const res = await request(app)
+        .get('/protected')
+        .set('Authorization', 'Bearer this-is-not-a-real-token')
+        .expect(401);
+
+      expect(res.body).toEqual({ error: 'Unauthorized' });
+      expect(res.headers['www-authenticate']).toContain('error="invalid_token"');
+    })
+  );
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Deleted-user / deleted-client edge cases
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('requireAuth — deleted user/client references', () => {
+  it(
+    'valid token referencing a deleted user → 401 invalid_token',
+    withLegacyToken(undefined, async () => {
+      // Create a throwaway user + token, then delete the user row.
+      // Tokens table has a FK to users without ON DELETE CASCADE — disable
+      // FK enforcement for this simulated-edge-case setup. The middleware
+      // runs normal queries; only the setup disables FK briefly.
+      const throwaway = usersDao.upsert({
+        github_login: 'throwaway',
+        github_id: 777777,
+      });
+      const { access_token } = tokensDao.mint({
+        client_id: clientId,
+        user_id: throwaway.id,
+        scope: 'docs:read',
+      });
+      const db = getDb();
+      db.pragma('foreign_keys = OFF');
+      try {
+        db.prepare('DELETE FROM users WHERE id = ?').run(throwaway.id);
+      } finally {
+        db.pragma('foreign_keys = ON');
+      }
+
+      const app = makeApp();
+      const res = await request(app)
+        .get('/protected')
+        .set('Authorization', `Bearer ${access_token}`)
+        .expect(401);
+
+      expect(res.body.error).toBe('invalid_token');
+      expect(res.body.error_description).toMatch(/user/i);
+      expect(res.headers['www-authenticate']).toContain('error="invalid_token"');
+    })
+  );
+
+  it(
+    'valid token referencing a deleted client → 401 invalid_token',
+    withLegacyToken(undefined, async () => {
+      // Register a throwaway client, mint a token, then delete the client.
+      const throwaway = clientsDao.register({
+        name: 'Throwaway',
+        redirect_uris: 'https://example.com/cb',
+        client_type: 'interactive',
+      });
+      const { access_token } = tokensDao.mint({
+        client_id: throwaway.id,
+        user_id: userId,
+        scope: 'docs:read',
+      });
+      const db = getDb();
+      db.pragma('foreign_keys = OFF');
+      try {
+        db.prepare('DELETE FROM oauth_clients WHERE id = ?').run(throwaway.id);
+      } finally {
+        db.pragma('foreign_keys = ON');
+      }
+
+      const app = makeApp();
+      const res = await request(app)
+        .get('/protected')
+        .set('Authorization', `Bearer ${access_token}`)
+        .expect(401);
+
+      expect(res.body.error).toBe('invalid_token');
+      expect(res.body.error_description).toMatch(/client/i);
+      expect(res.headers['www-authenticate']).toContain('error="invalid_token"');
+    })
+  );
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// WWW-Authenticate shape on no-token (AC5)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('requireAuth — WWW-Authenticate header (AC5)', () => {
+  it(
+    'no Authorization header (with auth configured) → 401 with realm + resource_metadata',
+    withLegacyToken('any-legacy-token', async () => {
+      const app = makeApp();
+      const res = await request(app).get('/protected').expect(401);
+
+      expect(res.body).toEqual({ error: 'Unauthorized' });
+      const www = res.headers['www-authenticate'];
+      expect(www).toBeDefined();
+      expect(www).toContain('Bearer ');
+      expect(www).toContain('realm="foundry"');
+      expect(www).toContain(
+        'resource_metadata="https://foundry.test/.well-known/oauth-protected-resource"'
+      );
+      // No token presented — no error="invalid_token" attribute.
+      expect(www).not.toContain('error=');
+    })
+  );
+
+  it(
+    'malformed Authorization header → 401 no-token shape (no error attribute)',
+    withLegacyToken('any-legacy-token', async () => {
+      const app = makeApp();
+      const res = await request(app)
+        .get('/protected')
+        .set('Authorization', 'Basic something')
+        .expect(401);
+
+      expect(res.body).toEqual({ error: 'Unauthorized' });
+      expect(res.headers['www-authenticate']).not.toContain('error=');
+    })
+  );
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// requireScope
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('requireScope', () => {
+  it(
+    'AC6 — 403 insufficient_scope when user lacks required scope',
+    withLegacyToken(undefined, async () => {
+      const { access_token } = tokensDao.mint({
+        client_id: clientId,
+        user_id: userId,
+        scope: 'docs:read', // no docs:read:private
+      });
+
+      const app = makeApp();
+      const res = await request(app)
+        .get('/read-private')
+        .set('Authorization', `Bearer ${access_token}`)
+        .expect(403);
+
+      expect(res.body.error).toBe('insufficient_scope');
+      expect(res.body.error_description).toBe('Requires scope: docs:read:private');
+      expect(res.headers['www-authenticate']).toContain('error="insufficient_scope"');
+      expect(res.headers['www-authenticate']).toContain('scope="docs:read:private"');
+    })
+  );
+
+  it(
+    '200 when user has the required scope',
+    withLegacyToken(undefined, async () => {
+      const { access_token } = tokensDao.mint({
+        client_id: clientId,
+        user_id: userId,
+        scope: 'docs:read docs:read:private',
+      });
+
+      const app = makeApp();
+      const res = await request(app)
+        .get('/read-private')
+        .set('Authorization', `Bearer ${access_token}`)
+        .expect(200);
+
+      expect(res.body.success).toBe(true);
+      expect(res.body.user.scopes).toEqual(
+        expect.arrayContaining(['docs:read:private'])
+      );
+    })
+  );
+
+  it(
+    'legacy token inherits all three docs scopes → passes requireScope(docs:read:private)',
+    withLegacyToken('legacy', async () => {
+      const app = makeApp();
+      const res = await request(app)
+        .get('/read-private')
+        .set('Authorization', 'Bearer legacy')
+        .expect(200);
+
+      expect(res.body.user.id).toBe('legacy');
+    })
+  );
+
+  it(
+    'dev-mode passthrough (no req.user) → requireScope is a no-op',
+    withLegacyToken(undefined, async () => {
+      // No env, no header — requireAuth calls next() without populating
+      // req.user. requireScope must NOT block in this state (symmetric
+      // passthrough so local dev still works).
+      const app = makeApp();
+      const res = await request(app).get('/read-private').expect(200);
+      expect(res.body.success).toBe(true);
+    })
+  );
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Dev-mode passthrough (AC — regression guard)
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('requireAuth — dev-mode passthrough preserved', () => {
+  it(
+    'no FOUNDRY_WRITE_TOKEN + no Authorization header → 200 without populating req.user',
+    withLegacyToken(undefined, async () => {
+      const app = makeApp();
+      const res = await request(app).get('/protected').expect(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.user).toBeUndefined();
+      expect(res.body.client).toBeUndefined();
+    })
+  );
+
+  it(
+    'no FOUNDRY_WRITE_TOKEN + fake Bearer token → still validated as OAuth (fails)',
+    withLegacyToken(undefined, async () => {
+      // Dev-mode passthrough is ONLY for unauthenticated requests. A
+      // Bearer token in dev mode is still checked and must fail if
+      // it's not a real OAuth token.
+      const app = makeApp();
+      await request(app)
+        .get('/protected')
+        .set('Authorization', 'Bearer completely-fake-token')
+        .expect(401);
+    })
+  );
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// FOUNDRY_OAUTH_ISSUER fail-loud
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('requireAuth — FOUNDRY_OAUTH_ISSUER fail-loud', () => {
+  it(
+    'throws when FOUNDRY_OAUTH_ISSUER is unset at 401 time',
+    withLegacyToken('token-value', async () => {
+      const prev = process.env.FOUNDRY_OAUTH_ISSUER;
+      delete process.env.FOUNDRY_OAUTH_ISSUER;
+      try {
+        const app = makeApp();
+        const res = await request(app).get('/protected').expect(500);
+        expect(res.body.error).toMatch(/FOUNDRY_OAUTH_ISSUER/);
+      } finally {
+        if (prev !== undefined) process.env.FOUNDRY_OAUTH_ISSUER = prev;
+      }
+    })
+  );
+});

--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -1,61 +1,233 @@
+import crypto from 'crypto';
 import { Request, Response, NextFunction } from 'express';
+import { tokensDao, usersDao, clientsDao } from '../oauth/dao.js';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type AuthClientType = 'interactive' | 'autonomous';
+
+// ─── Parsing ──────────────────────────────────────────────────────────────────
 
 /**
- * Check if authentication is enabled (FOUNDRY_WRITE_TOKEN is set)
+ * Strict `Bearer <token>` header parser. Rejects "Bearer", "Bearer  foo"
+ * (double space), "Basic foo", and anything without a single-space separator.
  */
-function isAuthEnabled(): boolean {
+const BEARER_RE = /^Bearer ([^\s]+)$/;
+
+// ─── Legacy-token helpers ─────────────────────────────────────────────────────
+
+/**
+ * Scopes granted to the legacy FOUNDRY_WRITE_TOKEN. Intentionally broad —
+ * pre-OAuth callers had full write access. S9 tightens this per OAuth client.
+ */
+const LEGACY_SCOPES: string[] = ['docs:read', 'docs:write', 'docs:read:private'];
+
+/**
+ * Timing-safe comparison for legacy tokens. Short-circuits on length
+ * mismatch (safe; lengths are not secret).
+ */
+function legacyTokenMatches(provided: string, expected: string): boolean {
+  if (provided.length !== expected.length) return false;
+  return crypto.timingSafeEqual(Buffer.from(provided), Buffer.from(expected));
+}
+
+// ─── Auth-enabled detection ───────────────────────────────────────────────────
+
+/**
+ * Auth is considered "configured" if either legacy or OAuth knobs are set.
+ * When neither is set AND no Authorization header is sent, we fall through
+ * as dev-mode passthrough (preserves existing local-dev UX).
+ *
+ * Note: the existence of an Authorization header on an otherwise-unconfigured
+ * dev machine still routes through OAuth validation (and fails), so agents
+ * sending fake tokens get 401s rather than silent passthrough.
+ */
+function isLegacyConfigured(): boolean {
   return !!process.env.FOUNDRY_WRITE_TOKEN;
 }
 
+// ─── WWW-Authenticate helpers ─────────────────────────────────────────────────
+
 /**
- * Bearer token authentication middleware
+ * Build the WWW-Authenticate header value for the Bearer-protected resource.
+ * Fails loud if FOUNDRY_OAUTH_ISSUER is unset — server misconfiguration per D-spec-1.
+ */
+function buildWwwAuthenticate(error?: string): string {
+  const issuer = process.env.FOUNDRY_OAUTH_ISSUER;
+  if (!issuer) {
+    throw new Error('FOUNDRY_OAUTH_ISSUER is required but not set');
+  }
+
+  const parts = [
+    `realm="foundry"`,
+    `resource_metadata="${issuer}/.well-known/oauth-protected-resource"`,
+  ];
+  if (error) {
+    parts.push(`error="${error}"`);
+  }
+  return `Bearer ${parts.join(', ')}`;
+}
+
+// Missing / malformed Authorization header — no token was meaningfully
+// presented. Body is `{ error: 'Unauthorized' }` for backwards-compat
+// with the pre-E12 test suite and existing CLI clients that string-match.
+function send401NoToken(res: Response): void {
+  res.setHeader('WWW-Authenticate', buildWwwAuthenticate());
+  res.status(401).json({ error: 'Unauthorized' });
+}
+
+// Well-formed Bearer token that failed validation (unknown hash,
+// expired, revoked, or legacy-mismatch that also wasn't a real OAuth
+// token). WWW-Authenticate signals `error="invalid_token"` per RFC 6750,
+// but the JSON body keeps `Unauthorized` for compat with pre-E12 tests.
+function send401TokenRejected(res: Response): void {
+  res.setHeader('WWW-Authenticate', buildWwwAuthenticate('invalid_token'));
+  res.status(401).json({ error: 'Unauthorized' });
+}
+
+// Valid token referencing a user/client row that has since been deleted.
+// Distinct diagnostic case — use the richer RFC 6750 body since no
+// existing tests assert on it.
+function send401BrokenReference(res: Response, description: string): void {
+  res.setHeader('WWW-Authenticate', buildWwwAuthenticate('invalid_token'));
+  res.status(401).json({ error: 'invalid_token', error_description: description });
+}
+
+// ─── requireAuth ──────────────────────────────────────────────────────────────
+
+/**
+ * Dual-auth Bearer middleware.
  *
- * Protects routes by requiring a valid Authorization: Bearer <token> header
- * that matches the FOUNDRY_WRITE_TOKEN environment variable.
+ * Accepts either:
+ *  1. Legacy FOUNDRY_WRITE_TOKEN (break-glass fallback during OAuth rollout)
+ *  2. OAuth access token minted via /oauth/token (S6)
  *
- * If FOUNDRY_WRITE_TOKEN is not set, all requests are allowed through (dev mode).
+ * On success populates `req.user` and `req.client` for downstream
+ * middleware / handlers. Exports stays `requireAuth` (D11) — existing
+ * callers need no changes.
+ *
+ * Dev-mode passthrough: if FOUNDRY_WRITE_TOKEN is unset AND the request
+ * has no Authorization header, next() is called without populating
+ * req.user / req.client. This keeps local dev working without any auth
+ * configured. Any request that DOES present a Bearer token will still
+ * be validated — fake tokens fail.
  */
 export function requireAuth(req: Request, res: Response, next: NextFunction): void {
-  // If auth token is not configured, allow all requests (dev mode)
-  if (!isAuthEnabled()) {
+  const authHeader = req.headers.authorization;
+
+  // Dev-mode passthrough — nothing configured, nothing sent.
+  if (!isLegacyConfigured() && !authHeader) {
+    // Explicitly null out Node's http built-in `req.client` alias (it
+    // points at the underlying Socket). Downstream code treats
+    // `req.client` as an AuthClient | undefined and must not see the
+    // Socket. `req.user` has no Node alias and is already undefined.
+    req.client = undefined;
     return next();
   }
 
-  const authHeader = req.headers.authorization;
-
-  // Check if Authorization header exists
+  // Missing header while auth is configured → 401 no-token shape.
   if (!authHeader) {
-    res.status(401).json({ error: 'Unauthorized' });
-    return;
+    return send401NoToken(res);
   }
 
-  // Check if header follows Bearer token format
-  if (!authHeader.startsWith('Bearer ')) {
-    res.status(401).json({ error: 'Unauthorized' });
-    return;
+  const match = BEARER_RE.exec(authHeader);
+  if (!match) {
+    return send401NoToken(res);
+  }
+  const token = match[1];
+
+  // ── Path 1: legacy FOUNDRY_WRITE_TOKEN ─────────────────────────────────────
+  const legacyToken = process.env.FOUNDRY_WRITE_TOKEN;
+  if (legacyToken && legacyTokenMatches(token, legacyToken)) {
+    req.user = {
+      id: 'legacy',
+      github_login: 'legacy',
+      scopes: [...LEGACY_SCOPES],
+    };
+    req.client = {
+      id: 'legacy',
+      name: 'legacy-bearer',
+      client_type: 'autonomous',
+    };
+    return next();
   }
 
-  // Extract token from "Bearer <token>" format
-  const token = authHeader.slice(7);
-  const expectedToken = process.env.FOUNDRY_WRITE_TOKEN;
-
-  // Verify token matches expected value
-  if (token !== expectedToken) {
-    res.status(401).json({ error: 'Unauthorized' });
-    return;
+  // ── Path 2: OAuth Bearer token ─────────────────────────────────────────────
+  // introspect returns null for unknown/revoked/expired tokens, and also
+  // covers the wrong-legacy-token case that fell through above.
+  const info = tokensDao.introspect(token);
+  if (!info) {
+    return send401TokenRejected(res);
   }
 
-  // Token is valid, proceed to next middleware/route handler
-  next();
+  const user = usersDao.findById(info.user_id);
+  if (!user) {
+    return send401BrokenReference(res, 'The access token references a user that no longer exists');
+  }
+
+  const client = clientsDao.findById(info.client_id);
+  if (!client) {
+    return send401BrokenReference(res, 'The access token references a client that no longer exists');
+  }
+
+  req.user = {
+    id: user.id,
+    github_login: user.github_login,
+    scopes: info.scope.split(' ').filter(Boolean),
+  };
+  req.client = {
+    id: client.id,
+    name: client.name,
+    // DAO persists client_type as string; downstream code expects the narrowed
+    // union. Cast is safe given /oauth/register validates to these two values.
+    client_type: client.client_type as AuthClientType,
+  };
+  return next();
 }
 
+// ─── requireScope ─────────────────────────────────────────────────────────────
+
 /**
- * Log authentication status on server startup
+ * Scope gate. Must be used AFTER requireAuth.
+ *
+ * Returns 403 insufficient_scope if the user is authenticated but lacks
+ * the required scope. If req.user is undefined (dev-mode passthrough),
+ * behaves as a no-op — symmetric with requireAuth's dev-mode behavior so
+ * local dev stays unblocked.
+ */
+export function requireScope(scope: string): (req: Request, res: Response, next: NextFunction) => void {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    // Dev-mode passthrough — requireAuth left req.user undefined because
+    // nothing was configured. Treat as "all scopes granted".
+    if (!req.user) {
+      return next();
+    }
+
+    if (!req.user.scopes.includes(scope)) {
+      res.setHeader(
+        'WWW-Authenticate',
+        `Bearer error="insufficient_scope", scope="${scope}"`
+      );
+      res.status(403).json({
+        error: 'insufficient_scope',
+        error_description: `Requires scope: ${scope}`,
+      });
+      return;
+    }
+
+    return next();
+  };
+}
+
+// ─── Startup log ──────────────────────────────────────────────────────────────
+
+/**
+ * Log authentication status on server startup.
  */
 export function logAuthStatus(): void {
-  if (isAuthEnabled()) {
-    console.log('🔒 Authentication enabled for write operations');
+  if (isLegacyConfigured()) {
+    console.log('🔒 Authentication enabled for write operations (legacy + OAuth)');
   } else {
-    console.log('⚠️ Authentication disabled (dev mode) - set FOUNDRY_WRITE_TOKEN to enable');
+    console.log('⚠️ Authentication disabled (dev mode) - set FOUNDRY_WRITE_TOKEN to enable legacy auth; OAuth still validated when presented');
   }
 }

--- a/packages/api/src/types/express.d.ts
+++ b/packages/api/src/types/express.d.ts
@@ -1,0 +1,34 @@
+/**
+ * Express Request type augmentation for OAuth-aware auth middleware.
+ *
+ * `requireAuth` (packages/api/src/middleware/auth.ts) populates `req.user`
+ * and `req.client` after successfully validating either an OAuth Bearer
+ * token or the legacy FOUNDRY_WRITE_TOKEN. Downstream middleware (e.g.
+ * requireScope) and route handlers read these fields for identity and
+ * scope checks.
+ *
+ * Both fields are optional because in dev mode (no FOUNDRY_WRITE_TOKEN
+ * configured AND no Authorization header on the request), requireAuth
+ * calls next() without populating identity.
+ */
+
+export interface AuthUser {
+  id: string;
+  github_login: string;
+  scopes: string[];
+}
+
+export interface AuthClient {
+  id: string;
+  name: string;
+  client_type: 'interactive' | 'autonomous';
+}
+
+declare global {
+  namespace Express {
+    interface Request {
+      user?: AuthUser;
+      client?: AuthClient;
+    }
+  }
+}

--- a/packages/api/vitest.config.ts
+++ b/packages/api/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+
+/**
+ * Vitest configuration for @foundry/api.
+ *
+ * `setupFiles` is applied before each test file's modules load, so it
+ * provides safe defaults for env vars the middleware / OAuth code
+ * expects. Individual test files can override these with module-top
+ * `process.env.X = '...'` assignments.
+ */
+export default defineConfig({
+  test: {
+    setupFiles: ['./vitest.setup.ts'],
+  },
+});

--- a/packages/api/vitest.setup.ts
+++ b/packages/api/vitest.setup.ts
@@ -1,0 +1,17 @@
+/**
+ * Global vitest setup — runs before every test file.
+ *
+ * Sets safe defaults for OAuth env vars so that middleware paths that
+ * require them (e.g. WWW-Authenticate header construction in
+ * packages/api/src/middleware/auth.ts) don't blow up in tests that
+ * predate E12 and weren't written with an issuer in mind.
+ *
+ * Individual test files may override these before importing modules
+ * under test — process.env assignments at the module top of a test
+ * file run before this setup is applied on reload but tests that don't
+ * care inherit these defaults.
+ */
+
+if (!process.env.FOUNDRY_OAUTH_ISSUER) {
+  process.env.FOUNDRY_OAUTH_ISSUER = 'https://foundry.test';
+}


### PR DESCRIPTION
## Story
FND-E12-S7 — dual-auth requireAuth middleware (Phase 2 entry)

## What changed
- Replaced internals of `requireAuth` in `packages/api/src/middleware/auth.ts`. Exported symbol stays `requireAuth` (per D11) so all existing route-level imports work untouched.
- Legacy FOUNDRY_WRITE_TOKEN path matched first with `crypto.timingSafeEqual`, then falls through to OAuth `tokensDao.introspect`. On valid OAuth, the middleware looks up the user + client and populates `req.user = { id, github_login, scopes }` and `req.client = { id, name, client_type }`. `client_type` is included now per forward-looking D-S8-1 so S8 doesn't need to re-touch this file.
- Added `requireScope(scope: string)` middleware factory. Returns 403 `insufficient_scope` with RFC 6750 `WWW-Authenticate: Bearer error="insufficient_scope", scope="..."` header when the authenticated user lacks the scope. Dev-mode passthrough (unpopulated `req.user`) treats as "all scopes granted" to keep local dev unblocked.
- Added spec-compliant WWW-Authenticate header on 401. Realm + `resource_metadata` derived from `FOUNDRY_OAUTH_ISSUER` (fails loud if unset, per D-spec-1).
- Body shape preserved for pre-E12 callers: missing/malformed header and well-formed-but-unknown tokens return `{ error: 'Unauthorized' }`. Deleted-user / deleted-client edge cases return the richer RFC 6750 body `{ error: 'invalid_token', error_description: '...' }`.
- Added `packages/api/src/types/express.d.ts` to augment `Express.Request` with optional `user?: AuthUser` and `client?: AuthClient` fields. No existing augmentation file existed.
- Added `packages/api/vitest.config.ts` + `vitest.setup.ts` to set a safe `FOUNDRY_OAUTH_ISSUER` default for tests. Individual test files that already set it at module-top continue to take precedence. This is needed because the pre-E12 `auth.test.ts` (unchanged) predates OAuth and doesn't set the var, and the new 401 path requires it to build WWW-Authenticate.
- 18 new tests in `packages/api/src/middleware/__tests__/auth.oauth.test.ts` — existing `auth.test.ts` left untouched.

## AC-to-diff mapping
- AC1 (valid OAuth → req.user + req.client populated) → `packages/api/src/middleware/auth.ts:173-184`; tests in `auth.oauth.test.ts:132-171`
- AC2 (valid legacy token → req.user.id = 'legacy', three docs scopes) → `auth.ts:141-153`; tests in `auth.oauth.test.ts:178-214`
- AC3 (expired OAuth token → 401 + WWW-Authenticate) → `auth.ts:158-161`; test `auth.oauth.test.ts:223-245`
- AC4 (revoked OAuth token → 401 + WWW-Authenticate) → `auth.ts:158-161`; test `auth.oauth.test.ts:250-268`
- AC5 (no Authorization header → 401 with realm + resource_metadata WWW-Authenticate) → `auth.ts:128-131, 71-77`; test `auth.oauth.test.ts:381-406`
- AC6 (requireScope 403 insufficient_scope) → `auth.ts:206-216`; test `auth.oauth.test.ts:425-446`
- AC7 (existing auth.test.ts unchanged) → confirmed: `git diff main -- packages/api/src/middleware/__tests__/auth.test.ts` shows no changes. All 6 existing tests pass.
- AC8 (new OAuth tests) → `packages/api/src/middleware/__tests__/auth.oauth.test.ts` (18 tests)

## QA notes
- Backend-only, no visual surface.
- Critical: existing `auth.test.ts` passes with zero changes (verified by grep + test runner).
- Dev-mode passthrough preserved: no WRITE_TOKEN env + no auth header → next() without populating req.user. A Bearer token in dev mode IS still validated (fake tokens 401).
- No route changes in this PR — S8/S9 will start consuming req.user.id.
- `FOUNDRY_OAUTH_ISSUER` is now required when any 401 path fires. Production already sets this for S6 discovery endpoints; no new env var to configure.
- Node's `req.client` is a deprecated alias for `req.socket`. The middleware explicitly overrides `req.client` in all branches (including setting `req.client = undefined` in dev-mode passthrough) so downstream handlers never accidentally see the Socket when JSON-serializing auth state.
- Smoke URLs for post-merge prod probe:
  - `GET /api/annotations` without token → 401 with WWW-Authenticate header present (realm="foundry", resource_metadata pointer).
  - `GET /api/annotations` with legacy FOUNDRY_WRITE_TOKEN → 200 (if creds exist).

## Known-flaky unrelated test
During full-suite runs I saw `src/routes/__tests__/oauth-register.test.ts` "accepts client_name at exactly 100 chars" flake once with a 404 (then pass on next run and every subsequent run). Appears to be pre-existing flakiness in that suite's app bootstrap — unrelated to this change. Flagging so it doesn't get attributed to S7.

## Test plan
- [x] `npm test` passes — 390 tests (372 baseline + 18 new).
- [x] `tsc` clean via `npm run build`.
- [ ] Post-merge: orchestrator probes `/api/annotations` for 401 WWW-Authenticate shape.