### PR TITLE
feat(oauth): propagate identity through write paths (FND-E12-S8)

### DIFF
--- a/packages/api/src/mcp/http-client.ts
+++ b/packages/api/src/mcp/http-client.ts
@@ -78,12 +78,21 @@ export async function getAnnotation(
 
 /**
  * Create an annotation via HTTP API.
+ *
+ * Identity fields (user_id, author_type) are derived server-side from the
+ * authenticated caller — this client does not send them. The server drops
+ * any user_id / author_type fields in request bodies (see routes/annotations.ts).
+ *
+ * `author_type` remains in the param shape for source-level back-compat
+ * with existing MCP tool call sites; it is intentionally ignored here.
+ * Will be removed once all call sites stop passing it.
  */
 export async function createAnnotation(params: {
   doc_path: string;
   section: string;
   content: string;
   parent_id?: string;
+  /** @deprecated ignored — server derives author_type from req.client.client_type */
   author_type?: string;
   quoted_text?: string;
   status?: string;
@@ -96,8 +105,6 @@ export async function createAnnotation(params: {
       content: params.content,
       parent_id: params.parent_id || undefined,
       quoted_text: params.quoted_text || undefined,
-      author_type: params.author_type || 'ai',
-      user_id: process.env.FOUNDRY_MCP_USER || 'clay',
       ...(params.status !== undefined ? { status: params.status } : {}),
     }),
   });
@@ -134,12 +141,13 @@ export async function submitReview(
   docPath: string,
   annotationIds?: string[],
 ): Promise<object> {
-  // 1. Create review (attribute to configured MCP user instead of "anonymous")
+  // 1. Create review. user_id is derived server-side from req.user (the
+  // authenticated caller's OAuth identity or 'legacy' for the break-glass
+  // token). This client no longer sends user_id — server is authoritative.
   const review = await apiFetch<{ id: string; doc_path: string }>('/api/reviews', {
     method: 'POST',
     body: JSON.stringify({
       doc_path: docPath,
-      user_id: process.env.FOUNDRY_MCP_USER || 'clay',
     }),
   });
 

--- a/packages/api/src/routes/__tests__/annotations.test.ts
+++ b/packages/api/src/routes/__tests__/annotations.test.ts
@@ -8,6 +8,7 @@ import { createAnnotationsRouter } from '../annotations.js';
 import { createReviewsRouter } from '../reviews.js';
 import { requireAuth } from '../../middleware/auth.js';
 import { getDb, closeDb } from '../../db.js';
+import { clientsDao, tokensDao, usersDao } from '../../oauth/dao.js';
 
 const ISO_8601_REGEX = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
 const CUID2_REGEX = /^[a-z0-9]{24,}$/;
@@ -15,6 +16,14 @@ const CUID2_REGEX = /^[a-z0-9]{24,}$/;
 let app: express.Express;
 const testDbPath = join(tmpdir(), `foundry-test-annotations-${Date.now()}.db`);
 const testContentDir = join(tmpdir(), `foundry-test-content-${Date.now()}`);
+
+// OAuth test identities — populated in beforeAll so tests can mint tokens
+// for interactive and autonomous clients to exercise S8 identity propagation.
+let oauthUserId: string;
+let interactiveClientId: string;
+let autonomousClientId: string;
+let interactiveAccessToken: string;
+let autonomousAccessToken: string;
 
 /** Create a stub markdown file in the test content directory */
 function seedDoc(docPath: string): void {
@@ -30,6 +39,10 @@ beforeAll(() => {
   process.env.FOUNDRY_DB_PATH = testDbPath;
   process.env.FOUNDRY_WRITE_TOKEN = 'test-token';
   process.env.CONTENT_DIR = testContentDir;
+  // requireAuth needs FOUNDRY_OAUTH_ISSUER to emit WWW-Authenticate — set
+  // a dummy value so OAuth paths in the test don't fail-loud on missing
+  // config (WWW-Authenticate contents aren't asserted in this suite).
+  process.env.FOUNDRY_OAUTH_ISSUER = process.env.FOUNDRY_OAUTH_ISSUER || 'https://foundry.test';
 
   // Seed all doc paths used by tests
   for (const docPath of [
@@ -42,9 +55,42 @@ beforeAll(() => {
     'delete-test/doc.md',
     'delete-cascade/doc.md',
     'delete-review/doc.md',
+    'identity-test/doc.md',
   ]) {
     seedDoc(docPath);
   }
+
+  // Seed OAuth identities + access tokens. The DB is opened lazily by
+  // getDb() on first use; force it here so usersDao/clientsDao can write.
+  getDb();
+
+  const oauthUser = usersDao.upsert({ github_login: 'fern', github_id: 20202 });
+  oauthUserId = oauthUser.id;
+
+  const interactiveClient = clientsDao.register({
+    name: 'Interactive Test Client',
+    redirect_uris: 'https://example.com/cb',
+    client_type: 'interactive',
+  });
+  interactiveClientId = interactiveClient.id;
+
+  const autonomousClient = clientsDao.register({
+    name: 'Autonomous Test Client',
+    redirect_uris: 'https://example.com/cb',
+    client_type: 'autonomous',
+  });
+  autonomousClientId = autonomousClient.id;
+
+  interactiveAccessToken = tokensDao.mint({
+    client_id: interactiveClientId,
+    user_id: oauthUserId,
+    scope: 'docs:read docs:write',
+  }).access_token;
+  autonomousAccessToken = tokensDao.mint({
+    client_id: autonomousClientId,
+    user_id: oauthUserId,
+    scope: 'docs:read docs:write',
+  }).access_token;
 
   app = express();
   app.use(express.json());
@@ -161,9 +207,12 @@ describe('Annotations Router', () => {
       expect(res.body.quoted_text).toBeNull();
       expect(res.body.parent_id).toBeNull();
       expect(res.body.review_id).toBeNull();
-      expect(res.body.user_id).toBe('anonymous');
-      expect(res.body.author_type).toBe('human');
-      expect(res.body.status).toBe('draft');
+      // Legacy-token callers inherit req.user.id='legacy' and
+      // req.client.client_type='autonomous' from S7, which maps to
+      // author_type='ai'. Draft/submitted status derives from author_type.
+      expect(res.body.user_id).toBe('legacy');
+      expect(res.body.author_type).toBe('ai');
+      expect(res.body.status).toBe('submitted');
       expect(res.body.created_at).toMatch(ISO_8601_REGEX);
       expect(res.body.updated_at).toMatch(ISO_8601_REGEX);
     });
@@ -178,84 +227,92 @@ describe('Annotations Router', () => {
       expect(res.body.quoted_text).toBe('some quoted text');
     });
 
-    it('should accept optional author_type of ai', async () => {
+    it('derives author_type from client_type (legacy → autonomous → ai)', async () => {
+      // Body author_type is ignored post-S8 — server derives from req.client.
+      // Legacy token callers get client_type='autonomous' → author_type='ai'.
       const res = await request(app)
         .post('/api/annotations')
         .set("Authorization", "Bearer test-token")
-        .send(validBody({ author_type: 'ai' }))
+        .send(validBody({ author_type: 'human' }))
         .expect(201);
 
       expect(res.body.author_type).toBe('ai');
     });
 
-    it('should default status to draft when author_type is human', async () => {
+    it('defaults status to submitted for legacy (autonomous/ai) caller', async () => {
+      // Legacy path → author_type='ai' → default status='submitted'.
       const res = await request(app)
         .post('/api/annotations')
         .set("Authorization", "Bearer test-token")
-        .send(validBody({ author_type: 'human' }))
-        .expect(201);
-
-      expect(res.body.status).toBe('draft');
-    });
-
-    it('should default status to submitted when author_type is ai', async () => {
-      const res = await request(app)
-        .post('/api/annotations')
-        .set("Authorization", "Bearer test-token")
-        .send(validBody({ author_type: 'ai' }))
+        .send(validBody())
         .expect(201);
 
       expect(res.body.status).toBe('submitted');
     });
 
-    it('should default status to submitted for human reply with parent_id', async () => {
+    it('defaults status to draft for interactive (human) caller on top-level annotation', async () => {
+      // Interactive OAuth client → author_type='human' → default status='draft'.
+      const res = await request(app)
+        .post('/api/annotations')
+        .set('Authorization', `Bearer ${interactiveAccessToken}`)
+        .send(validBody())
+        .expect(201);
+
+      expect(res.body.author_type).toBe('human');
+      expect(res.body.status).toBe('draft');
+    });
+
+    it('defaults status to submitted for interactive reply (parent_id set)', async () => {
+      // Replies always auto-submit regardless of author_type.
       const parent = await request(app)
         .post('/api/annotations')
-        .set("Authorization", "Bearer test-token")
-        .send(validBody({ author_type: 'human' }))
+        .set('Authorization', `Bearer ${interactiveAccessToken}`)
+        .send(validBody())
         .expect(201);
 
       const reply = await request(app)
         .post('/api/annotations')
-        .set("Authorization", "Bearer test-token")
-        .send(validBody({ author_type: 'human', parent_id: parent.body.id, content: 'human reply' }))
+        .set('Authorization', `Bearer ${interactiveAccessToken}`)
+        .send(validBody({ parent_id: parent.body.id, content: 'human reply' }))
         .expect(201);
 
       expect(reply.body.parent_id).toBe(parent.body.id);
+      expect(reply.body.author_type).toBe('human');
       expect(reply.body.status).toBe('submitted');
     });
 
-    it('should default status to submitted for ai reply with parent_id', async () => {
+    it('defaults status to submitted for autonomous reply (ai + parent_id)', async () => {
       const parent = await request(app)
         .post('/api/annotations')
-        .set("Authorization", "Bearer test-token")
-        .send(validBody({ author_type: 'human' }))
+        .set('Authorization', `Bearer ${interactiveAccessToken}`)
+        .send(validBody())
         .expect(201);
 
       const reply = await request(app)
         .post('/api/annotations')
-        .set("Authorization", "Bearer test-token")
-        .send(validBody({ author_type: 'ai', parent_id: parent.body.id, content: 'ai reply' }))
+        .set('Authorization', `Bearer ${autonomousAccessToken}`)
+        .send(validBody({ parent_id: parent.body.id, content: 'ai reply' }))
         .expect(201);
 
+      expect(reply.body.author_type).toBe('ai');
       expect(reply.body.status).toBe('submitted');
     });
 
-    it('should use explicit status when provided, regardless of author_type', async () => {
+    it('uses explicit status when provided, regardless of derived author_type', async () => {
       const res = await request(app)
         .post('/api/annotations')
         .set("Authorization", "Bearer test-token")
-        .send(validBody({ author_type: 'ai', status: 'draft' }))
+        .send(validBody({ status: 'draft' }))
         .expect(201);
 
       expect(res.body.status).toBe('draft');
     });
 
-    it('should use explicit status of replied when provided', async () => {
+    it('uses explicit status of replied when provided', async () => {
       const res = await request(app)
         .post('/api/annotations')
-        .set("Authorization", "Bearer test-token")
-        .send(validBody({ author_type: 'human', status: 'replied' }))
+        .set('Authorization', `Bearer ${interactiveAccessToken}`)
+        .send(validBody({ status: 'replied' }))
         .expect(201);
 
       expect(res.body.status).toBe('replied');
@@ -339,6 +396,78 @@ describe('Annotations Router', () => {
     });
   });
 
+  // ─── S8: Identity propagation (FND-E12-S8) ─────────────────────────
+
+  describe('POST /annotations — S8 identity propagation', () => {
+    // AC1: interactive client → author_type='human', user_id=req.user.id
+    it('interactive OAuth client stamps author_type=human and user_id=req.user.id', async () => {
+      const res = await request(app)
+        .post('/api/annotations')
+        .set('Authorization', `Bearer ${interactiveAccessToken}`)
+        .send(validBody({ doc_path: 'identity-test/doc.md', content: 'interactive comment' }))
+        .expect(201);
+
+      expect(res.body.author_type).toBe('human');
+      expect(res.body.user_id).toBe(oauthUserId);
+    });
+
+    // AC2: autonomous client → author_type='ai', user_id=req.user.id
+    it('autonomous OAuth client stamps author_type=ai and user_id=req.user.id', async () => {
+      const res = await request(app)
+        .post('/api/annotations')
+        .set('Authorization', `Bearer ${autonomousAccessToken}`)
+        .send(validBody({ doc_path: 'identity-test/doc.md', content: 'autonomous comment' }))
+        .expect(201);
+
+      expect(res.body.author_type).toBe('ai');
+      expect(res.body.user_id).toBe(oauthUserId);
+    });
+
+    // AC3: legacy Bearer → user_id='legacy', author_type='ai' (legacy is autonomous)
+    it('legacy Bearer caller stamps user_id=legacy and author_type=ai', async () => {
+      const res = await request(app)
+        .post('/api/annotations')
+        .set('Authorization', 'Bearer test-token')
+        .send(validBody({ doc_path: 'identity-test/doc.md', content: 'legacy comment' }))
+        .expect(201);
+
+      expect(res.body.user_id).toBe('legacy');
+      expect(res.body.author_type).toBe('ai');
+    });
+
+    // Server-authoritative: body user_id is silently dropped
+    it('ignores user_id sent in the request body (server is authoritative)', async () => {
+      const res = await request(app)
+        .post('/api/annotations')
+        .set('Authorization', `Bearer ${interactiveAccessToken}`)
+        .send(validBody({
+          doc_path: 'identity-test/doc.md',
+          content: 'spoofed body user_id',
+          user_id: 'attacker-id',
+        }))
+        .expect(201);
+
+      expect(res.body.user_id).toBe(oauthUserId);
+      expect(res.body.user_id).not.toBe('attacker-id');
+    });
+
+    // Server-authoritative: body author_type is silently dropped
+    it('ignores author_type sent in the request body (server is authoritative)', async () => {
+      // Autonomous client trying to spoof 'human' → still gets 'ai'.
+      const res = await request(app)
+        .post('/api/annotations')
+        .set('Authorization', `Bearer ${autonomousAccessToken}`)
+        .send(validBody({
+          doc_path: 'identity-test/doc.md',
+          content: 'spoofed body author_type',
+          author_type: 'human',
+        }))
+        .expect(201);
+
+      expect(res.body.author_type).toBe('ai');
+    });
+  });
+
   // ─── GET /annotations ──────────────────────────────────────────────
 
   describe('GET /annotations', () => {
@@ -346,11 +475,15 @@ describe('Annotations Router', () => {
     let seededIds: string[];
 
     beforeAll(async () => {
+      // Post-S8, legacy-token callers default to author_type='ai' and status='submitted'.
+      // We explicitly set status='draft' during seeding so the filter-by-status
+      // test below can verify that exactly one 'submitted' annotation is returned
+      // after we promote one of them via PATCH.
       const bodies = [
-        validBody({ doc_path: 'get-test/doc.md', heading_path: 'Section A', content: 'note 1' }),
-        validBody({ doc_path: 'get-test/doc.md', heading_path: 'Section B', content: 'note 2' }),
-        validBody({ doc_path: 'get-test/doc.md', heading_path: 'Section A', content: 'note 3', quoted_text: 'quote' }),
-        validBody({ doc_path: 'get-test/other.md', heading_path: 'Intro', content: 'note 4' }),
+        validBody({ doc_path: 'get-test/doc.md', heading_path: 'Section A', content: 'note 1', status: 'draft' }),
+        validBody({ doc_path: 'get-test/doc.md', heading_path: 'Section B', content: 'note 2', status: 'draft' }),
+        validBody({ doc_path: 'get-test/doc.md', heading_path: 'Section A', content: 'note 3', quoted_text: 'quote', status: 'draft' }),
+        validBody({ doc_path: 'get-test/other.md', heading_path: 'Intro', content: 'note 4', status: 'draft' }),
       ];
 
       seededIds = [];
@@ -461,24 +594,27 @@ describe('Annotations Router', () => {
         .expect(201);
       reviewId = review.body.id;
 
-      // Create annotations with and without review_id
+      // Create annotations with and without review_id. Post-S8 legacy callers
+      // default to status='submitted', so explicitly set status='draft' here
+      // so the combined review_id+status filter test finds exactly one
+      // submitted annotation.
       await request(app)
         .post('/api/annotations')
         .set('Authorization', 'Bearer test-token')
-        .send(validBody({ doc_path: 'review-filter/doc.md', content: 'with review', review_id: reviewId }))
+        .send(validBody({ doc_path: 'review-filter/doc.md', content: 'with review', review_id: reviewId, status: 'draft' }))
         .expect(201);
 
       const noReview = await request(app)
         .post('/api/annotations')
         .set('Authorization', 'Bearer test-token')
-        .send(validBody({ doc_path: 'review-filter/doc.md', content: 'no review' }))
+        .send(validBody({ doc_path: 'review-filter/doc.md', content: 'no review', status: 'draft' }))
         .expect(201);
 
       // Also create a submitted annotation with review_id for combined filter test
       const submitted = await request(app)
         .post('/api/annotations')
         .set('Authorization', 'Bearer test-token')
-        .send(validBody({ doc_path: 'review-filter/doc.md', content: 'submitted with review', review_id: reviewId }))
+        .send(validBody({ doc_path: 'review-filter/doc.md', content: 'submitted with review', review_id: reviewId, status: 'draft' }))
         .expect(201);
 
       await request(app)

--- a/packages/api/src/routes/__tests__/doc-crud.test.ts
+++ b/packages/api/src/routes/__tests__/doc-crud.test.ts
@@ -596,10 +596,9 @@ describe('move_section', () => {
 });
 
 describe('submit_review user_id attribution', () => {
-  // This test validates that /api/reviews accepts user_id from the body
-  // (the submitReview http-client helper now passes it). We test the route
-  // directly here, since the http-client is exercised end-to-end via MCP.
-  it('POST /api/reviews accepts user_id from body', async () => {
+  // Post-S8 (FND-E12-S8): server derives user_id from req.user, ignoring
+  // any user_id in the body. Legacy Bearer callers get user_id='legacy'.
+  it('POST /api/reviews stamps user_id from req.user and ignores body user_id', async () => {
     // Mount reviews router on its own app so we don't depend on router order
     const reviewsApp = express();
     reviewsApp.use(express.json());
@@ -615,6 +614,7 @@ describe('submit_review user_id attribution', () => {
       .send({ doc_path: 'user-attribution/test', user_id: 'clay' })
       .expect(201);
 
-    expect(res.body.user_id).toBe('clay');
+    // Body user_id='clay' is silently dropped; legacy token → user_id='legacy'.
+    expect(res.body.user_id).toBe('legacy');
   });
 });

--- a/packages/api/src/routes/__tests__/reviews.test.ts
+++ b/packages/api/src/routes/__tests__/reviews.test.ts
@@ -7,6 +7,7 @@ import { unlinkSync } from 'fs';
 import { createReviewsRouter } from '../reviews.js';
 import { requireAuth } from '../../middleware/auth.js';
 import { getDb, closeDb } from '../../db.js';
+import { clientsDao, tokensDao, usersDao } from '../../oauth/dao.js';
 
 const ISO_8601_REGEX = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
 const CUID2_REGEX = /^[a-z0-9]{24,}$/;
@@ -14,13 +15,52 @@ const CUID2_REGEX = /^[a-z0-9]{24,}$/;
 let app: express.Express;
 const testDbPath = join(tmpdir(), `foundry-test-reviews-${Date.now()}.db`);
 
+// OAuth test identities for S8 identity-propagation tests.
+let oauthUserId: string;
+let interactiveClientId: string;
+let autonomousClientId: string;
+let interactiveAccessToken: string;
+let autonomousAccessToken: string;
+
 beforeAll(() => {
   process.env.FOUNDRY_DB_PATH = testDbPath;
   process.env.FOUNDRY_WRITE_TOKEN = 'test-token';
+  process.env.FOUNDRY_OAUTH_ISSUER = process.env.FOUNDRY_OAUTH_ISSUER || 'https://foundry.test';
+
+  // Force DB init before DAO usage (schema creation happens inside getDb).
+  getDb();
+
+  const oauthUser = usersDao.upsert({ github_login: 'pip', github_id: 30303 });
+  oauthUserId = oauthUser.id;
+
+  const interactiveClient = clientsDao.register({
+    name: 'Interactive Reviews Client',
+    redirect_uris: 'https://example.com/cb',
+    client_type: 'interactive',
+  });
+  interactiveClientId = interactiveClient.id;
+
+  const autonomousClient = clientsDao.register({
+    name: 'Autonomous Reviews Client',
+    redirect_uris: 'https://example.com/cb',
+    client_type: 'autonomous',
+  });
+  autonomousClientId = autonomousClient.id;
+
+  interactiveAccessToken = tokensDao.mint({
+    client_id: interactiveClientId,
+    user_id: oauthUserId,
+    scope: 'docs:read docs:write',
+  }).access_token;
+  autonomousAccessToken = tokensDao.mint({
+    client_id: autonomousClientId,
+    user_id: oauthUserId,
+    scope: 'docs:read docs:write',
+  }).access_token;
 
   app = express();
   app.use(express.json());
-  
+
   // Create protected reviews router
   const protectedReviewsRouter = express.Router();
   protectedReviewsRouter.use('/reviews', requireAuth);
@@ -84,7 +124,8 @@ describe('Reviews Router', () => {
 
       expect(res.body.id).toMatch(CUID2_REGEX);
       expect(res.body.doc_path).toBe('docs/process');
-      expect(res.body.user_id).toBe('anonymous');
+      // Legacy-token caller → req.user.id='legacy' (populated by S7 requireAuth).
+      expect(res.body.user_id).toBe('legacy');
       expect(res.body.status).toBe('draft');
       expect(res.body.submitted_at).toBeNull();
       expect(res.body.completed_at).toBeNull();
@@ -153,6 +194,56 @@ describe('Reviews Router', () => {
         .expect(201);
 
       expect(res.body.created_at).toBe(res.body.updated_at);
+    });
+  });
+
+  // ─── S8: Identity propagation (FND-E12-S8) ─────────────────────────
+
+  describe('POST /reviews — S8 identity propagation', () => {
+    // AC4 (reviews parity with annotations):
+    // interactive OAuth → user_id=req.user.id (no author_type column on reviews)
+    it('interactive OAuth client stamps user_id=req.user.id', async () => {
+      const res = await request(app)
+        .post('/api/reviews')
+        .set('Authorization', `Bearer ${interactiveAccessToken}`)
+        .send({ doc_path: 'identity-reviews/interactive.md' })
+        .expect(201);
+
+      expect(res.body.user_id).toBe(oauthUserId);
+    });
+
+    // autonomous OAuth → user_id=req.user.id
+    it('autonomous OAuth client stamps user_id=req.user.id', async () => {
+      const res = await request(app)
+        .post('/api/reviews')
+        .set('Authorization', `Bearer ${autonomousAccessToken}`)
+        .send({ doc_path: 'identity-reviews/autonomous.md' })
+        .expect(201);
+
+      expect(res.body.user_id).toBe(oauthUserId);
+    });
+
+    // AC3/AC4: legacy Bearer → user_id='legacy'
+    it('legacy Bearer caller stamps user_id=legacy', async () => {
+      const res = await request(app)
+        .post('/api/reviews')
+        .set('Authorization', 'Bearer test-token')
+        .send({ doc_path: 'identity-reviews/legacy.md' })
+        .expect(201);
+
+      expect(res.body.user_id).toBe('legacy');
+    });
+
+    // Server-authoritative: body user_id is silently dropped
+    it('ignores user_id sent in the request body (server is authoritative)', async () => {
+      const res = await request(app)
+        .post('/api/reviews')
+        .set('Authorization', `Bearer ${interactiveAccessToken}`)
+        .send({ doc_path: 'identity-reviews/spoof.md', user_id: 'attacker-id' })
+        .expect(201);
+
+      expect(res.body.user_id).toBe(oauthUserId);
+      expect(res.body.user_id).not.toBe('attacker-id');
     });
   });
 

--- a/packages/api/src/routes/annotations.ts
+++ b/packages/api/src/routes/annotations.ts
@@ -105,10 +105,25 @@ export function createAnnotationsRouter(): Router {
         content,
         parent_id,
         review_id,
-        author_type = 'human',
-        user_id,
         status: bodyStatus,
       } = req.body;
+
+      // Identity is server-authoritative: we derive user_id and author_type
+      // from req.user / req.client (populated by requireAuth). Any user_id
+      // or author_type sent in the request body is silently ignored.
+      //
+      // Mapping per D-S8-1: author_type is a property of the act, not the
+      // GitHub account. Interactive clients → 'human', autonomous clients → 'ai'.
+      // Legacy Bearer callers (req.client.client_type === 'autonomous', from
+      // S7 middleware) thus inherit author_type='ai', matching pre-E12 behavior.
+      //
+      // Dev-mode passthrough: if requireAuth let the request through with
+      // req.user undefined (no FOUNDRY_WRITE_TOKEN and no Authorization
+      // header), we stamp user_id='anonymous' / author_type='ai' — documents
+      // the dev-mode write without falling back to the removed env-var dance.
+      const effectiveUserId = req.user?.id ?? 'anonymous';
+      const effectiveAuthorType: AuthorType =
+        req.client?.client_type === 'interactive' ? 'human' : 'ai';
 
       // Validate required fields (content_hash is optional — used for drift detection)
       if (!doc_path || !heading_path || !content) {
@@ -171,7 +186,7 @@ export function createAnnotationsRouter(): Router {
       const effectiveStatus: AnnotationStatus =
         bodyStatus !== undefined
           ? bodyStatus
-          : parent_id || author_type === 'ai'
+          : parent_id || effectiveAuthorType === 'ai'
           ? 'submitted'
           : 'draft';
 
@@ -184,8 +199,8 @@ export function createAnnotationsRouter(): Router {
         content,
         parent_id: parent_id || null,
         review_id: effectiveReviewId || null,
-        user_id: user_id || process.env.FOUNDRY_DEFAULT_USER || 'anonymous',
-        author_type,
+        user_id: effectiveUserId,
+        author_type: effectiveAuthorType,
         status: effectiveStatus,
         created_at: now,
         updated_at: now,

--- a/packages/api/src/routes/reviews.ts
+++ b/packages/api/src/routes/reviews.ts
@@ -81,7 +81,7 @@ export function createReviewsRouter(): Router {
   // POST /reviews - Create new review
   router.post('/reviews', async (req: Request<{}, Review, CreateReviewBody>, res: Response<Review>) => {
     try {
-      const { doc_path, user_id } = req.body;
+      const { doc_path } = req.body;
 
       // Validate required fields
       if (!doc_path) {
@@ -89,6 +89,14 @@ export function createReviewsRouter(): Router {
           error: 'doc_path is required',
         } as any);
       }
+
+      // Identity is server-authoritative — derive user_id from the
+      // authenticated caller (req.user, populated by requireAuth).
+      // Any user_id sent in the request body is silently ignored.
+      // Dev-mode passthrough (req.user undefined when auth is fully
+      // unconfigured) falls back to 'anonymous' to document the
+      // unauthenticated write.
+      const effectiveUserId = req.user?.id ?? 'anonymous';
 
       const db = getDb();
       const id = createId();
@@ -99,7 +107,7 @@ export function createReviewsRouter(): Router {
       const review: Review = {
         id,
         doc_path: normalizedDocPath,
-        user_id: user_id || process.env.FOUNDRY_DEFAULT_USER || 'anonymous',
+        user_id: effectiveUserId,
         status: 'draft',
         submitted_at: null,
         completed_at: null,


### PR DESCRIPTION
## Story
FND-E12-S8 — Identity propagation through write paths (W6 parallel with S9)

## What changed
- `packages/api/src/routes/annotations.ts` — POST handler derives `user_id` from `req.user.id` and `author_type` from `req.client.client_type` (interactive → human, autonomous → ai). Body `user_id` / `author_type` silently dropped.
- `packages/api/src/routes/reviews.ts` — POST handler derives `user_id` from `req.user.id`. Body `user_id` silently dropped. `FOUNDRY_DEFAULT_USER` reference removed.
- `packages/api/src/mcp/http-client.ts` — `createAnnotation` and `submitReview` no longer send `user_id` / `author_type` in the request body. `FOUNDRY_MCP_USER` reference removed. `author_type` param kept on the `createAnnotation` signature as a deprecated no-op (out-of-boundary MCP tool call sites still pass it).
- `packages/api/src/routes/__tests__/annotations.test.ts` — extended with 5 new S8 tests (AC1/AC2/AC3 + two spoof-drop tests) and updated existing draft/submitted-status assertions to match the new legacy-path default (autonomous → ai → submitted). Seeded OAuth interactive + autonomous clients inside `beforeAll`.
- `packages/api/src/routes/__tests__/reviews.test.ts` — extended with 4 new S8 tests (interactive/autonomous/legacy + spoof-drop).
- `packages/api/src/routes/__tests__/doc-crud.test.ts` — inverted the existing "POST /api/reviews accepts user_id from body" assertion to verify the new server-authoritative behavior (body `user_id: 'clay'` silently dropped → `user_id='legacy'`). Minimal necessary fix since that test enshrined the old contract.

## AC-to-diff mapping
- **AC1** (interactive → `author_type='human'`, `user_id=req.user.id`) → `annotations.ts:117-123` (derivation) + `annotations.test.ts` "interactive OAuth client stamps author_type=human…"
- **AC2** (autonomous → `author_type='ai'`, `user_id=req.user.id`) → same derivation + `annotations.test.ts` "autonomous OAuth client stamps author_type=ai…"
- **AC3** (legacy → `id='legacy'`, `author_type='ai'`) → inherited from S7 + `annotations.test.ts` "legacy Bearer caller stamps user_id=legacy…"
- **AC4** (reviews parity) → `reviews.ts:93-98` + `reviews.test.ts` S8 block (interactive/autonomous/legacy)
- **AC5** (`FOUNDRY_MCP_USER` removed) → grep clean across `packages/api/src`
- **AC6** (`FOUNDRY_DEFAULT_USER` removed) → grep clean across `packages/api/src`
- **AC7** (`FOUNDRY_AI_USER_LOGINS` not added) → confirmed not introduced (the bot-allowlist dropped per D-S8-1)
- **AC8** (tests) → `annotations.test.ts` + `reviews.test.ts` assert `author_type` matches client's `client_type` and `user_id` matches authenticated identity across all three paths; spoof-drop tests assert body `user_id` / `author_type` are ignored.

## QA notes
- Backend only, no visual surface.
- Request-body trust: HTTP clients can still send `user_id` / `author_type` fields; server ignores them. Confirmed via test (`ignores user_id sent in the request body`, `ignores author_type sent in the request body`).
- Smoke post-merge: `POST /api/annotations` with legacy token and no `user_id` in body — should get 201 with `user_id='legacy'`, `author_type='ai'`.
- `mcp/server.ts` still advertises `author_type` in its tool input schema; it is a deprecated no-op on the wire. Non-blocking cleanup (out of S8 boundary).

## Test plan
- [x] `npm test` — 399 passed (was 389 green + 1 pre-existing OAuth flake in baseline; added 9 new S8 tests, all existing suites still green)
- [x] `npm run build` — tsc clean
- [x] `grep -r FOUNDRY_MCP_USER packages/api/src` — zero matches
- [x] `grep -r FOUNDRY_DEFAULT_USER packages/api/src` — zero matches
- [x] `grep -r "'clay'" packages/api/src` — only 6 matches, all in out-of-boundary test files: 2 in `doc-crud.test.ts` (the literal `'clay'` sent in the spoof-drop test + a code comment describing it), 4 in `mcp/__tests__/annotations.test.ts` + `annotation-tools.test.ts` (mocked fixture values in tests that stub `http-client.js` entirely — no production code exercises them)
- [ ] Post-merge: orchestrator smoke-tests write path with legacy token