### PR TITLE
FND-E12-S9: per-user docs:read:private scope (fixes #99)

### DIFF
--- a/packages/api/src/middleware/__tests__/auth.oauth.test.ts
+++ b/packages/api/src/middleware/__tests__/auth.oauth.test.ts
@@ -29,7 +29,7 @@ import { tmpdir } from 'os';
 import { unlinkSync } from 'fs';
 import crypto from 'crypto';
 
-import { requireAuth, requireScope } from '../auth.js';
+import { requireAuth, requireScope, softAuth } from '../auth.js';
 import { getDb, closeDb } from '../../db.js';
 import { clientsDao, tokensDao, usersDao } from '../../oauth/dao.js';
 
@@ -529,6 +529,158 @@ describe('requireAuth — FOUNDRY_OAUTH_ISSUER fail-loud', () => {
       } finally {
         if (prev !== undefined) process.env.FOUNDRY_OAUTH_ISSUER = prev;
       }
+    })
+  );
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// S9 — softAuth: populates req.user on valid token, never 401s on failure
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Build a fresh app that uses softAuth and exposes req.user / req.client on
+ * the response so assertions can verify the middleware populated them.
+ */
+function makeSoftAuthApp(): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.get('/soft', softAuth, (req, res) => {
+    res.json({
+      success: true,
+      authenticated: !!req.user,
+      user: req.user,
+      client: req.client,
+    });
+  });
+  app.use(
+    (
+      err: any,
+      _req: express.Request,
+      res: express.Response,
+      _next: express.NextFunction
+    ) => {
+      res.status(500).json({ error: err.message ?? 'internal error' });
+    }
+  );
+  return app;
+}
+
+describe('softAuth — S9 soft introspection middleware', () => {
+  it(
+    'no Authorization header → next() with req.user undefined (no 401)',
+    withLegacyToken(undefined, async () => {
+      const res = await request(makeSoftAuthApp()).get('/soft').expect(200);
+      expect(res.body.authenticated).toBe(false);
+      expect(res.body.user).toBeUndefined();
+      expect(res.body.client).toBeUndefined();
+    })
+  );
+
+  it(
+    'missing header even when legacy token is configured → 200 (no 401)',
+    withLegacyToken('some-legacy-token', async () => {
+      // Key difference from requireAuth: this scenario 401s under requireAuth
+      // but MUST NOT 401 under softAuth (browser anonymous search).
+      const res = await request(makeSoftAuthApp()).get('/soft').expect(200);
+      expect(res.body.authenticated).toBe(false);
+    })
+  );
+
+  it(
+    'malformed Authorization header → next() with req.user undefined (no 401)',
+    withLegacyToken(undefined, async () => {
+      const res = await request(makeSoftAuthApp())
+        .get('/soft')
+        .set('Authorization', 'Basic something')
+        .expect(200);
+      expect(res.body.authenticated).toBe(false);
+    })
+  );
+
+  it(
+    'unknown/invalid Bearer token → next() with req.user undefined (no 401)',
+    withLegacyToken(undefined, async () => {
+      const res = await request(makeSoftAuthApp())
+        .get('/soft')
+        .set('Authorization', 'Bearer this-is-not-a-real-token')
+        .expect(200);
+      expect(res.body.authenticated).toBe(false);
+    })
+  );
+
+  it(
+    'valid OAuth token → req.user + req.client populated, 200',
+    withLegacyToken(undefined, async () => {
+      const { access_token } = tokensDao.mint({
+        client_id: clientId,
+        user_id: userId,
+        scope: 'docs:read docs:read:private',
+      });
+
+      const res = await request(makeSoftAuthApp())
+        .get('/soft')
+        .set('Authorization', `Bearer ${access_token}`)
+        .expect(200);
+
+      expect(res.body.authenticated).toBe(true);
+      expect(res.body.user.id).toBe(userId);
+      expect(res.body.user.github_login).toBe('alice');
+      expect(res.body.user.scopes).toEqual(['docs:read', 'docs:read:private']);
+      expect(res.body.client.id).toBe(clientId);
+    })
+  );
+
+  it(
+    'valid legacy token → legacy user/client populated, 200',
+    withLegacyToken('legacy-break-glass', async () => {
+      const res = await request(makeSoftAuthApp())
+        .get('/soft')
+        .set('Authorization', 'Bearer legacy-break-glass')
+        .expect(200);
+
+      expect(res.body.authenticated).toBe(true);
+      expect(res.body.user.id).toBe('legacy');
+      expect(res.body.user.scopes).toEqual(
+        expect.arrayContaining(['docs:read', 'docs:write', 'docs:read:private'])
+      );
+    })
+  );
+
+  it(
+    'revoked Bearer token → next() with req.user undefined (no 401)',
+    withLegacyToken(undefined, async () => {
+      const { access_token } = tokensDao.mint({
+        client_id: clientId,
+        user_id: userId,
+        scope: 'docs:read',
+      });
+      tokensDao.revoke(access_token);
+
+      const res = await request(makeSoftAuthApp())
+        .get('/soft')
+        .set('Authorization', `Bearer ${access_token}`)
+        .expect(200);
+
+      expect(res.body.authenticated).toBe(false);
+    })
+  );
+
+  it(
+    'expired Bearer token → next() with req.user undefined (no 401)',
+    withLegacyToken(undefined, async () => {
+      const { access_token } = tokensDao.mint({
+        client_id: clientId,
+        user_id: userId,
+        scope: 'docs:read',
+        access_ttl_seconds: -1,
+      });
+
+      const res = await request(makeSoftAuthApp())
+        .get('/soft')
+        .set('Authorization', `Bearer ${access_token}`)
+        .expect(200);
+
+      expect(res.body.authenticated).toBe(false);
     })
   );
 });

--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -93,6 +93,92 @@ function send401BrokenReference(res: Response, description: string): void {
   res.status(401).json({ error: 'invalid_token', error_description: description });
 }
 
+// ─── Token resolution (shared internal) ───────────────────────────────────────
+
+/**
+ * Outcome of resolving a Bearer token, shared between requireAuth and softAuth.
+ *
+ *  - 'ok': valid token; req.user / req.client are ready to populate (on the caller).
+ *  - 'invalid_token': well-formed Bearer but the token didn't introspect
+ *                     (unknown/expired/revoked, and also not a legacy match).
+ *  - 'user_gone' / 'client_gone': token introspected but referenced row deleted.
+ */
+type TokenResolution =
+  | {
+      kind: 'ok';
+      user: AuthUser;
+      client: AuthClient;
+    }
+  | { kind: 'invalid_token' }
+  | { kind: 'user_gone' }
+  | { kind: 'client_gone' };
+
+type AuthUser = NonNullable<Request['user']>;
+type AuthClient = NonNullable<Request['client']>;
+
+/**
+ * Resolve a raw Bearer token to an authenticated user + client, or classify
+ * the failure. No side effects — caller decides whether to respond, next(),
+ * or populate req.
+ *
+ * Legacy FOUNDRY_WRITE_TOKEN is tried first (timing-safe compare); on miss
+ * we fall through to OAuth introspection. This matches the original
+ * requireAuth ordering from S7.
+ */
+function resolveBearerToken(token: string): TokenResolution {
+  // ── Path 1: legacy FOUNDRY_WRITE_TOKEN ─────────────────────────────────────
+  const legacyToken = process.env.FOUNDRY_WRITE_TOKEN;
+  if (legacyToken && legacyTokenMatches(token, legacyToken)) {
+    return {
+      kind: 'ok',
+      user: {
+        id: 'legacy',
+        github_login: 'legacy',
+        scopes: [...LEGACY_SCOPES],
+      },
+      client: {
+        id: 'legacy',
+        name: 'legacy-bearer',
+        client_type: 'autonomous',
+      },
+    };
+  }
+
+  // ── Path 2: OAuth Bearer token ─────────────────────────────────────────────
+  // introspect returns null for unknown/revoked/expired tokens, and also
+  // covers the wrong-legacy-token case that fell through above.
+  const info = tokensDao.introspect(token);
+  if (!info) {
+    return { kind: 'invalid_token' };
+  }
+
+  const user = usersDao.findById(info.user_id);
+  if (!user) {
+    return { kind: 'user_gone' };
+  }
+
+  const client = clientsDao.findById(info.client_id);
+  if (!client) {
+    return { kind: 'client_gone' };
+  }
+
+  return {
+    kind: 'ok',
+    user: {
+      id: user.id,
+      github_login: user.github_login,
+      scopes: info.scope.split(' ').filter(Boolean),
+    },
+    client: {
+      id: client.id,
+      name: client.name,
+      // DAO persists client_type as string; downstream code expects the narrowed
+      // union. Cast is safe given /oauth/register validates to these two values.
+      client_type: client.client_type as AuthClientType,
+    },
+  };
+}
+
 // ─── requireAuth ──────────────────────────────────────────────────────────────
 
 /**
@@ -136,52 +222,64 @@ export function requireAuth(req: Request, res: Response, next: NextFunction): vo
   }
   const token = match[1];
 
-  // ── Path 1: legacy FOUNDRY_WRITE_TOKEN ─────────────────────────────────────
-  const legacyToken = process.env.FOUNDRY_WRITE_TOKEN;
-  if (legacyToken && legacyTokenMatches(token, legacyToken)) {
-    req.user = {
-      id: 'legacy',
-      github_login: 'legacy',
-      scopes: [...LEGACY_SCOPES],
-    };
-    req.client = {
-      id: 'legacy',
-      name: 'legacy-bearer',
-      client_type: 'autonomous',
-    };
+  const outcome = resolveBearerToken(token);
+  switch (outcome.kind) {
+    case 'ok':
+      req.user = outcome.user;
+      req.client = outcome.client;
+      return next();
+    case 'invalid_token':
+      return send401TokenRejected(res);
+    case 'user_gone':
+      return send401BrokenReference(res, 'The access token references a user that no longer exists');
+    case 'client_gone':
+      return send401BrokenReference(res, 'The access token references a client that no longer exists');
+  }
+}
+
+// ─── softAuth ─────────────────────────────────────────────────────────────────
+
+/**
+ * Soft introspection middleware — populates req.user / req.client on a valid
+ * Bearer token, but NEVER 401s on failure.
+ *
+ * Used by routes that must serve anonymous traffic but want to upgrade the
+ * response when a valid token is present — specifically /api/search, which
+ * is the only auth-optional route in the system (browser anonymous search
+ * is a product requirement).
+ *
+ * Behavior matrix:
+ *   - Missing Authorization header → next() with req.user undefined
+ *   - Malformed Bearer header       → next() with req.user undefined
+ *   - Unknown/expired/revoked token → next() with req.user undefined
+ *   - Deleted user/client reference → next() with req.user undefined
+ *   - Valid token                    → req.user + req.client populated, next()
+ *
+ * Handlers read req.user?.scopes to decide what to return (public-only vs
+ * full). Do NOT use this for write routes — those must use requireAuth.
+ */
+export function softAuth(req: Request, _res: Response, next: NextFunction): void {
+  // Start clean — same safety as requireAuth for Node's http built-in
+  // req.client alias (points at Socket). Downstream code must not see it.
+  req.client = undefined;
+
+  const authHeader = req.headers.authorization;
+  if (!authHeader) {
     return next();
   }
 
-  // ── Path 2: OAuth Bearer token ─────────────────────────────────────────────
-  // introspect returns null for unknown/revoked/expired tokens, and also
-  // covers the wrong-legacy-token case that fell through above.
-  const info = tokensDao.introspect(token);
-  if (!info) {
-    return send401TokenRejected(res);
+  const match = BEARER_RE.exec(authHeader);
+  if (!match) {
+    return next();
   }
+  const token = match[1];
 
-  const user = usersDao.findById(info.user_id);
-  if (!user) {
-    return send401BrokenReference(res, 'The access token references a user that no longer exists');
+  const outcome = resolveBearerToken(token);
+  if (outcome.kind === 'ok') {
+    req.user = outcome.user;
+    req.client = outcome.client;
   }
-
-  const client = clientsDao.findById(info.client_id);
-  if (!client) {
-    return send401BrokenReference(res, 'The access token references a client that no longer exists');
-  }
-
-  req.user = {
-    id: user.id,
-    github_login: user.github_login,
-    scopes: info.scope.split(' ').filter(Boolean),
-  };
-  req.client = {
-    id: client.id,
-    name: client.name,
-    // DAO persists client_type as string; downstream code expects the narrowed
-    // union. Cast is safe given /oauth/register validates to these two values.
-    client_type: client.client_type as AuthClientType,
-  };
+  // All failure cases fall through with req.user undefined — never 401.
   return next();
 }
 

--- a/packages/api/src/routes/__tests__/pages.test.ts
+++ b/packages/api/src/routes/__tests__/pages.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Tests for FND-E12-S9: /api/pages scope-aware auth.
+ *
+ * Matrix covered:
+ *   - AC4: include_private=true + OAuth user WITHOUT docs:read:private → 403
+ *   - AC5: include_private=true + no auth                              → 401 w/ WWW-Authenticate
+ *   - AC6: include_private=false (or unset) + no auth                  → 200, public pages only
+ *   - AC4+ve: include_private=true + OAuth user WITH docs:read:private → 200, all pages
+ *   - Legacy FOUNDRY_WRITE_TOKEN still works (backcompat)
+ */
+
+// Module-top env: WWW-Authenticate builder requires this.
+process.env.FOUNDRY_OAUTH_ISSUER = 'https://foundry.test';
+
+import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { unlinkSync } from 'fs';
+import { createPagesRouter } from '../pages.js';
+import { getDb, closeDb } from '../../db.js';
+import { clientsDao, tokensDao, usersDao } from '../../oauth/dao.js';
+import * as navGenerator from '../../utils/nav-generator.js';
+import * as config from '../../config.js';
+
+// ─── Test DB setup ────────────────────────────────────────────────────────────
+
+const testDbPath = join(
+  tmpdir(),
+  `foundry-pages-test-${process.pid}-${Date.now()}.db`
+);
+
+let userId: string;
+let clientId: string;
+
+// Two pages — one public, one private — covers both filtering branches.
+const MOCK_PAGES = [
+  { title: 'Public Doc', path: 'methodology/process.md', access: 'public' as const },
+  { title: 'Private Doc', path: 'projects/secret/design.md', access: 'private' as const },
+];
+
+beforeAll(() => {
+  process.env.FOUNDRY_DB_PATH = testDbPath;
+  closeDb();
+  getDb();
+
+  const user = usersDao.upsert({ github_login: 'eve', github_id: 555555 });
+  userId = user.id;
+
+  const { id } = clientsDao.register({
+    name: 'Pages Test Connector',
+    redirect_uris: 'https://example.com/cb',
+    client_type: 'autonomous',
+  });
+  clientId = id;
+});
+
+afterAll(() => {
+  closeDb();
+  try {
+    unlinkSync(testDbPath);
+  } catch {
+    /* ignore */
+  }
+  delete process.env.FOUNDRY_DB_PATH;
+});
+
+// ─── Shared app factory ───────────────────────────────────────────────────────
+
+function makeApp(): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.use('/api', createPagesRouter());
+  return app;
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  vi.spyOn(navGenerator, 'generateNavPages').mockReturnValue([...MOCK_PAGES]);
+  vi.spyOn(config, 'getDocsPath').mockReturnValue('/fake/docs');
+  // Ensure no lingering legacy token unless a test opts in.
+  delete process.env.FOUNDRY_WRITE_TOKEN;
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// AC6 — no flag (or flag=false) → public-only, no auth required
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('GET /api/pages — no include_private flag', () => {
+  it('AC6 — no flag + no auth → 200 with public pages only', async () => {
+    const res = await request(makeApp()).get('/api/pages').expect(200);
+
+    expect(res.body).toEqual([
+      { title: 'Public Doc', path: 'methodology/process.md', access: 'public' },
+    ]);
+  });
+
+  it('AC6 — include_private=false + no auth → 200 with public pages only', async () => {
+    const res = await request(makeApp())
+      .get('/api/pages?include_private=false')
+      .expect(200);
+
+    expect(res.body).toEqual([
+      { title: 'Public Doc', path: 'methodology/process.md', access: 'public' },
+    ]);
+  });
+
+  it('no flag + valid OAuth token (any scope) → still public-only (flag controls, not scope)', async () => {
+    const { access_token } = tokensDao.mint({
+      client_id: clientId,
+      user_id: userId,
+      scope: 'docs:read docs:read:private',
+    });
+
+    const res = await request(makeApp())
+      .get('/api/pages')
+      .set('Authorization', `Bearer ${access_token}`)
+      .expect(200);
+
+    // Flag absent → public-only regardless of what the token grants.
+    expect(res.body).toEqual([
+      { title: 'Public Doc', path: 'methodology/process.md', access: 'public' },
+    ]);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// AC5 — include_private=true without auth → 401 WWW-Authenticate
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('GET /api/pages?include_private=true — unauthenticated', () => {
+  it('AC5 — no auth + legacy token configured → 401 with WWW-Authenticate', async () => {
+    // S7 requireAuth only 401s on missing header when auth is "configured"
+    // (legacy env var set OR real Bearer presented). Set the env var so
+    // missing-header lands in the 401 path, exercising AC5's WWW-Authenticate.
+    process.env.FOUNDRY_WRITE_TOKEN = 'some-legacy-token';
+
+    const res = await request(makeApp())
+      .get('/api/pages?include_private=true')
+      .expect(401);
+
+    expect(res.body).toEqual({ error: 'Unauthorized' });
+    const www = res.headers['www-authenticate'];
+    expect(www).toBeDefined();
+    expect(www).toContain('Bearer ');
+    expect(www).toContain('realm="foundry"');
+    expect(www).toContain(
+      'resource_metadata="https://foundry.test/.well-known/oauth-protected-resource"'
+    );
+  });
+
+  it('AC5 — invalid Bearer token → 401 with error="invalid_token"', async () => {
+    const res = await request(makeApp())
+      .get('/api/pages?include_private=true')
+      .set('Authorization', 'Bearer this-is-not-a-real-token')
+      .expect(401);
+
+    expect(res.body).toEqual({ error: 'Unauthorized' });
+    expect(res.headers['www-authenticate']).toContain('error="invalid_token"');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// AC4 — include_private=true with auth but insufficient scope → 403
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('GET /api/pages?include_private=true — insufficient scope', () => {
+  it('AC4 — OAuth token WITHOUT docs:read:private → 403 insufficient_scope', async () => {
+    const { access_token } = tokensDao.mint({
+      client_id: clientId,
+      user_id: userId,
+      scope: 'docs:read', // explicitly lacks docs:read:private
+    });
+
+    const res = await request(makeApp())
+      .get('/api/pages?include_private=true')
+      .set('Authorization', `Bearer ${access_token}`)
+      .expect(403);
+
+    expect(res.body.error).toBe('insufficient_scope');
+    expect(res.body.error_description).toBe('Requires scope: docs:read:private');
+    expect(res.headers['www-authenticate']).toContain('error="insufficient_scope"');
+    expect(res.headers['www-authenticate']).toContain('scope="docs:read:private"');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Authenticated happy path — include_private=true with scope → 200, all pages
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('GET /api/pages?include_private=true — authorized', () => {
+  it('OAuth token WITH docs:read:private → 200 with all pages (public + private)', async () => {
+    const { access_token } = tokensDao.mint({
+      client_id: clientId,
+      user_id: userId,
+      scope: 'docs:read docs:read:private',
+    });
+
+    const res = await request(makeApp())
+      .get('/api/pages?include_private=true')
+      .set('Authorization', `Bearer ${access_token}`)
+      .expect(200);
+
+    expect(res.body).toEqual(MOCK_PAGES);
+  });
+
+  it('legacy FOUNDRY_WRITE_TOKEN → 200 with all pages (backcompat — legacy inherits all scopes)', async () => {
+    process.env.FOUNDRY_WRITE_TOKEN = 'legacy-break-glass';
+
+    const res = await request(makeApp())
+      .get('/api/pages?include_private=true')
+      .set('Authorization', 'Bearer legacy-break-glass')
+      .expect(200);
+
+    expect(res.body).toEqual(MOCK_PAGES);
+  });
+});

--- a/packages/api/src/routes/__tests__/search.test.ts
+++ b/packages/api/src/routes/__tests__/search.test.ts
@@ -1,10 +1,20 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+// Module-top env: required by middleware/auth.ts WWW-Authenticate builder.
+// (Search only 401s via softAuth -> never, but a mis-built header could still
+// throw; setting this matches the convention used by other OAuth test suites.)
+process.env.FOUNDRY_OAUTH_ISSUER = 'https://foundry.test';
+
+import { describe, it, expect, vi, beforeEach, beforeAll, afterAll } from 'vitest';
 import request from 'supertest';
 import express from 'express';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { unlinkSync } from 'fs';
 import type { Anvil } from '@claymore-dev/anvil';
 import { AnvilHolder } from '../../anvil-holder.js';
 import { createSearchRouter } from '../search.js';
 import * as access from '../../access.js';
+import { getDb, closeDb } from '../../db.js';
+import { clientsDao, tokensDao, usersDao } from '../../oauth/dao.js';
 
 // Create an AnvilHolder with a mock Anvil pre-loaded
 function createReadyHolder(mockAnvil: Anvil): AnvilHolder {
@@ -331,8 +341,10 @@ describe('POST /search', () => {
       expect(response.body.totalResults).toBe(1);
     });
 
-    it('should include all results when FOUNDRY_WRITE_TOKEN is not set (dev mode)', async () => {
-      // Clear the env var to simulate dev mode
+    it('AC3 (S9) — unauthenticated + no legacy token configured → public only, no 401', async () => {
+      // S9 contract: /api/search is auth-optional (the ONE such route),
+      // but anonymous callers get public results only. Pre-E12 this test
+      // expected all results in "dev mode" — that was the bug #99 fixes.
       delete process.env.FOUNDRY_WRITE_TOKEN;
 
       const mockResults = [
@@ -367,9 +379,10 @@ describe('POST /search', () => {
         .send({ query: 'test query' })
         .expect(200);
 
-      // Should return both results in dev mode
-      expect(response.body.results).toHaveLength(2);
-      expect(response.body.totalResults).toBe(2);
+      // Should only return the public result — anonymous = no private scope
+      expect(response.body.results).toHaveLength(1);
+      expect(response.body.results[0].path).toBe('methodology/process.md');
+      expect(response.body.totalResults).toBe(1);
 
       // Restore the env var for other tests
       process.env.FOUNDRY_WRITE_TOKEN = 'test-token';
@@ -415,3 +428,192 @@ describe('POST /search', () => {
     });
   });
 });
+
+// ═══════════════════════════════════════════════════════════════════════════
+// S9 — OAuth scope matrix for /api/search
+//
+// Covers AC1–AC3 using real OAuth tokens (not the legacy FOUNDRY_WRITE_TOKEN
+// path). Each mint produces a token tied to an actual user in the test DB;
+// the search router's softAuth middleware introspects it exactly as
+// requireAuth does in S7 — no bypass.
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('POST /search — S9 OAuth scope matrix', () => {
+  const testDbPath = join(
+    tmpdir(),
+    `foundry-search-s9-test-${process.pid}-${Date.now()}.db`
+  );
+
+  let userId: string;
+  let clientId: string;
+  const s9MockAnvil = {
+    search: vi.fn(),
+    getStatus: vi.fn(),
+  } as unknown as Anvil;
+  const s9App = express();
+  s9App.use(express.json());
+  s9App.use('/api', createSearchRouter(createReadyHolderForS9(s9MockAnvil)));
+
+  // Same mock results used across all scope-matrix tests.
+  const mockResults = [
+    {
+      content: 'Public content in methodology',
+      score: 0.85,
+      metadata: {
+        file_path: 'methodology/process.md',
+        heading_path: 'Process',
+        heading_level: 1,
+        last_modified: '2024-01-01T00:00:00Z',
+        char_count: 100,
+      },
+    },
+    {
+      content: 'Private content in projects',
+      score: 0.75,
+      metadata: {
+        file_path: 'projects/secret/design.md',
+        heading_path: 'Secret Design',
+        heading_level: 1,
+        last_modified: '2024-01-02T00:00:00Z',
+        char_count: 200,
+      },
+    },
+  ];
+
+  beforeAll(() => {
+    process.env.FOUNDRY_DB_PATH = testDbPath;
+    closeDb();
+    getDb(); // creates schema
+
+    const user = usersDao.upsert({ github_login: 'bob', github_id: 424242 });
+    userId = user.id;
+
+    const { id } = clientsDao.register({
+      name: 'Search Test Connector',
+      redirect_uris: 'https://example.com/cb',
+      client_type: 'autonomous',
+    });
+    clientId = id;
+  });
+
+  afterAll(() => {
+    closeDb();
+    try {
+      unlinkSync(testDbPath);
+    } catch {
+      /* ignore */
+    }
+    delete process.env.FOUNDRY_DB_PATH;
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Un-set legacy token so OAuth path is the only auth mechanism.
+    delete process.env.FOUNDRY_WRITE_TOKEN;
+
+    vi.spyOn(access, 'getAccessLevel').mockImplementation((path) => {
+      if (path.startsWith('projects/')) return 'private';
+      return 'public';
+    });
+    (s9MockAnvil.getStatus as any).mockResolvedValue({ total_chunks: 100 });
+    (s9MockAnvil.search as any).mockResolvedValue(mockResults);
+  });
+
+  it('AC1 — OAuth user WITH docs:read:private → sees private results', async () => {
+    const { access_token } = tokensDao.mint({
+      client_id: clientId,
+      user_id: userId,
+      scope: 'docs:read docs:read:private',
+    });
+
+    const response = await request(s9App)
+      .post('/api/search')
+      .set('Authorization', `Bearer ${access_token}`)
+      .send({ query: 'test query' })
+      .expect(200);
+
+    expect(response.body.results).toHaveLength(2);
+    expect(response.body.results.map((r: any) => r.path)).toEqual([
+      'methodology/process.md',
+      'projects/secret/design.md',
+    ]);
+  });
+
+  it('AC2 — OAuth user WITHOUT docs:read:private → public only, 200 (no 401)', async () => {
+    const { access_token } = tokensDao.mint({
+      client_id: clientId,
+      user_id: userId,
+      scope: 'docs:read', // deliberately missing docs:read:private
+    });
+
+    const response = await request(s9App)
+      .post('/api/search')
+      .set('Authorization', `Bearer ${access_token}`)
+      .send({ query: 'test query' })
+      .expect(200);
+
+    expect(response.body.results).toHaveLength(1);
+    expect(response.body.results[0].path).toBe('methodology/process.md');
+  });
+
+  it('AC3 — unauthenticated (no header) → public only, 200 (no 401)', async () => {
+    // Product requirement: browser anonymous search must not 401. This is
+    // the only auth-optional route in the system.
+    const response = await request(s9App)
+      .post('/api/search')
+      .send({ query: 'test query' })
+      .expect(200);
+
+    expect(response.body.results).toHaveLength(1);
+    expect(response.body.results[0].path).toBe('methodology/process.md');
+  });
+
+  it('softAuth swallows invalid tokens — bogus Bearer returns public-only, not 401', async () => {
+    const response = await request(s9App)
+      .post('/api/search')
+      .set('Authorization', 'Bearer this-is-not-a-real-token')
+      .send({ query: 'test query' })
+      .expect(200);
+
+    expect(response.body.results).toHaveLength(1);
+    expect(response.body.results[0].path).toBe('methodology/process.md');
+  });
+
+  it('softAuth swallows revoked tokens — revoked Bearer returns public-only, not 401', async () => {
+    const { access_token } = tokensDao.mint({
+      client_id: clientId,
+      user_id: userId,
+      scope: 'docs:read docs:read:private',
+    });
+    tokensDao.revoke(access_token);
+
+    const response = await request(s9App)
+      .post('/api/search')
+      .set('Authorization', `Bearer ${access_token}`)
+      .send({ query: 'test query' })
+      .expect(200);
+
+    expect(response.body.results).toHaveLength(1);
+    expect(response.body.results[0].path).toBe('methodology/process.md');
+  });
+
+  it('softAuth swallows malformed header — Basic auth gets public-only, not 401', async () => {
+    const response = await request(s9App)
+      .post('/api/search')
+      .set('Authorization', 'Basic something')
+      .send({ query: 'test query' })
+      .expect(200);
+
+    expect(response.body.results).toHaveLength(1);
+    expect(response.body.results[0].path).toBe('methodology/process.md');
+  });
+});
+
+// Local helper so the top-file helper doesn't get hoisted into a shared
+// closure that the S9 block's mockAnvil could see stale.
+function createReadyHolderForS9(mockAnvil: Anvil): AnvilHolder {
+  const holder = new AnvilHolder();
+  (holder as any).anvil = mockAnvil;
+  (holder as any)._status = 'ready';
+  return holder;
+}

--- a/packages/api/src/routes/pages.ts
+++ b/packages/api/src/routes/pages.ts
@@ -1,34 +1,41 @@
-import { Router, Request, Response } from 'express';
+import { Router, Request, Response, NextFunction } from 'express';
 import { getDocsPath } from '../config.js';
 import { generateNavPages } from '../utils/nav-generator.js';
+import { requireAuth, requireScope } from '../middleware/auth.js';
 
 /**
- * Check if the request has a valid auth token.
+ * Conditional auth gate for /api/pages.
+ *
+ * When `?include_private=true`, the caller is explicitly asking for
+ * private docs and must present a Bearer token carrying `docs:read:private`.
+ * Without the flag, anonymous callers can list public pages (used by the
+ * browser's site-wide nav).
+ *
+ * Implementation uses nested middleware invocation so that errors from
+ * requireAuth (401 WWW-Authenticate) and requireScope (403 insufficient_scope)
+ * surface intact without tripping the global error handler.
  */
-function isAuthenticated(req: Request): boolean {
-  const expectedToken = process.env.FOUNDRY_WRITE_TOKEN;
-  if (!expectedToken) return true; // dev mode — no token required
-
-  const authHeader = req.headers.authorization;
-  if (!authHeader || !authHeader.startsWith('Bearer ')) return false;
-
-  return authHeader.slice(7) === expectedToken;
+function authIfIncludePrivate(req: Request, res: Response, next: NextFunction): void {
+  if (req.query.include_private !== 'true') {
+    return next();
+  }
+  requireAuth(req, res, (err?: unknown) => {
+    if (err) return next(err);
+    // If requireAuth already sent a 401 response, bail — no further chain.
+    if (res.headersSent) return;
+    requireScope('docs:read:private')(req, res, next);
+  });
 }
 
 export function createPagesRouter(): Router {
   const router = Router();
 
-  router.get('/pages', (req: Request, res: Response) => {
+  router.get('/pages', authIfIncludePrivate, (req: Request, res: Response) => {
     try {
       const docsPath = getDocsPath();
       const allPages = generateNavPages(docsPath);
 
       const includePrivate = req.query.include_private === 'true';
-
-      if (includePrivate && !isAuthenticated(req)) {
-        res.status(401).json({ error: 'Unauthorized' });
-        return;
-      }
 
       const pages = includePrivate
         ? allPages

--- a/packages/api/src/routes/search.ts
+++ b/packages/api/src/routes/search.ts
@@ -1,6 +1,7 @@
 import { Router, Request, Response } from 'express';
 import type { AnvilHolder } from '../anvil-holder.js';
 import { getAccessLevel } from '../access.js';
+import { softAuth } from '../middleware/auth.js';
 
 interface SearchRequest {
   query: string;
@@ -23,21 +24,28 @@ interface SearchResponse {
 }
 
 /**
- * Check if the request is authenticated
- */
-function isRequestAuthenticated(req: Request): boolean {
-  if (!process.env.FOUNDRY_WRITE_TOKEN) return true; // dev mode
-  const token = req.headers.authorization?.replace("Bearer ", "");
-  return token === process.env.FOUNDRY_WRITE_TOKEN;
-}
-
-/**
- * Creates the search router
+ * Creates the search router.
+ *
+ * NOTE: /api/search is the ONE auth-optional route in Foundry. Browsers
+ * hit it anonymously (no Bearer header) for the site-wide search UI —
+ * that's a product requirement. All other routes either require auth
+ * outright (requireAuth) or don't surface access-gated data.
+ *
+ * Because of this, we use `softAuth` instead of `requireAuth`: it
+ * populates req.user when a valid Bearer token is presented, but never
+ * 401s on missing/invalid tokens. Private results are filtered in/out
+ * based on `req.user?.scopes?.includes('docs:read:private')`.
+ *
+ * Matrix:
+ *   no auth           → public results only, 200
+ *   auth, no scope    → public results only, 200
+ *   auth, with scope  → all results, 200
+ *   invalid token     → public results only, 200 (treated as anonymous)
  */
 export function createSearchRouter(holder: AnvilHolder): Router {
   const router = Router();
 
-  router.post('/search', async (req: Request<{}, SearchResponse, SearchRequest>, res: Response<SearchResponse>) => {
+  router.post('/search', softAuth, async (req: Request<{}, SearchResponse, SearchRequest>, res: Response<SearchResponse>) => {
     const anvil = holder.get();
 
     if (!anvil) {
@@ -91,10 +99,15 @@ export function createSearchRouter(holder: AnvilHolder): Router {
         charCount: result.metadata.char_count,
       }));
 
-      // Filter results based on access level and authentication
-      const accessFiltered = isRequestAuthenticated(req)
+      // Scope-aware filter: include private docs only if the caller's token
+      // carries `docs:read:private`. Missing/invalid tokens → req.user is
+      // undefined → public-only. Legacy FOUNDRY_WRITE_TOKEN inherits all
+      // three docs scopes (set in middleware/auth.ts LEGACY_SCOPES) and
+      // passes this check.
+      const canReadPrivate = req.user?.scopes?.includes('docs:read:private') ?? false;
+      const accessFiltered = canReadPrivate
         ? results
-        : results.filter(r => getAccessLevel(r.path) !== "private");
+        : results.filter(r => getAccessLevel(r.path) !== 'private');
 
       // Filter out low-relevance results
       const MIN_RELEVANCE_SCORE = 0.5;


### PR DESCRIPTION
## Story
FND-E12-S9 — Per-user `docs:read:private` scope (W6 parallel with S8) — fixes #99

## What changed
- `packages/api/src/middleware/auth.ts` — new `softAuth` export; extracted shared `resolveBearerToken()` so `requireAuth` delegates without behavior change
- `packages/api/src/routes/search.ts` — uses `softAuth`; filters private results by `req.user?.scopes?.includes('docs:read:private')`; inline comment explains the auth-optional product requirement
- `packages/api/src/routes/pages.ts` — `authIfIncludePrivate` conditional middleware wires `requireAuth` + `requireScope('docs:read:private')` only when `?include_private=true`; removed duplicate inline `isAuthenticated` helper
- `packages/api/src/middleware/__tests__/auth.oauth.test.ts` — +8 `softAuth` tests (missing/malformed/unknown/revoked/expired/valid-oauth/valid-legacy)
- `packages/api/src/routes/__tests__/search.test.ts` — +6 S9 OAuth scope matrix tests (AC1–AC3) using real minted tokens; flipped one pre-E12 test that asserted the bug being fixed
- `packages/api/src/routes/__tests__/pages.test.ts` — new file, 8 tests covering the include_private × auth × scope matrix

## AC-to-diff mapping
- AC1 (authenticated w/ scope → private in search) → `src/routes/__tests__/search.test.ts:522` + `src/routes/search.ts:107-109`
- AC2 (authenticated w/o scope → public only in search) → `src/routes/__tests__/search.test.ts:542` + `src/routes/search.ts:107-109`
- AC3 (anonymous → public only in search, no 401) → `src/routes/__tests__/search.test.ts:344,559` + `src/routes/search.ts:48` (`softAuth` wiring)
- AC4 (pages?include_private=true w/o scope → 403) → `src/routes/__tests__/pages.test.ts:169` + `src/routes/pages.ts:26`
- AC5 (pages?include_private=true w/o auth → 401) → `src/routes/__tests__/pages.test.ts:133,153` + `src/routes/pages.ts:22` (requireAuth branch)
- AC6 (pages?include_private=false → no auth required) → `src/routes/__tests__/pages.test.ts:91,99` + `src/routes/pages.ts:19-20` (early-return branch)
- AC7 (tests) → `src/middleware/__tests__/auth.oauth.test.ts`, `src/routes/__tests__/search.test.ts`, `src/routes/__tests__/pages.test.ts`

## QA notes
- Backend-only, no visual surface.
- `softAuth` is a pure addition to `middleware/auth.ts`. `requireAuth`'s external behavior is unchanged — S7's `auth.test.ts` file was not touched and its 6 tests still pass as-is. S7's `auth.oauth.test.ts` was only extended (new `softAuth` describe block appended; existing 18 tests unchanged).
- Browser search stays anonymous (product req): tested explicitly in `search.test.ts:559`.
- Smoke post-merge:
  - `/api/search` (no auth) → 200, zero private docs
  - `/api/pages?include_private=true` (no auth, with `FOUNDRY_WRITE_TOKEN` env set) → 401 with `WWW-Authenticate`
  - `/api/pages` (no auth) → 200 with public pages

## Scope-creep finding
The story's guardrail grep turned up a **third** route that reads a doc's access field and branches on `'private'`: `packages/api/src/routes/docs.ts:91-106` (GET `/docs/:path(*)` gates private docs behind an inline `requireAuth` wrapper but does NOT check scope). That's the same vulnerability class #99 describes — any valid Bearer currently unlocks private doc reads there too. Out of scope for this PR; surfaced to orchestrator for a follow-up ticket.

`doc-crud.ts:182` also uses `getAccessLevel` but only to persist the computed access into `docs_meta` on create — it's a write-path metadata write, not a scope-aware read filter, so not scope creep.

## Test plan
- [x] npm test passes (412 tests, baseline 390 + 22 new)
- [x] tsc clean (npm run build succeeds)
- [x] S7 `auth.test.ts` unchanged (`git diff main -- auth.test.ts` empty)
- [x] S7 `auth.oauth.test.ts` existing 18 tests pass unchanged
- [ ] Post-merge: orchestrator smoke-tests search+pages paths

Fixes #99.