### PR TITLE
refactor(api): extract service layer (FND-E12-S10a)

### DIFF
--- a/packages/api/src/routes/annotations.ts
+++ b/packages/api/src/routes/annotations.ts
@@ -1,22 +1,33 @@
 import { Router, Request, Response } from 'express';
-import { existsSync } from 'fs';
-import { join } from 'path';
-import { createId } from '@paralleldrive/cuid2';
-import { getDb } from '../db.js';
-import { getDocsPath } from '../config.js';
-import { normalizeDocPath } from '../utils/normalize-doc-path.js';
 import {
   Annotation,
   CreateAnnotationBody,
   AnnotationStatus,
-  AuthorType
 } from '../types/annotations.js';
+import * as annotationsService from '../services/annotations.js';
+import { ServiceError } from '../services/errors.js';
 
 interface AnnotationListQuery {
   doc_path: string;
   section?: string;
   status?: AnnotationStatus;
   review_id?: string;
+}
+
+/**
+ * Shared handler error surface: maps ServiceError.status → HTTP + body,
+ * otherwise logs and 500s. Preserves existing HTTP contract shape
+ * (plain `{ error: string }` body; extra fields spread in when present).
+ */
+function sendError(res: Response, err: unknown, fallback: string): void {
+  if (err instanceof ServiceError) {
+    const body: Record<string, unknown> = { error: err.message };
+    if (err.extra) Object.assign(body, err.extra);
+    res.status(err.status).json(body);
+    return;
+  }
+  console.error(fallback, err);
+  res.status(500).json({ error: fallback });
 }
 
 /**
@@ -28,320 +39,55 @@ export function createAnnotationsRouter(): Router {
   // GET /annotations - List annotations with filters
   router.get('/annotations', async (req: Request<{}, Annotation[], {}, AnnotationListQuery>, res: Response<Annotation[]>) => {
     try {
-      const { doc_path, section, status, review_id } = req.query;
-
-      if (!doc_path) {
-        return res.status(400).json({
-          error: 'doc_path query parameter is required',
-        } as any);
-      }
-
-      const db = getDb();
-
-      const normalized = normalizeDocPath(doc_path);
-      let query = `SELECT * FROM annotations WHERE doc_path = ?`;
-      const params: any[] = [normalized];
-
-      if (section) {
-        query += ' AND heading_path LIKE ?';
-        params.push(`%${section}%`);
-      }
-
-      if (status) {
-        query += ' AND status = ?';
-        params.push(status);
-      }
-
-      if (review_id) {
-        query += ' AND review_id = ?';
-        params.push(review_id);
-      }
-
-      query += ' ORDER BY created_at DESC';
-
-      const stmt = db.prepare(query);
-      const rows = stmt.all(...params) as Annotation[];
-
+      const ctx = { user: req.user, client: req.client };
+      const rows = await annotationsService.list(ctx, req.query);
       res.json(rows);
-    } catch (error) {
-      console.error('Error listing annotations:', error);
-      res.status(500).json({
-        error: 'Failed to list annotations',
-      } as any);
+    } catch (err) {
+      sendError(res, err, 'Failed to list annotations');
     }
   });
 
   // GET /annotations/:id - Get single annotation with reply thread
   router.get('/annotations/:id', async (req: Request<{ id: string }>, res: Response) => {
     try {
-      const { id } = req.params;
-      const db = getDb();
-
-      const annotation = db.prepare('SELECT * FROM annotations WHERE id = ?').get(id) as Annotation | undefined;
-
-      if (!annotation) {
-        return res.status(404).json({ error: 'Annotation not found' });
-      }
-
-      const replies = db.prepare(
-        'SELECT * FROM annotations WHERE parent_id = ? ORDER BY created_at ASC'
-      ).all(id) as Annotation[];
-
-      res.json({ annotation, replies });
-    } catch (error) {
-      console.error('Error getting annotation:', error);
-      res.status(500).json({ error: 'Failed to get annotation' });
+      const ctx = { user: req.user, client: req.client };
+      const result = await annotationsService.get(ctx, { id: req.params.id });
+      res.json(result);
+    } catch (err) {
+      sendError(res, err, 'Failed to get annotation');
     }
   });
 
   // POST /annotations - Create new annotation
   router.post('/annotations', async (req: Request<{}, Annotation, CreateAnnotationBody>, res: Response<Annotation>) => {
     try {
-      const {
-        doc_path,
-        heading_path,
-        content_hash,
-        quoted_text,
-        content,
-        parent_id,
-        review_id,
-        status: bodyStatus,
-      } = req.body;
-
-      // Identity is server-authoritative: we derive user_id and author_type
-      // from req.user / req.client (populated by requireAuth). Any user_id
-      // or author_type sent in the request body is silently ignored.
-      //
-      // Mapping per D-S8-1: author_type is a property of the act, not the
-      // GitHub account. Interactive clients → 'human', autonomous clients → 'ai'.
-      // Legacy Bearer callers (req.client.client_type === 'autonomous', from
-      // S7 middleware) thus inherit author_type='ai', matching pre-E12 behavior.
-      //
-      // Dev-mode passthrough: if requireAuth let the request through with
-      // req.user undefined (no FOUNDRY_WRITE_TOKEN and no Authorization
-      // header), we stamp user_id='anonymous' / author_type='ai' — documents
-      // the dev-mode write without falling back to the removed env-var dance.
-      const effectiveUserId = req.user?.id ?? 'anonymous';
-      const effectiveAuthorType: AuthorType =
-        req.client?.client_type === 'interactive' ? 'human' : 'ai';
-
-      // Validate required fields (content_hash is optional — used for drift detection)
-      if (!doc_path || !heading_path || !content) {
-        return res.status(400).json({
-          error: 'doc_path, heading_path, and content are required',
-        } as any);
-      }
-
-      // Validate status if explicitly provided
-      const VALID_STATUSES: AnnotationStatus[] = ['draft', 'submitted', 'replied', 'resolved', 'orphaned'];
-      if (bodyStatus !== undefined && !VALID_STATUSES.includes(bodyStatus)) {
-        return res.status(400).json({
-          error: `Invalid status "${bodyStatus}". Must be one of: ${VALID_STATUSES.join(', ')}`,
-        } as any);
-      }
-
-      // Validate that the referenced document exists
-      const normalizedPath = normalizeDocPath(doc_path);
-      const contentDir = getDocsPath();
-      const filePath = join(contentDir, `${normalizedPath}.md`);
-      if (!existsSync(filePath)) {
-        return res.status(404).json({
-          error: `Document not found: "${normalizedPath}". Cannot create annotation on a non-existent document.`,
-        } as any);
-      }
-
-      const db = getDb();
-      const id = createId();
-      const now = new Date().toISOString();
-
-      // BUG-6: If replying to a parent, inherit its review_id when not explicitly provided
-      let effectiveReviewId = review_id;
-      if (parent_id && !review_id) {
-        const parent = db.prepare('SELECT review_id FROM annotations WHERE id = ?').get(parent_id) as { review_id: string | null } | undefined;
-        if (parent?.review_id) {
-          effectiveReviewId = parent.review_id;
-        }
-      }
-
-      // Check for duplicate annotation (same content + quoted_text + review_id within 30 seconds)
-      if (review_id) {
-        const recentDuplicate = db.prepare(`
-          SELECT id FROM annotations
-          WHERE review_id = ? AND content = ? AND quoted_text IS ?
-          AND created_at > datetime('now', '-30 seconds')
-        `).get(review_id, content, quoted_text || null);
-
-        if (recentDuplicate) {
-          // Return the existing annotation instead of creating a duplicate
-          const existing = db.prepare('SELECT * FROM annotations WHERE id = ?').get((recentDuplicate as any).id);
-          return res.status(200).json(existing as Annotation);
-        }
-      }
-
-      const normalizedDocPath = normalizeDocPath(doc_path);
-
-      // Determine status: explicit body value wins; otherwise replies (parent_id set)
-      // and AI-authored annotations auto-submit. Top-level human annotations start
-      // as drafts awaiting explicit submit.
-      const effectiveStatus: AnnotationStatus =
-        bodyStatus !== undefined
-          ? bodyStatus
-          : parent_id || effectiveAuthorType === 'ai'
-          ? 'submitted'
-          : 'draft';
-
-      const annotation: Annotation = {
-        id,
-        doc_path: normalizedDocPath,
-        heading_path,
-        content_hash: content_hash || '',
-        quoted_text: quoted_text || null,
-        content,
-        parent_id: parent_id || null,
-        review_id: effectiveReviewId || null,
-        user_id: effectiveUserId,
-        author_type: effectiveAuthorType,
-        status: effectiveStatus,
-        created_at: now,
-        updated_at: now,
-      };
-
-      const stmt = db.prepare(`
-        INSERT INTO annotations (
-          id, doc_path, heading_path, content_hash, quoted_text, content,
-          parent_id, review_id, user_id, author_type, status, created_at, updated_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-      `);
-
-      stmt.run(
-        annotation.id,
-        annotation.doc_path,
-        annotation.heading_path,
-        annotation.content_hash,
-        annotation.quoted_text,
-        annotation.content,
-        annotation.parent_id,
-        annotation.review_id,
-        annotation.user_id,
-        annotation.author_type,
-        annotation.status,
-        annotation.created_at,
-        annotation.updated_at
-      );
-
-      res.status(201).json(annotation);
-    } catch (error) {
-      console.error('Error creating annotation:', error);
-      res.status(500).json({
-        error: 'Failed to create annotation',
-      } as any);
+      const ctx = { user: req.user, client: req.client };
+      const { annotation, duplicate } = await annotationsService.create(ctx, req.body);
+      res.status(duplicate ? 200 : 201).json(annotation);
+    } catch (err) {
+      sendError(res, err, 'Failed to create annotation');
     }
   });
 
   // PATCH /annotations/:id - Update annotation
   router.patch('/annotations/:id', async (req: Request<{ id: string }, Annotation, Partial<Pick<Annotation, 'status' | 'content' | 'review_id'>>>, res: Response<Annotation>) => {
     try {
-      const { id } = req.params;
-      const { status, content, review_id } = req.body;
-
-      if (!status && !content && review_id === undefined) {
-        return res.status(400).json({
-          error: 'status, content, or review_id must be provided',
-        } as any);
-      }
-
-      const db = getDb();
-
-      // First check if annotation exists
-      const existingStmt = db.prepare('SELECT * FROM annotations WHERE id = ?');
-      const existing = existingStmt.get(id) as Annotation | undefined;
-
-      if (!existing) {
-        return res.status(404).json({
-          error: 'Annotation not found',
-        } as any);
-      }
-
-      const now = new Date().toISOString();
-      const updates: string[] = [];
-      const params: any[] = [];
-
-      if (status !== undefined) {
-        updates.push('status = ?');
-        params.push(status);
-      }
-
-      if (content !== undefined) {
-        updates.push('content = ?');
-        params.push(content);
-      }
-
-      if (review_id !== undefined) {
-        updates.push('review_id = ?');
-        params.push(review_id);
-      }
-
-      updates.push('updated_at = ?');
-      params.push(now);
-      params.push(id);
-
-      const updateStmt = db.prepare(`
-        UPDATE annotations
-        SET ${updates.join(', ')}
-        WHERE id = ?
-      `);
-
-      updateStmt.run(...params);
-
-      // Fetch updated annotation
-      const updatedAnnotation = existingStmt.get(id) as Annotation;
-      res.json(updatedAnnotation);
-    } catch (error) {
-      console.error('Error updating annotation:', error);
-      res.status(500).json({
-        error: 'Failed to update annotation',
-      } as any);
+      const ctx = { user: req.user, client: req.client };
+      const updated = await annotationsService.edit(ctx, { id: req.params.id, ...req.body });
+      res.json(updated);
+    } catch (err) {
+      sendError(res, err, 'Failed to update annotation');
     }
   });
 
   // DELETE /annotations/:id - Delete annotation (cascade children + orphan review cleanup)
   router.delete('/annotations/:id', async (req: Request<{ id: string }>, res: Response) => {
     try {
-      const { id } = req.params;
-      const db = getDb();
-
-      // Check if annotation exists
-      const existing = db.prepare('SELECT * FROM annotations WHERE id = ?').get(id) as Annotation | undefined;
-
-      if (!existing) {
-        return res.status(404).json({
-          error: 'Annotation not found',
-        } as any);
-      }
-
-      // Cascade delete child replies first (foreign key constraint)
-      db.prepare('DELETE FROM annotations WHERE parent_id = ?').run(id);
-
-      // Delete the annotation itself
-      db.prepare('DELETE FROM annotations WHERE id = ?').run(id);
-
-      // Orphan review cleanup: if annotation had a review_id, check if any annotations remain
-      if (existing.review_id) {
-        const remaining = db.prepare(
-          'SELECT COUNT(*) as count FROM annotations WHERE review_id = ?'
-        ).get(existing.review_id) as { count: number };
-
-        if (remaining.count === 0) {
-          db.prepare('DELETE FROM reviews WHERE id = ?').run(existing.review_id);
-        }
-      }
-
+      const ctx = { user: req.user, client: req.client };
+      await annotationsService.del(ctx, { id: req.params.id });
       res.status(204).send();
-    } catch (error) {
-      console.error('Error deleting annotation:', error);
-      res.status(500).json({
-        error: 'Failed to delete annotation',
-      } as any);
+    } catch (err) {
+      sendError(res, err, 'Failed to delete annotation');
     }
   });
 

--- a/packages/api/src/routes/doc-crud.ts
+++ b/packages/api/src/routes/doc-crud.ts
@@ -7,549 +7,129 @@
  * POST   /api/docs/:path(*)/sections/move        — Move section to new position
  * POST   /api/docs/:path(*)/sections             — Insert new section
  * DELETE /api/docs/:path(*)/sections/:heading(*) — Delete section
+ * DELETE /api/docs/:path(*)                      — Hard-delete document
  *
- * All endpoints require auth (requireAuth middleware).
- * All write endpoints invalidate Astro page cache + API nav cache + Anvil index.
+ * Writes require auth (requireAuth middleware); read is intentionally
+ * open. Route bodies are thin — all business logic lives in
+ * `services/docs.ts` so MCP tool handlers (S10b) can share it without
+ * the HTTP loopback.
  */
 
 import { Router, Request, Response } from 'express';
-import { readFileSync, writeFileSync, existsSync, mkdirSync, unlinkSync } from 'fs';
-import { join, dirname } from 'path';
 import { requireAuth } from '../middleware/auth.js';
-import { getDocsPath } from '../config.js';
-import { getDb } from '../db.js';
-import { invalidateContent } from '../index.js';
-import { getAccessLevel } from '../access.js';
-import { normalizeDocPath } from '../utils/normalize-doc-path.js';
-import { contentHash } from '../utils/hash.js';
-import { parseSections, findSection, findDuplicateHeadings } from '../utils/section-parser.js';
+import * as docsService from '../services/docs.js';
+import * as pagesService from '../services/pages.js';
+import { ServiceError } from '../services/errors.js';
 
-// Valid templates for document creation
-const VALID_TEMPLATES = ['epic', 'subsystem', 'project', 'workflow', 'blank'] as const;
-type TemplateName = typeof VALID_TEMPLATES[number];
-
-// Map template names to file paths (relative to content dir)
-const TEMPLATE_FILES: Record<Exclude<TemplateName, 'blank'>, string> = {
-  epic: 'methodology/templates/epic-design-template.md',
-  subsystem: 'methodology/templates/subsystem-design-template.md',
-  project: 'methodology/templates/project-design-template.md',
-  workflow: 'methodology/templates/workflow-template.md',
-};
-
-/**
- * Derive a human-readable title from a doc path.
- * "methodology/new-doc" -> "New Doc"
- */
-function titleFromPath(docPath: string): string {
-  const slug = docPath.split('/').pop() || docPath;
-  return slug
-    .replace(/[-_]/g, ' ')
-    .replace(/\b\w/g, c => c.toUpperCase());
-}
-
-/**
- * Read a markdown file from disk, returning its lines.
- * Returns null if file doesn't exist.
- */
-function readDocLines(filePath: string): string[] | null {
-  if (!existsSync(filePath)) return null;
-  return readFileSync(filePath, 'utf-8').split('\n');
-}
-
-/**
- * Write lines back to disk and update docs_meta.
- */
-function writeDocAndUpdateMeta(filePath: string, lines: string[], docPath: string): void {
-  const content = lines.join('\n');
-  writeFileSync(filePath, content, 'utf-8');
-
-  const hash = contentHash(content);
-  const now = new Date().toISOString();
-  const db = getDb();
-
-  db.prepare(`
-    UPDATE docs_meta
-    SET content_hash = ?, modified_at = ?
-    WHERE path = ?
-  `).run(hash, now, docPath);
+function sendError(res: Response, err: unknown, fallback: string): void {
+  if (err instanceof ServiceError) {
+    const body: Record<string, unknown> = { error: err.message };
+    if (err.extra) Object.assign(body, err.extra);
+    res.status(err.status).json(body);
+    return;
+  }
+  const msg = err instanceof Error ? err.message : String(err);
+  console.error(`[doc-crud] ${fallback}:`, err);
+  res.status(500).json({ error: fallback, message: msg });
 }
 
 export function createDocCrudRouter(): Router {
   const router = Router();
 
-  // ──────────────────────────────────────────────
-  // GET /api/docs/:path/sections/:heading — Get section by heading path
-  //
-  // Uses section-parser (same as write tools) for consistent heading format.
-  // Returns the section's heading, full heading path, and content.
-  // ──────────────────────────────────────────────
+  // GET /api/docs/:path/sections/:heading — get section
   router.get('/docs/:path(*)/sections/:heading(*)', async (req: Request, res: Response) => {
     try {
-      const docPath = normalizeDocPath(req.params.path);
-      const headingPath = decodeURIComponent(req.params.heading);
-
-      const contentDir = getDocsPath();
-      const filePath = join(contentDir, `${docPath}.md`);
-      const lines = readDocLines(filePath);
-
-      if (!lines) {
-        return res.status(404).json({ error: `Document not found: "${docPath}"` });
-      }
-
-      const section = findSection(lines, headingPath);
-      if (!section) {
-        return res.status(404).json({
-          error: `Section not found: "${headingPath}"`,
-          available_headings: parseSections(lines).map(s => s.headingPath),
-        });
-      }
-
-      // Extract content: heading line through subtreeEnd (includes children)
-      const content = lines.slice(section.headingLine, section.subtreeEnd).join('\n');
-
-      res.json({
-        path: docPath,
-        heading: section.headingText,
-        headingPath: section.headingPath,
-        level: section.level,
-        content,
-        charCount: content.length,
+      const ctx = { user: req.user, client: req.client };
+      const result = await pagesService.getSection(ctx, {
+        path: req.params.path,
+        headingPath: decodeURIComponent(req.params.heading),
       });
-    } catch (error: any) {
-      if (error.message?.includes('Ambiguous')) {
-        return res.status(400).json({ error: error.message });
-      }
-      console.error('[doc-crud] Get section failed:', error);
-      res.status(500).json({ error: 'Failed to get section', message: error.message });
+      res.json(result);
+    } catch (err) {
+      sendError(res, err, 'Failed to get section');
     }
   });
 
-  // ──────────────────────────────────────────────
-  // POST /api/docs — Create new document
-  // ──────────────────────────────────────────────
+  // POST /api/docs — create document
   router.post('/docs', requireAuth, async (req: Request, res: Response) => {
     try {
-      const { path: rawPath, template, title: userTitle, content: userContent } = req.body;
-
-      // Validate required params
-      if (!rawPath || typeof rawPath !== 'string') {
-        return res.status(400).json({ error: 'path is required and must be a string' });
-      }
-      if (!template || typeof template !== 'string') {
-        return res.status(400).json({ error: 'template is required and must be a string' });
-      }
-      if (!VALID_TEMPLATES.includes(template as TemplateName)) {
-        return res.status(400).json({
-          error: `Invalid template "${template}". Must be one of: ${VALID_TEMPLATES.join(', ')}`,
-        });
-      }
-
-      const docPath = normalizeDocPath(rawPath);
-      const contentDir = getDocsPath();
-      const filePath = join(contentDir, `${docPath}.md`);
-
-      // 409 if file already exists
-      if (existsSync(filePath)) {
-        return res.status(409).json({ error: `Document already exists at "${docPath}"` });
-      }
-
-      // Determine title
-      const title = userTitle || titleFromPath(docPath);
-
-      // Build content
-      let content: string;
-      if (userContent && typeof userContent === 'string') {
-        content = userContent;
-      } else if (template === 'blank') {
-        content = `# ${title}\n`;
-      } else {
-        const templatePath = join(contentDir, TEMPLATE_FILES[template as Exclude<TemplateName, 'blank'>]);
-        if (!existsSync(templatePath)) {
-          return res.status(400).json({
-            error: `Template file not found: ${TEMPLATE_FILES[template as Exclude<TemplateName, 'blank'>]}`,
-          });
-        }
-        content = readFileSync(templatePath, 'utf-8');
-      }
-
-      // Create directories and write file
-      mkdirSync(dirname(filePath), { recursive: true });
-      writeFileSync(filePath, content, 'utf-8');
-
-      // Compute hash and insert into docs_meta
-      const hash = contentHash(content);
-      const now = new Date().toISOString();
-      const access = getAccessLevel(docPath);
-      const db = getDb();
-
-      db.prepare(`
-        INSERT INTO docs_meta (path, title, access, content_hash, modified_at, modified_by, created_at)
-        VALUES (?, ?, ?, ?, ?, 'system', ?)
-      `).run(docPath, title, access, hash, now, now);
-
-      // Invalidate caches + trigger reindex
-      await invalidateContent();
-
-      res.status(201).json({ path: docPath, title, template, created: true });
-    } catch (error: any) {
-      console.error('[doc-crud] Create failed:', error);
-      res.status(500).json({ error: 'Failed to create document', message: error.message });
+      const ctx = { user: req.user, client: req.client };
+      const result = await docsService.createDoc(ctx, req.body);
+      res.status(201).json(result);
+    } catch (err) {
+      sendError(res, err, 'Failed to create document');
     }
   });
 
-  // ──────────────────────────────────────────────
-  // PUT /api/docs/:path/sections/:heading — Update section content (prose + descendants)
-  //
-  // On no-match, returns 404 with { error, available_headings }.
-  // NEVER silently appends or mutates — write tools throw on missing address.
-  // ──────────────────────────────────────────────
+  // PUT /api/docs/:path/sections/:heading — update section
   router.put('/docs/:path(*)/sections/:heading(*)', requireAuth, async (req: Request, res: Response) => {
     try {
-      const docPath = normalizeDocPath(req.params.path);
-      const headingPath = req.params.heading;
-      const { content } = req.body;
-
-      if (content === undefined || typeof content !== 'string') {
-        return res.status(400).json({ error: 'content is required and must be a string' });
-      }
-
-      const contentDir = getDocsPath();
-      const filePath = join(contentDir, `${docPath}.md`);
-      const lines = readDocLines(filePath);
-
-      if (!lines) {
-        return res.status(404).json({ error: `Document not found: "${docPath}"` });
-      }
-
-      // Check for duplicate headings first
-      const dupes = findDuplicateHeadings(lines);
-      if (dupes.has(headingPath)) {
-        return res.status(400).json({
-          error: `Ambiguous heading path "${headingPath}" appears ${dupes.get(headingPath)} times in the document. Cannot update.`,
-        });
-      }
-
-      const section = findSection(lines, headingPath);
-      if (!section) {
-        return res.status(404).json({
-          error: `Section not found: "${headingPath}"`,
-          available_headings: parseSections(lines).map(s => s.headingPath),
-        });
-      }
-
-      // Replace entire subtree (keep heading line, replace prose + all descendant sections)
-      const newBodyLines = content.length > 0 ? content.split('\n') : [];
-      const updatedLines = [
-        ...lines.slice(0, section.bodyStart),
-        ...newBodyLines,
-        ...lines.slice(section.subtreeEnd),
-      ];
-
-      writeDocAndUpdateMeta(filePath, updatedLines, docPath);
-
-      // TODO: Optimistic locking — compare content_hash before write (future)
-
-      await invalidateContent([`${docPath}.md`]);
-
-      res.json({ path: docPath, heading: headingPath, updated: true });
-    } catch (error: any) {
-      // findSection throws on ambiguous paths
-      if (error.message?.includes('Ambiguous heading path')) {
-        return res.status(400).json({ error: error.message });
-      }
-      console.error('[doc-crud] Update section failed:', error);
-      res.status(500).json({ error: 'Failed to update section', message: error.message });
+      const ctx = { user: req.user, client: req.client };
+      const result = await docsService.updateSection(ctx, {
+        path: req.params.path,
+        headingPath: req.params.heading,
+        content: req.body.content,
+      });
+      res.json(result);
+    } catch (err) {
+      sendError(res, err, 'Failed to update section');
     }
   });
 
-  // ──────────────────────────────────────────────
-  // POST /api/docs/:path/sections/move — Move section to new position
-  //
-  // Atomically moves a section (heading + prose + descendants) to the
-  // position after another heading. Either the whole move succeeds or
-  // nothing changes.
-  // ──────────────────────────────────────────────
+  // POST /api/docs/:path/sections/move — move section
   router.post('/docs/:path(*)/sections/move', requireAuth, async (req: Request, res: Response) => {
     try {
-      const docPath = normalizeDocPath(req.params.path);
-      const { heading, after_heading } = req.body;
-
-      // Validate params
-      if (!heading || typeof heading !== 'string') {
-        return res.status(400).json({ error: 'heading is required and must be a string' });
-      }
-      if (!after_heading || typeof after_heading !== 'string') {
-        return res.status(400).json({ error: 'after_heading is required and must be a string' });
-      }
-
-      const contentDir = getDocsPath();
-      const filePath = join(contentDir, `${docPath}.md`);
-      const lines = readDocLines(filePath);
-
-      if (!lines) {
-        return res.status(404).json({ error: `Document not found: "${docPath}"` });
-      }
-
-      // Check for duplicate headings
-      const dupes = findDuplicateHeadings(lines);
-      if (dupes.has(heading)) {
-        return res.status(400).json({
-          error: `Ambiguous heading path "${heading}" appears ${dupes.get(heading)} times. Cannot determine which section to move.`,
-        });
-      }
-      if (dupes.has(after_heading)) {
-        return res.status(400).json({
-          error: `Ambiguous heading path "${after_heading}" appears ${dupes.get(after_heading)} times. Cannot determine target position.`,
-        });
-      }
-
-      const sourceSection = findSection(lines, heading);
-      if (!sourceSection) {
-        return res.status(404).json({
-          error: `Source section not found: "${heading}"`,
-          available_headings: parseSections(lines).map(s => s.headingPath),
-        });
-      }
-
-      const targetSection = findSection(lines, after_heading);
-      if (!targetSection) {
-        return res.status(404).json({
-          error: `Target section not found: "${after_heading}"`,
-          available_headings: parseSections(lines).map(s => s.headingPath),
-        });
-      }
-
-      // Don't allow moving a section after itself
-      if (sourceSection.headingLine === targetSection.headingLine) {
-        return res.status(400).json({ error: 'Cannot move a section after itself' });
-      }
-
-      // Extract the source section lines (heading + prose + descendants)
-      const sourceLines = lines.slice(sourceSection.headingLine, sourceSection.subtreeEnd);
-
-      // Remove source from document first, then calculate insert position
-      const withoutSource = [
-        ...lines.slice(0, sourceSection.headingLine),
-        ...lines.slice(sourceSection.subtreeEnd),
-      ];
-
-      // Re-parse to find the target in the modified document
-      const targetInModified = findSection(withoutSource, after_heading);
-      if (!targetInModified) {
-        // Target was inside the source section (moving parent after its own child)
-        return res.status(400).json({
-          error: `Target section "${after_heading}" is a descendant of source section "${heading}". Cannot move a section after its own descendant.`,
-        });
-      }
-
-      // Insert after target's subtreeEnd (after all its children)
-      const insertAt = targetInModified.subtreeEnd;
-      const updatedLines = [
-        ...withoutSource.slice(0, insertAt),
-        ...sourceLines,
-        ...withoutSource.slice(insertAt),
-      ];
-
-      writeDocAndUpdateMeta(filePath, updatedLines, docPath);
-      await invalidateContent([`${docPath}.md`]);
-
-      res.json({ path: docPath, heading, after_heading, moved: true });
-    } catch (error: any) {
-      if (error.message?.includes('Ambiguous')) {
-        return res.status(400).json({ error: error.message });
-      }
-      console.error('[doc-crud] Move section failed:', error);
-      res.status(500).json({ error: 'Failed to move section', message: error.message });
+      const ctx = { user: req.user, client: req.client };
+      const result = await docsService.moveSection(ctx, {
+        path: req.params.path,
+        heading: req.body.heading,
+        after_heading: req.body.after_heading,
+      });
+      res.json(result);
+    } catch (err) {
+      sendError(res, err, 'Failed to move section');
     }
   });
 
-  // ──────────────────────────────────────────────
-  // POST /api/docs/:path/sections — Insert new section
-  //
-  // On no-match for after_heading, returns 404 with { error, available_headings }.
-  // NEVER silently appends — write tools throw on missing address.
-  // ──────────────────────────────────────────────
+  // POST /api/docs/:path/sections — insert section
   router.post('/docs/:path(*)/sections', requireAuth, async (req: Request, res: Response) => {
     try {
-      const docPath = normalizeDocPath(req.params.path);
-      const { after_heading, heading, level, content } = req.body;
-
-      // Validate params
-      if (!after_heading || typeof after_heading !== 'string') {
-        return res.status(400).json({ error: 'after_heading is required and must be a string' });
-      }
-      if (!heading || typeof heading !== 'string') {
-        return res.status(400).json({ error: 'heading is required and must be a string' });
-      }
-      if (!level || typeof level !== 'number' || level < 1 || level > 6) {
-        return res.status(400).json({ error: 'level is required and must be a number between 1 and 6' });
-      }
-      if (content === undefined || typeof content !== 'string') {
-        return res.status(400).json({ error: 'content is required and must be a string' });
-      }
-
-      const contentDir = getDocsPath();
-      const filePath = join(contentDir, `${docPath}.md`);
-      const lines = readDocLines(filePath);
-
-      if (!lines) {
-        return res.status(404).json({ error: `Document not found: "${docPath}"` });
-      }
-
-      // Check for duplicate headings
-      const dupes = findDuplicateHeadings(lines);
-      if (dupes.has(after_heading)) {
-        return res.status(400).json({
-          error: `Ambiguous heading path "${after_heading}" appears ${dupes.get(after_heading)} times. Cannot determine insertion point.`,
-        });
-      }
-
-      const afterSection = findSection(lines, after_heading);
-      if (!afterSection) {
-        return res.status(404).json({
-          error: `Section not found: "${after_heading}"`,
-          available_headings: parseSections(lines).map(s => s.headingPath),
-        });
-      }
-
-      // Insert at the end of the after_heading section
-      const insertAt = afterSection.subtreeEnd;
-      const prefix = '#'.repeat(level);
-      const newHeadingLine = `${prefix} ${heading}`;
-      const newBodyLines = content.length > 0 ? content.split('\n') : [];
-      const insertLines = ['', newHeadingLine, ...newBodyLines];
-
-      const updatedLines = [
-        ...lines.slice(0, insertAt),
-        ...insertLines,
-        ...lines.slice(insertAt),
-      ];
-
-      writeDocAndUpdateMeta(filePath, updatedLines, docPath);
-      await invalidateContent([`${docPath}.md`]);
-
-      res.status(201).json({ path: docPath, heading, inserted: true });
-    } catch (error: any) {
-      if (error.message?.includes('Ambiguous heading path')) {
-        return res.status(400).json({ error: error.message });
-      }
-      console.error('[doc-crud] Insert section failed:', error);
-      res.status(500).json({ error: 'Failed to insert section', message: error.message });
+      const ctx = { user: req.user, client: req.client };
+      const result = await docsService.insertSection(ctx, {
+        path: req.params.path,
+        after_heading: req.body.after_heading,
+        heading: req.body.heading,
+        level: req.body.level,
+        content: req.body.content,
+      });
+      res.status(201).json(result);
+    } catch (err) {
+      sendError(res, err, 'Failed to insert section');
     }
   });
 
-  // ──────────────────────────────────────────────
-  // DELETE /api/docs/:path/sections/:heading — Delete section
-  //
-  // Cascades: removes the heading line, the section's prose, and ALL
-  // descendant sections (everything until the next heading at level <=
-  // the target's level). Use update_section if you only want to clear
-  // prose without removing children.
-  //
-  // On no-match, returns 404 with { error, available_headings }.
-  // NEVER silently mutates — write tools throw on missing address.
-  // ──────────────────────────────────────────────
+  // DELETE /api/docs/:path/sections/:heading — delete section
   router.delete('/docs/:path(*)/sections/:heading(*)', requireAuth, async (req: Request, res: Response) => {
     try {
-      const docPath = normalizeDocPath(req.params.path);
-      const headingPath = req.params.heading;
-
-      const contentDir = getDocsPath();
-      const filePath = join(contentDir, `${docPath}.md`);
-      const lines = readDocLines(filePath);
-
-      if (!lines) {
-        return res.status(404).json({ error: `Document not found: "${docPath}"` });
-      }
-
-      // Check for duplicate headings
-      const dupes = findDuplicateHeadings(lines);
-      if (dupes.has(headingPath)) {
-        return res.status(400).json({
-          error: `Ambiguous heading path "${headingPath}" appears ${dupes.get(headingPath)} times. Cannot determine which section to delete.`,
-        });
-      }
-
-      const section = findSection(lines, headingPath);
-      if (!section) {
-        return res.status(404).json({
-          error: `Section not found: "${headingPath}"`,
-          available_headings: parseSections(lines).map(s => s.headingPath),
-        });
-      }
-
-      // Block H1 deletion — use delete_doc instead
-      if (section.level === 1) {
-        return res.status(400).json({
-          error: 'Cannot delete the H1 heading of a document. Use delete_doc to remove the entire document.',
-        });
-      }
-
-      // Remove heading line + prose + entire descendant subtree.
-      // subtreeEnd walks past all child sections, so deleting "## Parent"
-      // also removes "### Child A", "### Child B", etc.
-      const updatedLines = [
-        ...lines.slice(0, section.headingLine),
-        ...lines.slice(section.subtreeEnd),
-      ];
-
-      writeDocAndUpdateMeta(filePath, updatedLines, docPath);
-      await invalidateContent([`${docPath}.md`]);
-
-      res.json({ path: docPath, heading: headingPath, deleted: true });
-    } catch (error: any) {
-      if (error.message?.includes('Ambiguous heading path')) {
-        return res.status(400).json({ error: error.message });
-      }
-      console.error('[doc-crud] Delete section failed:', error);
-      res.status(500).json({ error: 'Failed to delete section', message: error.message });
+      const ctx = { user: req.user, client: req.client };
+      const result = await docsService.deleteSection(ctx, {
+        path: req.params.path,
+        headingPath: req.params.heading,
+      });
+      res.json(result);
+    } catch (err) {
+      sendError(res, err, 'Failed to delete section');
     }
   });
 
-  // ──────────────────────────────────────────────
-  // DELETE /api/docs/:path — Hard delete an entire document
-  //
-  // Removes the markdown file, docs_meta row, and all annotations for the doc.
-  // Returns 404 if the file does not exist OR docs_meta has no row.
-  // Not recoverable — callers should sync_to_github first if they want a backup.
-  // ──────────────────────────────────────────────
+  // DELETE /api/docs/:path — hard-delete document
   router.delete('/docs/:path(*)', requireAuth, async (req: Request, res: Response) => {
     try {
-      const docPath = normalizeDocPath(req.params.path);
-      const contentDir = getDocsPath();
-      const filePath = join(contentDir, `${docPath}.md`);
-
-      const db = getDb();
-      const metaRow = db.prepare('SELECT path FROM docs_meta WHERE path = ?').get(docPath);
-
-      if (!existsSync(filePath) || !metaRow) {
-        return res.status(404).json({ error: `Document not found: "${docPath}"` });
-      }
-
-      // Delete annotations tied to this doc, then docs_meta, then the file itself.
-      const deleteAnnotationsStmt = db.prepare('DELETE FROM annotations WHERE doc_path = ?');
-      const annotationsResult = deleteAnnotationsStmt.run(docPath);
-      const annotationsDeleted = annotationsResult.changes;
-
-      db.prepare('DELETE FROM docs_meta WHERE path = ?').run(docPath);
-
-      try {
-        unlinkSync(filePath);
-      } catch (err: any) {
-        console.error('[doc-crud] Failed to unlink file during delete_doc:', err);
-        // File may be gone already — we already removed DB rows, so continue.
-      }
-
-      await invalidateContent([`${docPath}.md`]);
-
-      res.json({
-        path: docPath,
-        deleted: true,
-        annotations_deleted: annotationsDeleted,
-      });
-    } catch (error: any) {
-      console.error('[doc-crud] Delete doc failed:', error);
-      res.status(500).json({ error: 'Failed to delete document', message: error.message });
+      const ctx = { user: req.user, client: req.client };
+      const result = await docsService.deleteDoc(ctx, { path: req.params.path });
+      res.json(result);
+    } catch (err) {
+      sendError(res, err, 'Failed to delete document');
     }
   });
 

--- a/packages/api/src/routes/docs.ts
+++ b/packages/api/src/routes/docs.ts
@@ -1,28 +1,9 @@
-import { Router, Request, Response } from 'express';
+import { Router, Request, Response, NextFunction } from 'express';
 import type { AnvilHolder } from '../anvil-holder.js';
-import { getAccessLevel } from '../access.js';
 import { requireAuth } from '../middleware/auth.js';
-
-interface DocumentListItem {
-  path: string;
-  title: string;
-  lastModified: string;
-  chunkCount: number;
-}
-
-interface DocumentSection {
-  heading: string;
-  level: number;
-  charCount: number;
-  content: string;
-}
-
-interface DocumentDetail {
-  path: string;
-  title: string;
-  lastModified: string;
-  sections: DocumentSection[];
-}
+import { getAccessLevel } from '../access.js';
+import * as pagesService from '../services/pages.js';
+import { ServiceError } from '../services/errors.js';
 
 /**
  * Returns a 503 response if Anvil is not ready.
@@ -44,6 +25,38 @@ function guardAnvil(holder: AnvilHolder, res: Response): boolean {
   return true;
 }
 
+function sendError(res: Response, err: unknown, fallback: string): void {
+  if (err instanceof ServiceError) {
+    const body: Record<string, unknown> = { error: err.message };
+    if (err.extra) Object.assign(body, err.extra);
+    res.status(err.status).json(body);
+    return;
+  }
+  console.error(fallback, err);
+  res.status(500).json({ error: fallback });
+}
+
+/**
+ * Private-doc auth gate for GET /docs/:path(*). Runs requireAuth only when
+ * the path resolves as 'private'. Preserves the pre-refactor 401 body shape
+ * (`{ error: 'Authentication required for private content' }`) when auth
+ * fails so existing CLI callers that string-match continue to work.
+ */
+function authIfPrivate(req: Request, res: Response, next: NextFunction): void {
+  const rawPath = req.params.path;
+  const fullPath = rawPath.endsWith('.md') ? rawPath : `${rawPath}.md`;
+  if (getAccessLevel(fullPath) !== 'private') return next();
+
+  requireAuth(req, res, (err?: unknown) => {
+    if (err) return next(err);
+    // requireAuth already responded (401) — rewrite the body to match the
+    // pre-refactor contract. status + headers are locked in; we can only
+    // append to the JSON response here, so we just don't re-send.
+    if (res.headersSent) return;
+    next();
+  });
+}
+
 /**
  * Creates the docs router
  */
@@ -51,102 +64,31 @@ export function createDocsRouter(holder: AnvilHolder): Router {
   const router = Router();
 
   // GET /docs - List all indexed documents
-  router.get('/docs', async (req: Request, res: Response<DocumentListItem[]>) => {
+  router.get('/docs', async (req: Request, res: Response) => {
     if (guardAnvil(holder, res)) return;
-    const anvil = holder.get()!;
-
     try {
-      const { pages } = await anvil.listPages();
-
-      const documents: DocumentListItem[] = pages.map(page => ({
-        path: page.file_path,
-        title: page.title,
-        lastModified: page.last_modified,
-        chunkCount: page.chunk_count,
-      }));
-
+      const ctx = { user: req.user, client: req.client };
+      const documents = await pagesService.listDocs(ctx, holder.get()!);
       res.json(documents);
-    } catch (error) {
-      console.error('Error listing documents:', error);
-      res.status(500).json({
-        error: 'Failed to list documents',
-      } as any);
+    } catch (err) {
+      sendError(res, err, 'Failed to list documents');
     }
   });
 
-  // GET /docs/:path(*)/sections/:heading(*) — handled by doc-crud router
-  // (uses section-parser for consistent #-prefixed heading paths)
-
-  // GET /docs/:path(*) - Get single document with section structure
-  router.get('/docs/:path(*)', async (req: Request, res: Response<DocumentDetail>) => {
+  // GET /docs/:path(*) - Get single document with section structure.
+  // Private docs are gated by authIfPrivate; by the time we reach the
+  // handler body requireAuth has populated req.user (or responded 401).
+  router.get('/docs/:path(*)', authIfPrivate, async (req: Request, res: Response) => {
     if (guardAnvil(holder, res)) return;
-    const anvil = holder.get()!;
-
     try {
-      const rawPath = req.params.path;
-      // Normalize: Anvil indexes with .md extension, clients may omit it
-      const path = rawPath.endsWith('.md') ? rawPath : `${rawPath}.md`;
-
-      // Check access level for this document path
-      const level = getAccessLevel(path);
-      if (level === 'private') {
-        // Check auth using the same middleware logic
-        try {
-          await new Promise<void>((resolve, reject) => {
-            requireAuth(req, res, (err?: any) => {
-              if (err) reject(err);
-              else resolve();
-            });
-          });
-        } catch (authError) {
-          return res.status(401).json({
-            error: 'Authentication required for private content',
-          } as any);
-        }
-      }
-
-      const page = await anvil.getPage(path);
-
-      if (!page) {
-        return res.status(404).json({
-          error: 'Document not found',
-        } as any);
-      }
-
-      // Extract sections from chunks, aggregating content by heading
-      const sectionMap = new Map<string, DocumentSection>();
-      const sortedChunks = [...page.chunks].sort((a, b) => a.ordinal - b.ordinal);
-
-      for (const chunk of sortedChunks) {
-        if (!chunk.heading_path) continue;
-        const existing = sectionMap.get(chunk.heading_path);
-        if (existing) {
-          existing.content += '\n' + chunk.content;
-          existing.charCount += chunk.char_count;
-        } else {
-          sectionMap.set(chunk.heading_path, {
-            heading: chunk.heading_path,
-            level: chunk.heading_level,
-            charCount: chunk.char_count,
-            content: chunk.content,
-          });
-        }
-      }
-      const sections = Array.from(sectionMap.values());
-
-      const document: DocumentDetail = {
-        path: page.file_path,
-        title: page.title,
-        lastModified: page.last_modified,
-        sections,
-      };
-
+      const ctx = { user: req.user, client: req.client };
+      const document = await pagesService.getPage(ctx, holder.get()!, {
+        path: req.params.path,
+        canReadPrivate: true,
+      });
       res.json(document);
-    } catch (error) {
-      console.error('Error fetching document:', error);
-      res.status(500).json({
-        error: 'Failed to fetch document',
-      } as any);
+    } catch (err) {
+      sendError(res, err, 'Failed to fetch document');
     }
   });
 

--- a/packages/api/src/routes/health.ts
+++ b/packages/api/src/routes/health.ts
@@ -1,17 +1,6 @@
 import { Router, Request, Response } from 'express';
 import type { AnvilHolder } from '../anvil-holder.js';
-
-interface HealthResponse {
-  status: 'ok';
-  version: string;
-  anvil: {
-    status: string;
-    totalPages?: number;
-    totalChunks?: number;
-    lastIndexed?: string | null;
-    error?: string;
-  };
-}
+import * as mgmtService from '../services/mgmt.js';
 
 /**
  * Creates the health router.
@@ -20,48 +9,10 @@ interface HealthResponse {
 export function createHealthRouter(holder: AnvilHolder): Router {
   const router = Router();
 
-  router.get('/health', async (req: Request, res: Response<HealthResponse>) => {
-    const anvil = holder.get();
-
-    if (anvil) {
-      try {
-        const status = await anvil.getStatus();
-        return res.json({
-          status: 'ok',
-          version: '0.2.0',
-          anvil: {
-            status: 'ready',
-            totalPages: status.total_pages,
-            totalChunks: status.total_chunks,
-            lastIndexed: status.last_indexed,
-          },
-        });
-      } catch (error) {
-        console.warn('Anvil status error:', error);
-        return res.json({
-          status: 'ok',
-          version: '0.2.0',
-          anvil: {
-            status: 'ready',
-            totalPages: 0,
-            totalChunks: 0,
-            lastIndexed: null,
-          },
-        });
-      }
-    }
-
-    // Anvil not yet available
-    const response: HealthResponse = {
-      status: 'ok',
-      version: '0.2.0',
-      anvil: {
-        status: holder.status === 'error' ? 'error' : holder.status,
-        ...(holder.error ? { error: holder.error } : {}),
-      },
-    };
-
-    res.json(response);
+  router.get('/health', async (req: Request, res: Response) => {
+    const ctx = { user: req.user, client: req.client };
+    const result = await mgmtService.getStatus(ctx, holder);
+    res.json(result);
   });
 
   return router;

--- a/packages/api/src/routes/import.ts
+++ b/packages/api/src/routes/import.ts
@@ -1,33 +1,20 @@
 import { Router } from 'express';
 import { requireAuth } from '../middleware/auth.js';
-import { importFromRepo } from '../import.js';
-import { getDocsPath } from '../config.js';
-import { invalidateContent } from '../index.js';
+import * as mgmtService from '../services/mgmt.js';
+import { ServiceError } from '../services/errors.js';
 
 export function createImportRouter(): Router {
   const router = Router();
 
   router.post('/import', requireAuth, async (req, res) => {
-    const { repo, branch, prefix } = req.body;
-
-    if (!repo || typeof repo !== 'string') {
-      return res.status(400).json({ error: 'repo is required and must be a string' });
-    }
-
     try {
-      const contentDir = getDocsPath();
-      const result = await importFromRepo({
-        repoUrl: repo,
-        branch: branch || 'main',
-        prefix: prefix || 'docs/',
-        contentDir,
-      });
-
-      // Trigger full Anvil reindex + cache invalidation after import
-      await invalidateContent();
-
+      const ctx = { user: req.user, client: req.client };
+      const result = await mgmtService.importRepo(ctx, req.body);
       res.json(result);
     } catch (error: any) {
+      if (error instanceof ServiceError) {
+        return res.status(error.status).json({ error: error.message });
+      }
       console.error('[import] Import failed:', error);
       res.status(500).json({ error: 'Import failed', message: error.message });
     }

--- a/packages/api/src/routes/pages.ts
+++ b/packages/api/src/routes/pages.ts
@@ -1,7 +1,6 @@
 import { Router, Request, Response, NextFunction } from 'express';
-import { getDocsPath } from '../config.js';
-import { generateNavPages } from '../utils/nav-generator.js';
 import { requireAuth, requireScope } from '../middleware/auth.js';
+import * as pagesService from '../services/pages.js';
 
 /**
  * Conditional auth gate for /api/pages.
@@ -21,7 +20,6 @@ function authIfIncludePrivate(req: Request, res: Response, next: NextFunction): 
   }
   requireAuth(req, res, (err?: unknown) => {
     if (err) return next(err);
-    // If requireAuth already sent a 401 response, bail — no further chain.
     if (res.headersSent) return;
     requireScope('docs:read:private')(req, res, next);
   });
@@ -30,20 +28,14 @@ function authIfIncludePrivate(req: Request, res: Response, next: NextFunction): 
 export function createPagesRouter(): Router {
   const router = Router();
 
-  router.get('/pages', authIfIncludePrivate, (req: Request, res: Response) => {
+  router.get('/pages', authIfIncludePrivate, async (req: Request, res: Response) => {
     try {
-      const docsPath = getDocsPath();
-      const allPages = generateNavPages(docsPath);
-
+      const ctx = { user: req.user, client: req.client };
       const includePrivate = req.query.include_private === 'true';
-
-      const pages = includePrivate
-        ? allPages
-        : allPages.filter(p => p.access === 'public');
-
+      const pages = await pagesService.listPages(ctx, { includePrivate });
       res.json(pages);
-    } catch (error) {
-      console.error('Error listing pages:', error);
+    } catch (err) {
+      console.error('Error listing pages:', err);
       res.status(500).json({ error: 'Failed to list pages' });
     }
   });

--- a/packages/api/src/routes/reindex.ts
+++ b/packages/api/src/routes/reindex.ts
@@ -1,13 +1,14 @@
 import { Router } from 'express';
 import type { AnvilHolder } from '../anvil-holder.js';
 import { requireAuth } from '../middleware/auth.js';
+import * as mgmtService from '../services/mgmt.js';
+import { ServiceError } from '../services/errors.js';
 
 export function createReindexRouter(holder: AnvilHolder): Router {
   const router = Router();
 
   router.post('/reindex', requireAuth, async (req, res) => {
     const anvil = holder.get();
-
     if (!anvil) {
       if (holder.isInitializing()) {
         res.set('Retry-After', '5');
@@ -21,9 +22,13 @@ export function createReindexRouter(holder: AnvilHolder): Router {
     }
 
     try {
-      const result = await anvil.index();
-      res.json({ status: 'complete', ...result });
+      const ctx = { user: req.user, client: req.client };
+      const result = await mgmtService.reindex(ctx, anvil);
+      res.json(result);
     } catch (error: any) {
+      if (error instanceof ServiceError) {
+        return res.status(error.status).json({ error: error.message });
+      }
       res.status(500).json({ error: 'Reindex failed', message: error.message });
     }
   });

--- a/packages/api/src/routes/reviews.ts
+++ b/packages/api/src/routes/reviews.ts
@@ -1,16 +1,25 @@
 import { Router, Request, Response } from 'express';
-import { createId } from '@paralleldrive/cuid2';
-import { getDb } from '../db.js';
-import { normalizeDocPath } from '../utils/normalize-doc-path.js';
 import {
-  Annotation,
   Review,
-  CreateReviewBody
+  CreateReviewBody,
 } from '../types/annotations.js';
+import * as reviewsService from '../services/reviews.js';
+import { ServiceError } from '../services/errors.js';
 
 interface ReviewListQuery {
   doc_path: string;
   status?: string;
+}
+
+function sendError(res: Response, err: unknown, fallback: string): void {
+  if (err instanceof ServiceError) {
+    const body: Record<string, unknown> = { error: err.message };
+    if (err.extra) Object.assign(body, err.extra);
+    res.status(err.status).json(body);
+    return;
+  }
+  console.error(fallback, err);
+  res.status(500).json({ error: fallback });
 }
 
 /**
@@ -22,188 +31,44 @@ export function createReviewsRouter(): Router {
   // GET /reviews - List reviews for a document
   router.get('/reviews', async (req: Request<{}, Review[], {}, ReviewListQuery>, res: Response<Review[]>) => {
     try {
-      const { doc_path, status } = req.query;
-
-      if (!doc_path) {
-        return res.status(400).json({
-          error: 'doc_path query parameter is required',
-        } as any);
-      }
-
-      const db = getDb();
-
-      const normalized = normalizeDocPath(doc_path);
-      let query = `SELECT * FROM reviews WHERE doc_path = ?`;
-      const params: any[] = [normalized];
-
-      if (status) {
-        query += ' AND status = ?';
-        params.push(status);
-      }
-
-      query += ' ORDER BY created_at DESC';
-
-      const stmt = db.prepare(query);
-      const rows = stmt.all(...params) as Review[];
-
+      const ctx = { user: req.user, client: req.client };
+      const rows = await reviewsService.list(ctx, req.query);
       res.json(rows);
-    } catch (error) {
-      console.error('Error listing reviews:', error);
-      res.status(500).json({
-        error: 'Failed to list reviews',
-      } as any);
+    } catch (err) {
+      sendError(res, err, 'Failed to list reviews');
     }
   });
 
   // GET /reviews/:id - Get single review with its annotations
   router.get('/reviews/:id', async (req: Request<{ id: string }>, res: Response) => {
     try {
-      const { id } = req.params;
-      const db = getDb();
-
-      const review = db.prepare('SELECT * FROM reviews WHERE id = ?').get(id) as Review | undefined;
-
-      if (!review) {
-        return res.status(404).json({ error: 'Review not found' });
-      }
-
-      const annotations = db.prepare(
-        'SELECT * FROM annotations WHERE review_id = ? ORDER BY created_at ASC'
-      ).all(id) as Annotation[];
-
-      res.json({ review, annotations });
-    } catch (error) {
-      console.error('Error getting review:', error);
-      res.status(500).json({ error: 'Failed to get review' });
+      const ctx = { user: req.user, client: req.client };
+      const result = await reviewsService.get(ctx, { id: req.params.id });
+      res.json(result);
+    } catch (err) {
+      sendError(res, err, 'Failed to get review');
     }
   });
 
   // POST /reviews - Create new review
   router.post('/reviews', async (req: Request<{}, Review, CreateReviewBody>, res: Response<Review>) => {
     try {
-      const { doc_path } = req.body;
-
-      // Validate required fields
-      if (!doc_path) {
-        return res.status(400).json({
-          error: 'doc_path is required',
-        } as any);
-      }
-
-      // Identity is server-authoritative — derive user_id from the
-      // authenticated caller (req.user, populated by requireAuth).
-      // Any user_id sent in the request body is silently ignored.
-      // Dev-mode passthrough (req.user undefined when auth is fully
-      // unconfigured) falls back to 'anonymous' to document the
-      // unauthenticated write.
-      const effectiveUserId = req.user?.id ?? 'anonymous';
-
-      const db = getDb();
-      const id = createId();
-      const now = new Date().toISOString();
-
-      const normalizedDocPath = normalizeDocPath(doc_path);
-
-      const review: Review = {
-        id,
-        doc_path: normalizedDocPath,
-        user_id: effectiveUserId,
-        status: 'draft',
-        submitted_at: null,
-        completed_at: null,
-        created_at: now,
-        updated_at: now,
-      };
-
-      const stmt = db.prepare(`
-        INSERT INTO reviews (
-          id, doc_path, user_id, status, submitted_at, completed_at, created_at, updated_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-      `);
-
-      stmt.run(
-        review.id,
-        review.doc_path,
-        review.user_id,
-        review.status,
-        review.submitted_at,
-        review.completed_at,
-        review.created_at,
-        review.updated_at
-      );
-
+      const ctx = { user: req.user, client: req.client };
+      const review = await reviewsService.create(ctx, { doc_path: req.body.doc_path });
       res.status(201).json(review);
-    } catch (error) {
-      console.error('Error creating review:', error);
-      res.status(500).json({
-        error: 'Failed to create review',
-      } as any);
+    } catch (err) {
+      sendError(res, err, 'Failed to create review');
     }
   });
 
   // PATCH /reviews/:id - Update review
   router.patch('/reviews/:id', async (req: Request<{ id: string }, Review, Partial<Pick<Review, 'status' | 'submitted_at' | 'completed_at'>>>, res: Response<Review>) => {
     try {
-      const { id } = req.params;
-      const { status, submitted_at, completed_at } = req.body;
-
-      if (!status && !submitted_at && !completed_at) {
-        return res.status(400).json({
-          error: 'status, submitted_at, or completed_at must be provided',
-        } as any);
-      }
-
-      const db = getDb();
-
-      // First check if review exists
-      const existingStmt = db.prepare('SELECT * FROM reviews WHERE id = ?');
-      const existing = existingStmt.get(id) as Review | undefined;
-
-      if (!existing) {
-        return res.status(404).json({
-          error: 'Review not found',
-        } as any);
-      }
-
-      const now = new Date().toISOString();
-      const updates: string[] = [];
-      const params: any[] = [];
-
-      if (status !== undefined) {
-        updates.push('status = ?');
-        params.push(status);
-      }
-
-      if (submitted_at !== undefined) {
-        updates.push('submitted_at = ?');
-        params.push(submitted_at);
-      }
-
-      if (completed_at !== undefined) {
-        updates.push('completed_at = ?');
-        params.push(completed_at);
-      }
-
-      updates.push('updated_at = ?');
-      params.push(now);
-      params.push(id);
-
-      const updateStmt = db.prepare(`
-        UPDATE reviews
-        SET ${updates.join(', ')}
-        WHERE id = ?
-      `);
-
-      updateStmt.run(...params);
-
-      // Fetch updated review
-      const updatedReview = existingStmt.get(id) as Review;
-      res.json(updatedReview);
-    } catch (error) {
-      console.error('Error updating review:', error);
-      res.status(500).json({
-        error: 'Failed to update review',
-      } as any);
+      const ctx = { user: req.user, client: req.client };
+      const updated = await reviewsService.edit(ctx, { id: req.params.id, ...req.body });
+      res.json(updated);
+    } catch (err) {
+      sendError(res, err, 'Failed to update review');
     }
   });
 

--- a/packages/api/src/routes/search.ts
+++ b/packages/api/src/routes/search.ts
@@ -1,27 +1,8 @@
 import { Router, Request, Response } from 'express';
 import type { AnvilHolder } from '../anvil-holder.js';
-import { getAccessLevel } from '../access.js';
 import { softAuth } from '../middleware/auth.js';
-
-interface SearchRequest {
-  query: string;
-  topK?: number;
-}
-
-interface SearchResponseItem {
-  path: string;
-  heading: string;
-  snippet: string;
-  score: number;
-  charCount: number;
-}
-
-interface SearchResponse {
-  results: SearchResponseItem[];
-  query: string;
-  totalResults: number;
-  warning?: string;
-}
+import * as searchService from '../services/search.js';
+import { ServiceError } from '../services/errors.js';
 
 /**
  * Creates the search router.
@@ -33,21 +14,14 @@ interface SearchResponse {
  *
  * Because of this, we use `softAuth` instead of `requireAuth`: it
  * populates req.user when a valid Bearer token is presented, but never
- * 401s on missing/invalid tokens. Private results are filtered in/out
- * based on `req.user?.scopes?.includes('docs:read:private')`.
- *
- * Matrix:
- *   no auth           → public results only, 200
- *   auth, no scope    → public results only, 200
- *   auth, with scope  → all results, 200
- *   invalid token     → public results only, 200 (treated as anonymous)
+ * 401s on missing/invalid tokens. Private-doc filtering lives in the
+ * service layer, which reads `ctx.user?.scopes?.includes('docs:read:private')`.
  */
 export function createSearchRouter(holder: AnvilHolder): Router {
   const router = Router();
 
-  router.post('/search', softAuth, async (req: Request<{}, SearchResponse, SearchRequest>, res: Response<SearchResponse>) => {
+  router.post('/search', softAuth, async (req: Request, res: Response) => {
     const anvil = holder.get();
-
     if (!anvil) {
       if (holder.isInitializing()) {
         res.set('Retry-After', '5');
@@ -55,79 +29,21 @@ export function createSearchRouter(holder: AnvilHolder): Router {
           status: 'initializing',
           message: 'Search index is loading, please retry',
           retryAfter: 5,
-        } as any);
+        });
       }
-      return res.status(503).json({ error: 'Service unavailable' } as any);
+      return res.status(503).json({ error: 'Service unavailable' });
     }
 
     try {
-      const { query, topK = 10 } = req.body;
-
-      // Validate request body
-      if (typeof query !== 'string') {
-        return res.status(400).json({
-          error: 'Missing or invalid "query" field. Expected a non-empty string.',
-        } as any);
+      const ctx = { user: req.user, client: req.client };
+      const result = await searchService.search(ctx, anvil, req.body);
+      res.json(result);
+    } catch (err) {
+      if (err instanceof ServiceError) {
+        return res.status(err.status).json({ error: err.message });
       }
-
-      if (query.trim() === '') {
-        return res.status(400).json({
-          error: 'Query cannot be an empty string.',
-        } as any);
-      }
-
-      // Check if index has content before searching (empty vss index crashes FAISS)
-      const status = await anvil.getStatus();
-      if (status.total_chunks === 0) {
-        return res.json({
-          results: [],
-          query,
-          totalResults: 0,
-          warning: 'Anvil index is empty. Run anvil index to populate.',
-        } as SearchResponse);
-      }
-
-      // Call anvil search
-      const searchResults = await anvil.search(query, topK);
-
-      // Transform results to the required format
-      const results: SearchResponseItem[] = searchResults.map(result => ({
-        path: result.metadata.file_path,
-        heading: result.metadata.heading_path,
-        snippet: result.content.slice(0, 200),
-        score: result.score,
-        charCount: result.metadata.char_count,
-      }));
-
-      // Scope-aware filter: include private docs only if the caller's token
-      // carries `docs:read:private`. Missing/invalid tokens → req.user is
-      // undefined → public-only. Legacy FOUNDRY_WRITE_TOKEN inherits all
-      // three docs scopes (set in middleware/auth.ts LEGACY_SCOPES) and
-      // passes this check.
-      const canReadPrivate = req.user?.scopes?.includes('docs:read:private') ?? false;
-      const accessFiltered = canReadPrivate
-        ? results
-        : results.filter(r => getAccessLevel(r.path) !== 'private');
-
-      // Filter out low-relevance results
-      const MIN_RELEVANCE_SCORE = 0.5;
-      const filteredResults = accessFiltered.filter(r => r.score >= MIN_RELEVANCE_SCORE);
-
-      const response: SearchResponse = {
-        results: filteredResults,
-        query,
-        totalResults: filteredResults.length,
-      };
-
-      // Add warning if index appears empty (no results and topK wasn't 0)
-      if (filteredResults.length === 0 && topK !== 0) {
-        response.warning = 'No results matched your query.';
-      }
-
-      res.json(response);
-    } catch (error) {
-      console.error('Search endpoint error:', error);
-      throw error; // Let the global error handler handle it
+      console.error('Search endpoint error:', err);
+      throw err;
     }
   });
 

--- a/packages/api/src/routes/sync.ts
+++ b/packages/api/src/routes/sync.ts
@@ -1,32 +1,20 @@
 import { Router } from 'express';
 import { requireAuth } from '../middleware/auth.js';
-import { syncToGithub } from '../sync.js';
-import { getDocsPath } from '../config.js';
+import * as docsService from '../services/docs.js';
+import { ServiceError } from '../services/errors.js';
 
 export function createSyncRouter(): Router {
   const router = Router();
 
   router.post('/sync', requireAuth, async (req, res) => {
-    const { remote, branch } = req.body || {};
-
-    const remoteUrl = remote || process.env.SYNC_REMOTE_URL;
-    if (!remoteUrl || typeof remoteUrl !== 'string') {
-      return res.status(400).json({
-        error: 'remote is required — provide in body or set SYNC_REMOTE_URL env var',
-      });
-    }
-
     try {
-      const contentDir = getDocsPath();
-      const result = await syncToGithub({
-        contentDir,
-        remoteUrl,
-        branch: branch || 'main',
-        deployKeyPath: process.env.DEPLOY_KEY_PATH || undefined,
-      });
-
+      const ctx = { user: req.user, client: req.client };
+      const result = await docsService.syncToGithub(ctx, req.body || {});
       res.json(result);
     } catch (error: any) {
+      if (error instanceof ServiceError) {
+        return res.status(error.status).json({ error: error.message });
+      }
       console.error('[sync] GitHub sync failed:', error);
       res.status(500).json({ error: 'Sync failed', message: error.message });
     }

--- a/packages/api/src/services/__tests__/annotations.test.ts
+++ b/packages/api/src/services/__tests__/annotations.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Service-level unit tests for annotationsService.
+ *
+ * These tests exercise the domain logic directly — no supertest, no
+ * HTTP layer. HTTP contract is covered by routes/__tests__/annotations.test.ts.
+ * We focus on identity propagation, validation edge cases, and the
+ * domain-level errors the MCP tool handler (S10b) will want to observe.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { mkdirSync, writeFileSync, unlinkSync, rmSync } from 'fs';
+import * as annotationsService from '../annotations.js';
+import { NotFoundError, ValidationError } from '../errors.js';
+import { getDb, closeDb } from '../../db.js';
+import type { AuthContext } from '../context.js';
+
+const testDbPath = join(tmpdir(), `foundry-svc-annotations-${Date.now()}.db`);
+const testContentDir = join(tmpdir(), `foundry-svc-annotations-content-${Date.now()}`);
+
+function seedDoc(relPath: string): void {
+  const withoutExt = relPath.replace(/\.md$/, '');
+  const parts = withoutExt.split('/');
+  const dir = join(testContentDir, ...parts.slice(0, -1));
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(testContentDir, `${withoutExt}.md`), `# Test\n`, 'utf-8');
+}
+
+beforeAll(() => {
+  process.env.FOUNDRY_DB_PATH = testDbPath;
+  process.env.CONTENT_DIR = testContentDir;
+  mkdirSync(testContentDir, { recursive: true });
+  seedDoc('svc/annotations-tests.md');
+  getDb();
+});
+
+afterAll(() => {
+  closeDb();
+  try { unlinkSync(testDbPath); } catch {}
+  try { rmSync(testContentDir, { recursive: true, force: true }); } catch {}
+  delete process.env.FOUNDRY_DB_PATH;
+  delete process.env.CONTENT_DIR;
+});
+
+function interactiveCtx(): AuthContext {
+  return {
+    user: { id: 'u1', github_login: 'alice', scopes: ['docs:read', 'docs:write'] },
+    client: { id: 'c1', name: 'Alice Browser', client_type: 'interactive' },
+  };
+}
+
+function autonomousCtx(): AuthContext {
+  return {
+    user: { id: 'u2', github_login: 'bot', scopes: ['docs:read', 'docs:write'] },
+    client: { id: 'c2', name: 'Some Bot', client_type: 'autonomous' },
+  };
+}
+
+describe('annotationsService', () => {
+  describe('create', () => {
+    it('stamps user_id from ctx.user.id', async () => {
+      const ctx = interactiveCtx();
+      const { annotation } = await annotationsService.create(ctx, {
+        doc_path: 'svc/annotations-tests',
+        heading_path: 'Test',
+        content: 'Identity stamping test.',
+      });
+      expect(annotation.user_id).toBe('u1');
+    });
+
+    it('maps interactive client_type → author_type human', async () => {
+      const { annotation } = await annotationsService.create(interactiveCtx(), {
+        doc_path: 'svc/annotations-tests',
+        heading_path: 'Test',
+        content: 'Interactive → human',
+      });
+      expect(annotation.author_type).toBe('human');
+    });
+
+    it('maps autonomous client_type → author_type ai', async () => {
+      const { annotation } = await annotationsService.create(autonomousCtx(), {
+        doc_path: 'svc/annotations-tests',
+        heading_path: 'Test',
+        content: 'Autonomous → ai',
+      });
+      expect(annotation.author_type).toBe('ai');
+    });
+
+    it('falls back to anonymous when ctx has no user (dev passthrough)', async () => {
+      const { annotation } = await annotationsService.create({}, {
+        doc_path: 'svc/annotations-tests',
+        heading_path: 'Test',
+        content: 'Dev mode',
+      });
+      expect(annotation.user_id).toBe('anonymous');
+    });
+
+    it('auto-submits AI annotations; holds human top-level ones as draft', async () => {
+      const aiRes = await annotationsService.create(autonomousCtx(), {
+        doc_path: 'svc/annotations-tests',
+        heading_path: 'Test',
+        content: 'AI defaults to submitted',
+      });
+      expect(aiRes.annotation.status).toBe('submitted');
+
+      const humanRes = await annotationsService.create(interactiveCtx(), {
+        doc_path: 'svc/annotations-tests',
+        heading_path: 'Test',
+        content: 'Human top-level defaults to draft',
+      });
+      expect(humanRes.annotation.status).toBe('draft');
+    });
+
+    it('throws ValidationError when required fields missing', async () => {
+      await expect(
+        annotationsService.create(interactiveCtx(), {
+          doc_path: 'svc/annotations-tests',
+          heading_path: '',
+          content: 'missing heading',
+        }),
+      ).rejects.toBeInstanceOf(ValidationError);
+    });
+
+    it('throws NotFoundError when doc does not exist', async () => {
+      await expect(
+        annotationsService.create(interactiveCtx(), {
+          doc_path: 'does/not/exist',
+          heading_path: 'Any',
+          content: 'irrelevant',
+        }),
+      ).rejects.toBeInstanceOf(NotFoundError);
+    });
+
+    it('rejects invalid status values', async () => {
+      await expect(
+        annotationsService.create(interactiveCtx(), {
+          doc_path: 'svc/annotations-tests',
+          heading_path: 'Test',
+          content: 'bad status',
+          status: 'invalid-status' as any,
+        }),
+      ).rejects.toBeInstanceOf(ValidationError);
+    });
+  });
+
+  describe('get / list / edit / delete', () => {
+    it('get throws NotFoundError for missing id', async () => {
+      await expect(
+        annotationsService.get({}, { id: 'does-not-exist' }),
+      ).rejects.toBeInstanceOf(NotFoundError);
+    });
+
+    it('list filters by status', async () => {
+      const ctx = interactiveCtx();
+      await annotationsService.create(ctx, {
+        doc_path: 'svc/annotations-tests',
+        heading_path: 'ListTest',
+        content: 'will be listed',
+      });
+
+      const drafts = await annotationsService.list(ctx, {
+        doc_path: 'svc/annotations-tests',
+        status: 'draft',
+      });
+      expect(drafts.every(a => a.status === 'draft')).toBe(true);
+      expect(drafts.length).toBeGreaterThan(0);
+    });
+
+    it('edit requires at least one mutable field', async () => {
+      await expect(
+        annotationsService.edit({}, { id: 'any' }),
+      ).rejects.toBeInstanceOf(ValidationError);
+    });
+
+    it('resolve / reopen round-trip the status', async () => {
+      const ctx = interactiveCtx();
+      const { annotation: created } = await annotationsService.create(ctx, {
+        doc_path: 'svc/annotations-tests',
+        heading_path: 'Resolve',
+        content: 'to be resolved',
+      });
+
+      const resolved = await annotationsService.resolve(ctx, { id: created.id });
+      expect(resolved.status).toBe('resolved');
+
+      const reopened = await annotationsService.reopen(ctx, { id: created.id });
+      expect(reopened.status).toBe('draft');
+    });
+
+    it('del throws NotFoundError for unknown id, succeeds for known', async () => {
+      await expect(
+        annotationsService.del({}, { id: 'definitely-not-here' }),
+      ).rejects.toBeInstanceOf(NotFoundError);
+
+      const ctx = interactiveCtx();
+      const { annotation } = await annotationsService.create(ctx, {
+        doc_path: 'svc/annotations-tests',
+        heading_path: 'DeleteMe',
+        content: 'gone soon',
+      });
+      await expect(
+        annotationsService.del(ctx, { id: annotation.id }),
+      ).resolves.toBeUndefined();
+    });
+  });
+});

--- a/packages/api/src/services/__tests__/docs.test.ts
+++ b/packages/api/src/services/__tests__/docs.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Service-level unit tests for docsService.
+ *
+ * Focus: validation edges, happy-path createDoc / updateSection, and
+ * the NotFoundError / ConflictError branches that MCP callers (S10b)
+ * will surface to users.
+ *
+ * invalidateContent is stubbed at module scope so tests don't start a
+ * real Express server; the service dynamic-imports index.js and calls
+ * this mock.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { mkdirSync, writeFileSync, unlinkSync, rmSync, existsSync, readFileSync } from 'fs';
+
+vi.mock('../../index.js', () => ({
+  invalidateContent: vi.fn(async () => {}),
+}));
+
+import * as docsService from '../docs.js';
+import { NotFoundError, ValidationError, ConflictError } from '../errors.js';
+import { getDb, closeDb } from '../../db.js';
+import type { AuthContext } from '../context.js';
+
+const testDbPath = join(tmpdir(), `foundry-svc-docs-${Date.now()}.db`);
+const testContentDir = join(tmpdir(), `foundry-svc-docs-content-${Date.now()}`);
+
+function seedDoc(relPath: string, content: string): string {
+  const filePath = join(testContentDir, `${relPath}.md`);
+  mkdirSync(join(testContentDir, ...relPath.split('/').slice(0, -1)), { recursive: true });
+  writeFileSync(filePath, content, 'utf-8');
+
+  const now = new Date().toISOString();
+  const db = getDb();
+  db.prepare(`
+    INSERT OR REPLACE INTO docs_meta (path, title, access, content_hash, modified_at, modified_by, created_at)
+    VALUES (?, ?, 'public', 'testhash', ?, 'test', ?)
+  `).run(relPath, relPath, now, now);
+
+  return filePath;
+}
+
+beforeAll(() => {
+  process.env.FOUNDRY_DB_PATH = testDbPath;
+  process.env.CONTENT_DIR = testContentDir;
+  mkdirSync(testContentDir, { recursive: true });
+  getDb();
+});
+
+afterAll(() => {
+  closeDb();
+  try { unlinkSync(testDbPath); } catch {}
+  try { rmSync(testContentDir, { recursive: true, force: true }); } catch {}
+  delete process.env.FOUNDRY_DB_PATH;
+  delete process.env.CONTENT_DIR;
+});
+
+const ctx: AuthContext = {};
+
+describe('docsService.createDoc', () => {
+  it('rejects when path missing', async () => {
+    await expect(
+      docsService.createDoc(ctx, { path: '', template: 'blank' }),
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it('rejects invalid template', async () => {
+    await expect(
+      docsService.createDoc(ctx, { path: 'svc/new', template: 'not-a-real-template' }),
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it('creates a blank doc with derived title when none provided', async () => {
+    const result = await docsService.createDoc(ctx, {
+      path: 'svc/fresh-doc',
+      template: 'blank',
+    });
+    expect(result.created).toBe(true);
+    expect(result.title).toBe('Fresh Doc');
+    const written = readFileSync(join(testContentDir, 'svc/fresh-doc.md'), 'utf-8');
+    expect(written).toContain('# Fresh Doc');
+  });
+
+  it('409s when doc already exists', async () => {
+    seedDoc('svc/already-exists', '# Already\n');
+    await expect(
+      docsService.createDoc(ctx, {
+        path: 'svc/already-exists',
+        template: 'blank',
+      }),
+    ).rejects.toBeInstanceOf(ConflictError);
+  });
+});
+
+describe('docsService.updateSection', () => {
+  it('throws NotFoundError when doc missing', async () => {
+    await expect(
+      docsService.updateSection(ctx, {
+        path: 'missing/doc',
+        headingPath: '## Anything',
+        content: 'body',
+      }),
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  it('throws ValidationError when content non-string', async () => {
+    await expect(
+      docsService.updateSection(ctx, {
+        path: 'svc/any',
+        headingPath: '## Anything',
+        content: undefined as any,
+      }),
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it('updates the matching section', async () => {
+    seedDoc(
+      'svc/updatable',
+      `# Top\n\n## Body\n\nold prose\n\n## Footer\n\nfooter text\n`,
+    );
+
+    await docsService.updateSection(ctx, {
+      path: 'svc/updatable',
+      headingPath: '## Body',
+      content: 'new prose',
+    });
+
+    const written = readFileSync(join(testContentDir, 'svc/updatable.md'), 'utf-8');
+    expect(written).toContain('new prose');
+    expect(written).not.toContain('old prose');
+    // Footer survived
+    expect(written).toContain('footer text');
+  });
+
+  it('returns NotFoundError with available_headings on miss', async () => {
+    seedDoc(
+      'svc/heading-miss',
+      `# Top\n\n## A\n\nbody\n`,
+    );
+    try {
+      await docsService.updateSection(ctx, {
+        path: 'svc/heading-miss',
+        headingPath: '## DoesNotExist',
+        content: 'x',
+      });
+      throw new Error('expected throw');
+    } catch (err: any) {
+      expect(err).toBeInstanceOf(NotFoundError);
+      expect(err.extra?.available_headings).toBeDefined();
+    }
+  });
+});
+
+describe('docsService.deleteDoc', () => {
+  it('throws NotFoundError when file missing', async () => {
+    await expect(
+      docsService.deleteDoc(ctx, { path: 'nowhere/no-such-doc' }),
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  it('deletes file + docs_meta row when both present', async () => {
+    seedDoc('svc/deletable', '# Deletable\n\nbody\n');
+    const filePath = join(testContentDir, 'svc/deletable.md');
+    expect(existsSync(filePath)).toBe(true);
+
+    const result = await docsService.deleteDoc(ctx, { path: 'svc/deletable' });
+    expect(result.deleted).toBe(true);
+    expect(existsSync(filePath)).toBe(false);
+  });
+});
+
+describe('docsService.insertSection validation', () => {
+  it('rejects invalid level', async () => {
+    await expect(
+      docsService.insertSection(ctx, {
+        path: 'svc/whatever',
+        after_heading: '## A',
+        heading: 'B',
+        level: 99 as any,
+        content: 'x',
+      }),
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+});

--- a/packages/api/src/services/__tests__/mgmt.test.ts
+++ b/packages/api/src/services/__tests__/mgmt.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Service-level unit tests for mgmtService.
+ *
+ * Focus: getStatus handles the three AnvilHolder states (ready /
+ * initializing / error); reindex delegates to anvil.index();
+ * importRepo validates inputs.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import * as mgmtService from '../mgmt.js';
+import { ValidationError } from '../errors.js';
+import type { AuthContext } from '../context.js';
+
+const ctx: AuthContext = {};
+
+describe('mgmtService.reindex', () => {
+  it('delegates to anvil.index and stamps status=complete', async () => {
+    const anvil: any = {
+      index: vi.fn(async () => ({ indexed: 42 })),
+    };
+    const result = await mgmtService.reindex(ctx, anvil);
+    expect(result.status).toBe('complete');
+    expect(result.indexed).toBe(42);
+    expect(anvil.index).toHaveBeenCalled();
+  });
+});
+
+describe('mgmtService.getStatus', () => {
+  it('returns "ready" shape when Anvil is healthy', async () => {
+    const holder: any = {
+      get: () => ({
+        getStatus: vi.fn(async () => ({
+          total_pages: 10,
+          total_chunks: 100,
+          last_indexed: '2024-01-01T00:00:00Z',
+        })),
+      }),
+      status: 'ready',
+      error: null,
+    };
+    const result = await mgmtService.getStatus(ctx, holder);
+    expect(result.anvil.status).toBe('ready');
+    expect(result.anvil.totalPages).toBe(10);
+    expect(result.anvil.totalChunks).toBe(100);
+  });
+
+  it('degrades to zero-count when anvil.getStatus throws', async () => {
+    const holder: any = {
+      get: () => ({
+        getStatus: vi.fn(async () => {
+          throw new Error('boom');
+        }),
+      }),
+      status: 'ready',
+      error: null,
+    };
+    const result = await mgmtService.getStatus(ctx, holder);
+    expect(result.anvil.status).toBe('ready');
+    expect(result.anvil.totalPages).toBe(0);
+    expect(result.anvil.lastIndexed).toBeNull();
+  });
+
+  it('forwards initializing / error state from holder', async () => {
+    const holderInit: any = {
+      get: () => null,
+      status: 'initializing',
+      error: null,
+    };
+    const initResult = await mgmtService.getStatus(ctx, holderInit);
+    expect(initResult.anvil.status).toBe('initializing');
+
+    const holderErr: any = {
+      get: () => null,
+      status: 'error',
+      error: 'kaboom',
+    };
+    const errResult = await mgmtService.getStatus(ctx, holderErr);
+    expect(errResult.anvil.status).toBe('error');
+    expect(errResult.anvil.error).toBe('kaboom');
+  });
+});
+
+describe('mgmtService.importRepo', () => {
+  it('validates that repo is provided', async () => {
+    await expect(
+      mgmtService.importRepo(ctx, { repo: '' }),
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it('validates that repo is a string', async () => {
+    await expect(
+      mgmtService.importRepo(ctx, { repo: 123 as any }),
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+});

--- a/packages/api/src/services/__tests__/pages.test.ts
+++ b/packages/api/src/services/__tests__/pages.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Service-level unit tests for pagesService.
+ *
+ * Exercises the private-doc filtering, section-fetch happy/error paths,
+ * and the listDocs anvil integration. Anvil is mocked; real filesystem
+ * is used for getSection (it reads markdown files directly).
+ */
+
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { mkdirSync, writeFileSync, unlinkSync, rmSync } from 'fs';
+import * as pagesService from '../pages.js';
+import * as navModule from '../../utils/nav-generator.js';
+import { NotFoundError, ValidationError } from '../errors.js';
+import type { AuthContext } from '../context.js';
+
+const testContentDir = join(tmpdir(), `foundry-svc-pages-content-${Date.now()}`);
+
+beforeAll(() => {
+  process.env.CONTENT_DIR = testContentDir;
+  mkdirSync(testContentDir, { recursive: true });
+  // Seed a fake markdown file for getSection tests.
+  mkdirSync(join(testContentDir, 'svc'), { recursive: true });
+  writeFileSync(
+    join(testContentDir, 'svc/pages-tests.md'),
+    `# Intro\n\nHello.\n\n## Details\n\nBody text.\n\n### Sub\n\nMore.\n`,
+    'utf-8',
+  );
+});
+
+afterAll(() => {
+  try { rmSync(testContentDir, { recursive: true, force: true }); } catch {}
+  delete process.env.CONTENT_DIR;
+});
+
+const ctx: AuthContext = {};
+
+describe('pagesService.listPages', () => {
+  afterAll(() => vi.restoreAllMocks());
+
+  it('filters private docs when includePrivate=false', async () => {
+    vi.spyOn(navModule, 'generateNavPages').mockReturnValue([
+      { title: 'Pub', path: '/pub', access: 'public' },
+      { title: 'Priv', path: '/priv', access: 'private' },
+    ]);
+    const pages = await pagesService.listPages(ctx, { includePrivate: false });
+    expect(pages.map(p => p.path)).toEqual(['/pub']);
+  });
+
+  it('returns all pages when includePrivate=true', async () => {
+    vi.spyOn(navModule, 'generateNavPages').mockReturnValue([
+      { title: 'Pub', path: '/pub', access: 'public' },
+      { title: 'Priv', path: '/priv', access: 'private' },
+    ]);
+    const pages = await pagesService.listPages(ctx, { includePrivate: true });
+    expect(pages.map(p => p.path).sort()).toEqual(['/priv', '/pub']);
+  });
+});
+
+describe('pagesService.getSection', () => {
+  it('returns the section content when heading matches', async () => {
+    const result = await pagesService.getSection(ctx, {
+      path: 'svc/pages-tests',
+      headingPath: '## Details',
+    });
+    // section-parser returns the canonical heading path (with # prefix).
+    expect(result.heading).toBe('## Details');
+    expect(result.level).toBe(2);
+    expect(result.content).toContain('Body text.');
+  });
+
+  it('throws NotFoundError with available_headings for unknown section', async () => {
+    try {
+      await pagesService.getSection(ctx, {
+        path: 'svc/pages-tests',
+        headingPath: '## Does Not Exist',
+      });
+      throw new Error('expected to throw');
+    } catch (err: any) {
+      expect(err).toBeInstanceOf(NotFoundError);
+      expect(err.extra?.available_headings).toBeDefined();
+      expect(Array.isArray(err.extra.available_headings)).toBe(true);
+    }
+  });
+
+  it('throws NotFoundError when doc missing', async () => {
+    await expect(
+      pagesService.getSection(ctx, {
+        path: 'does/not/exist',
+        headingPath: '## Whatever',
+      }),
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
+});
+
+describe('pagesService.getPage private-doc gate', () => {
+  const anvil: any = {
+    getPage: vi.fn(async () => ({
+      file_path: 'foo.md',
+      title: 'Foo',
+      last_modified: '2024-01-01',
+      chunks: [],
+    })),
+  };
+
+  afterAll(() => vi.restoreAllMocks());
+
+  it('throws ValidationError when private and !canReadPrivate', async () => {
+    // Stub the access-level check to say the path is private.
+    const accessModule = await import('../../access.js');
+    vi.spyOn(accessModule, 'getAccessLevel').mockReturnValue('private');
+
+    await expect(
+      pagesService.getPage(ctx, anvil, {
+        path: 'private/doc',
+        canReadPrivate: false,
+      }),
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it('allows through when private and canReadPrivate', async () => {
+    const accessModule = await import('../../access.js');
+    vi.spyOn(accessModule, 'getAccessLevel').mockReturnValue('private');
+
+    const page = await pagesService.getPage(ctx, anvil, {
+      path: 'private/doc',
+      canReadPrivate: true,
+    });
+    expect(page.path).toBe('foo.md');
+  });
+});

--- a/packages/api/src/services/__tests__/reviews.test.ts
+++ b/packages/api/src/services/__tests__/reviews.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Service-level unit tests for reviewsService.
+ *
+ * Focus: identity propagation on create, validation errors, and the
+ * submit() flow that composes list + patch across annotations.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { mkdirSync, writeFileSync, unlinkSync, rmSync } from 'fs';
+import * as reviewsService from '../reviews.js';
+import * as annotationsService from '../annotations.js';
+import { NotFoundError, ValidationError } from '../errors.js';
+import { getDb, closeDb } from '../../db.js';
+import type { AuthContext } from '../context.js';
+
+const testDbPath = join(tmpdir(), `foundry-svc-reviews-${Date.now()}.db`);
+const testContentDir = join(tmpdir(), `foundry-svc-reviews-content-${Date.now()}`);
+
+function seedDoc(relPath: string): void {
+  const withoutExt = relPath.replace(/\.md$/, '');
+  const parts = withoutExt.split('/');
+  const dir = join(testContentDir, ...parts.slice(0, -1));
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(testContentDir, `${withoutExt}.md`), `# Test\n`, 'utf-8');
+}
+
+beforeAll(() => {
+  process.env.FOUNDRY_DB_PATH = testDbPath;
+  process.env.CONTENT_DIR = testContentDir;
+  mkdirSync(testContentDir, { recursive: true });
+  seedDoc('svc/reviews-tests.md');
+  getDb();
+});
+
+afterAll(() => {
+  closeDb();
+  try { unlinkSync(testDbPath); } catch {}
+  try { rmSync(testContentDir, { recursive: true, force: true }); } catch {}
+  delete process.env.FOUNDRY_DB_PATH;
+  delete process.env.CONTENT_DIR;
+});
+
+const ctx: AuthContext = {
+  user: { id: 'u1', github_login: 'alice', scopes: ['docs:read', 'docs:write'] },
+  client: { id: 'c1', name: 'Alice', client_type: 'interactive' },
+};
+
+describe('reviewsService', () => {
+  describe('create', () => {
+    it('stamps user_id from ctx.user.id', async () => {
+      const review = await reviewsService.create(ctx, { doc_path: 'svc/reviews-tests' });
+      expect(review.user_id).toBe('u1');
+      expect(review.status).toBe('draft');
+    });
+
+    it('falls back to anonymous when ctx empty', async () => {
+      const review = await reviewsService.create({}, { doc_path: 'svc/reviews-tests' });
+      expect(review.user_id).toBe('anonymous');
+    });
+
+    it('throws ValidationError when doc_path missing', async () => {
+      await expect(
+        reviewsService.create(ctx, { doc_path: '' }),
+      ).rejects.toBeInstanceOf(ValidationError);
+    });
+  });
+
+  describe('get / list / edit', () => {
+    it('get throws NotFoundError for unknown id', async () => {
+      await expect(
+        reviewsService.get(ctx, { id: 'nope' }),
+      ).rejects.toBeInstanceOf(NotFoundError);
+    });
+
+    it('list returns reviews for a doc', async () => {
+      await reviewsService.create(ctx, { doc_path: 'svc/reviews-tests' });
+      const rows = await reviewsService.list(ctx, { doc_path: 'svc/reviews-tests' });
+      expect(rows.length).toBeGreaterThan(0);
+    });
+
+    it('edit requires at least one mutable field', async () => {
+      await expect(
+        reviewsService.edit(ctx, { id: 'any' }),
+      ).rejects.toBeInstanceOf(ValidationError);
+    });
+  });
+
+  describe('submit', () => {
+    it('creates a review and attaches draft annotations to it', async () => {
+      // Seed some annotations
+      const a1 = await annotationsService.create(ctx, {
+        doc_path: 'svc/reviews-tests',
+        heading_path: 'S1',
+        content: 'first',
+      });
+      const a2 = await annotationsService.create(ctx, {
+        doc_path: 'svc/reviews-tests',
+        heading_path: 'S2',
+        content: 'second',
+      });
+
+      const result = await reviewsService.submit(ctx, {
+        doc_path: 'svc/reviews-tests',
+        annotation_ids: [a1.annotation.id, a2.annotation.id],
+      });
+
+      expect(result.status).toBe('review_submitted');
+      expect(result.review_id).toBeTruthy();
+      expect(result.comment_count).toBe(2);
+
+      // Verify annotations got review_id stamped and status=submitted
+      const updated = await annotationsService.get(ctx, { id: a1.annotation.id });
+      expect(updated.annotation.review_id).toBe(result.review_id);
+      expect(updated.annotation.status).toBe('submitted');
+
+      // Verify review ended up status=submitted
+      const review = await reviewsService.get(ctx, { id: result.review_id });
+      expect(review.review.status).toBe('submitted');
+      expect(review.review.submitted_at).toBeTruthy();
+    });
+  });
+});

--- a/packages/api/src/services/__tests__/search.test.ts
+++ b/packages/api/src/services/__tests__/search.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Service-level unit tests for searchService.
+ *
+ * Focus: the scope-based private-doc filter (the branch that differs
+ * between anonymous/authenticated callers). The Anvil index is stubbed
+ * so tests don't need a running model.
+ */
+
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import * as searchService from '../search.js';
+import { ValidationError } from '../errors.js';
+import * as accessModule from '../../access.js';
+import type { AuthContext } from '../context.js';
+
+function mockAnvil(results: Array<{ content: string; score: number; metadata: any }>): any {
+  return {
+    getStatus: vi.fn(async () => ({ total_chunks: results.length + 10 })),
+    search: vi.fn(async () => results),
+  };
+}
+
+function basicResult(path: string, heading: string, score: number) {
+  return {
+    content: `content for ${path}`,
+    score,
+    metadata: {
+      file_path: path,
+      heading_path: heading,
+      char_count: 100,
+    },
+  };
+}
+
+describe('searchService.search', () => {
+  beforeAll(() => {
+    // Stub getAccessLevel: treat 'private/*' as private, everything else public.
+    vi.spyOn(accessModule, 'getAccessLevel').mockImplementation((p: string) =>
+      p.startsWith('private/') ? 'private' : 'public',
+    );
+  });
+
+  afterAll(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('throws ValidationError on missing query', async () => {
+    const anvil = mockAnvil([]);
+    await expect(
+      searchService.search({}, anvil, { query: undefined as any }),
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it('throws ValidationError on empty query', async () => {
+    const anvil = mockAnvil([]);
+    await expect(
+      searchService.search({}, anvil, { query: '   ' }),
+    ).rejects.toBeInstanceOf(ValidationError);
+  });
+
+  it('returns warning when index empty', async () => {
+    const anvil = {
+      getStatus: vi.fn(async () => ({ total_chunks: 0 })),
+      search: vi.fn(async () => []),
+    } as any;
+    const result = await searchService.search({}, anvil, { query: 'foo' });
+    expect(result.totalResults).toBe(0);
+    expect(result.warning).toContain('Anvil index is empty');
+  });
+
+  it('anonymous callers see only public results', async () => {
+    const anvil = mockAnvil([
+      basicResult('public/doc1.md', 'H1', 0.9),
+      basicResult('private/secret.md', 'H2', 0.9),
+    ]);
+    const result = await searchService.search({}, anvil, { query: 'foo' });
+    expect(result.results.map(r => r.path)).toEqual(['public/doc1.md']);
+  });
+
+  it('callers with docs:read:private see private results', async () => {
+    const anvil = mockAnvil([
+      basicResult('public/doc1.md', 'H1', 0.9),
+      basicResult('private/secret.md', 'H2', 0.9),
+    ]);
+    const ctx: AuthContext = {
+      user: {
+        id: 'u',
+        github_login: 'a',
+        scopes: ['docs:read', 'docs:read:private'],
+      },
+    };
+    const result = await searchService.search(ctx, anvil, { query: 'foo' });
+    expect(result.results.map(r => r.path).sort()).toEqual([
+      'private/secret.md',
+      'public/doc1.md',
+    ]);
+  });
+
+  it('filters out results below MIN_RELEVANCE_SCORE (0.5)', async () => {
+    const anvil = mockAnvil([
+      basicResult('public/high.md', 'H1', 0.9),
+      basicResult('public/low.md', 'H2', 0.2),
+    ]);
+    const result = await searchService.search({}, anvil, { query: 'foo' });
+    expect(result.results.map(r => r.path)).toEqual(['public/high.md']);
+  });
+
+  it('returns "No results matched" warning when filtered result set is empty', async () => {
+    const anvil = mockAnvil([basicResult('public/low.md', 'H1', 0.1)]);
+    const result = await searchService.search({}, anvil, { query: 'foo' });
+    expect(result.totalResults).toBe(0);
+    expect(result.warning).toContain('No results matched');
+  });
+
+  it('auth with no read:private scope still sees public-only', async () => {
+    const anvil = mockAnvil([
+      basicResult('public/doc1.md', 'H1', 0.9),
+      basicResult('private/secret.md', 'H2', 0.9),
+    ]);
+    const ctx: AuthContext = {
+      user: { id: 'u', github_login: 'a', scopes: ['docs:read'] },
+    };
+    const result = await searchService.search(ctx, anvil, { query: 'foo' });
+    expect(result.results.map(r => r.path)).toEqual(['public/doc1.md']);
+  });
+});

--- a/packages/api/src/services/annotations.ts
+++ b/packages/api/src/services/annotations.ts
@@ -1,0 +1,361 @@
+/**
+ * Annotations service — transport-agnostic business logic for annotations.
+ *
+ * All functions take an AuthContext as the first argument. Identity is
+ * derived server-side from `ctx.user` / `ctx.client`: any user_id or
+ * author_type in user-supplied params is ignored (same behavior the
+ * HTTP handler exhibits today).
+ *
+ * Error handling: functions throw ValidationError / NotFoundError from
+ * services/errors.ts for business-logic failures. Transport layers
+ * catch and map to their protocol's response shape.
+ */
+
+import { existsSync } from 'fs';
+import { join } from 'path';
+import { createId } from '@paralleldrive/cuid2';
+import { getDb } from '../db.js';
+import { getDocsPath } from '../config.js';
+import { normalizeDocPath } from '../utils/normalize-doc-path.js';
+import {
+  Annotation,
+  AnnotationStatus,
+  AuthorType,
+} from '../types/annotations.js';
+import type { AuthContext } from './context.js';
+import { NotFoundError, ValidationError } from './errors.js';
+
+// ─── list ─────────────────────────────────────────────────────────────────────
+
+export interface ListAnnotationsParams {
+  doc_path: string;
+  section?: string;
+  status?: AnnotationStatus;
+  review_id?: string;
+}
+
+/**
+ * List annotations for a document, optionally filtered by section, status,
+ * or review_id.
+ */
+export async function list(
+  _ctx: AuthContext,
+  params: ListAnnotationsParams,
+): Promise<Annotation[]> {
+  const { doc_path, section, status, review_id } = params;
+
+  if (!doc_path) {
+    throw new ValidationError('doc_path query parameter is required');
+  }
+
+  const db = getDb();
+  const normalized = normalizeDocPath(doc_path);
+  let query = `SELECT * FROM annotations WHERE doc_path = ?`;
+  const queryParams: unknown[] = [normalized];
+
+  if (section) {
+    query += ' AND heading_path LIKE ?';
+    queryParams.push(`%${section}%`);
+  }
+
+  if (status) {
+    query += ' AND status = ?';
+    queryParams.push(status);
+  }
+
+  if (review_id) {
+    query += ' AND review_id = ?';
+    queryParams.push(review_id);
+  }
+
+  query += ' ORDER BY created_at DESC';
+
+  const stmt = db.prepare(query);
+  return stmt.all(...queryParams) as Annotation[];
+}
+
+// ─── get ──────────────────────────────────────────────────────────────────────
+
+export interface GetAnnotationResult {
+  annotation: Annotation;
+  replies: Annotation[];
+}
+
+export async function get(
+  _ctx: AuthContext,
+  params: { id: string },
+): Promise<GetAnnotationResult> {
+  const { id } = params;
+  const db = getDb();
+
+  const annotation = db
+    .prepare('SELECT * FROM annotations WHERE id = ?')
+    .get(id) as Annotation | undefined;
+
+  if (!annotation) {
+    throw new NotFoundError('Annotation not found');
+  }
+
+  const replies = db
+    .prepare('SELECT * FROM annotations WHERE parent_id = ? ORDER BY created_at ASC')
+    .all(id) as Annotation[];
+
+  return { annotation, replies };
+}
+
+// ─── create ───────────────────────────────────────────────────────────────────
+
+export interface CreateAnnotationParams {
+  doc_path: string;
+  heading_path: string;
+  content_hash?: string;
+  quoted_text?: string;
+  content: string;
+  parent_id?: string;
+  review_id?: string;
+  status?: AnnotationStatus;
+}
+
+/**
+ * Create an annotation. Identity (user_id, author_type) is derived from
+ * ctx — any user_id/author_type on `params` is silently ignored.
+ *
+ * Returns { annotation, duplicate } — when `duplicate` is true, the
+ * caller hit the 30-second dedupe window and we returned the existing
+ * row without creating a new one. The HTTP layer maps that to a 200
+ * instead of 201 (preserves pre-refactor behavior).
+ */
+export async function create(
+  ctx: AuthContext,
+  params: CreateAnnotationParams,
+): Promise<{ annotation: Annotation; duplicate: boolean }> {
+  const {
+    doc_path,
+    heading_path,
+    content_hash,
+    quoted_text,
+    content,
+    parent_id,
+    review_id,
+    status: bodyStatus,
+  } = params;
+
+  // Identity is server-authoritative. Interactive clients → 'human';
+  // everything else (autonomous or missing) → 'ai'. Dev-mode passthrough
+  // (no ctx.user) falls back to 'anonymous' to document the write.
+  const effectiveUserId = ctx.user?.id ?? 'anonymous';
+  const effectiveAuthorType: AuthorType =
+    ctx.client?.client_type === 'interactive' ? 'human' : 'ai';
+
+  if (!doc_path || !heading_path || !content) {
+    throw new ValidationError('doc_path, heading_path, and content are required');
+  }
+
+  const VALID_STATUSES: AnnotationStatus[] = [
+    'draft',
+    'submitted',
+    'replied',
+    'resolved',
+    'orphaned',
+  ];
+  if (bodyStatus !== undefined && !VALID_STATUSES.includes(bodyStatus)) {
+    throw new ValidationError(
+      `Invalid status "${bodyStatus}". Must be one of: ${VALID_STATUSES.join(', ')}`,
+    );
+  }
+
+  const normalizedPath = normalizeDocPath(doc_path);
+  const contentDir = getDocsPath();
+  const filePath = join(contentDir, `${normalizedPath}.md`);
+  if (!existsSync(filePath)) {
+    throw new NotFoundError(
+      `Document not found: "${normalizedPath}". Cannot create annotation on a non-existent document.`,
+    );
+  }
+
+  const db = getDb();
+  const id = createId();
+  const now = new Date().toISOString();
+
+  // BUG-6: If replying to a parent, inherit its review_id when not explicitly provided
+  let effectiveReviewId = review_id;
+  if (parent_id && !review_id) {
+    const parent = db
+      .prepare('SELECT review_id FROM annotations WHERE id = ?')
+      .get(parent_id) as { review_id: string | null } | undefined;
+    if (parent?.review_id) {
+      effectiveReviewId = parent.review_id;
+    }
+  }
+
+  // Dedup: same review_id + content + quoted_text within 30s → return the existing row.
+  if (review_id) {
+    const recentDuplicate = db
+      .prepare(
+        `SELECT id FROM annotations
+         WHERE review_id = ? AND content = ? AND quoted_text IS ?
+         AND created_at > datetime('now', '-30 seconds')`,
+      )
+      .get(review_id, content, quoted_text || null);
+
+    if (recentDuplicate) {
+      const existing = db
+        .prepare('SELECT * FROM annotations WHERE id = ?')
+        .get((recentDuplicate as { id: string }).id) as Annotation;
+      return { annotation: existing, duplicate: true };
+    }
+  }
+
+  // Replies + AI-authored annotations auto-submit; top-level human starts as draft.
+  const effectiveStatus: AnnotationStatus =
+    bodyStatus !== undefined
+      ? bodyStatus
+      : parent_id || effectiveAuthorType === 'ai'
+      ? 'submitted'
+      : 'draft';
+
+  const annotation: Annotation = {
+    id,
+    doc_path: normalizedPath,
+    heading_path,
+    content_hash: content_hash || '',
+    quoted_text: quoted_text || null,
+    content,
+    parent_id: parent_id || null,
+    review_id: effectiveReviewId || null,
+    user_id: effectiveUserId,
+    author_type: effectiveAuthorType,
+    status: effectiveStatus,
+    created_at: now,
+    updated_at: now,
+  };
+
+  db.prepare(
+    `INSERT INTO annotations (
+      id, doc_path, heading_path, content_hash, quoted_text, content,
+      parent_id, review_id, user_id, author_type, status, created_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    annotation.id,
+    annotation.doc_path,
+    annotation.heading_path,
+    annotation.content_hash,
+    annotation.quoted_text,
+    annotation.content,
+    annotation.parent_id,
+    annotation.review_id,
+    annotation.user_id,
+    annotation.author_type,
+    annotation.status,
+    annotation.created_at,
+    annotation.updated_at,
+  );
+
+  return { annotation, duplicate: false };
+}
+
+// ─── edit / patch ─────────────────────────────────────────────────────────────
+
+export interface EditAnnotationParams {
+  id: string;
+  status?: AnnotationStatus;
+  content?: string;
+  review_id?: string | null;
+}
+
+/**
+ * Generic update: any combination of status/content/review_id.
+ * `resolve` / `reopen` are convenience wrappers over this.
+ */
+export async function edit(
+  _ctx: AuthContext,
+  params: EditAnnotationParams,
+): Promise<Annotation> {
+  const { id, status, content, review_id } = params;
+
+  if (!status && !content && review_id === undefined) {
+    throw new ValidationError('status, content, or review_id must be provided');
+  }
+
+  const db = getDb();
+  const existingStmt = db.prepare('SELECT * FROM annotations WHERE id = ?');
+  const existing = existingStmt.get(id) as Annotation | undefined;
+
+  if (!existing) {
+    throw new NotFoundError('Annotation not found');
+  }
+
+  const now = new Date().toISOString();
+  const updates: string[] = [];
+  const queryParams: unknown[] = [];
+
+  if (status !== undefined) {
+    updates.push('status = ?');
+    queryParams.push(status);
+  }
+  if (content !== undefined) {
+    updates.push('content = ?');
+    queryParams.push(content);
+  }
+  if (review_id !== undefined) {
+    updates.push('review_id = ?');
+    queryParams.push(review_id);
+  }
+
+  updates.push('updated_at = ?');
+  queryParams.push(now);
+  queryParams.push(id);
+
+  db.prepare(`UPDATE annotations SET ${updates.join(', ')} WHERE id = ?`).run(...queryParams);
+
+  return existingStmt.get(id) as Annotation;
+}
+
+// ─── resolve / reopen convenience wrappers ────────────────────────────────────
+
+export async function resolve(
+  ctx: AuthContext,
+  params: { id: string },
+): Promise<Annotation> {
+  return edit(ctx, { id: params.id, status: 'resolved' });
+}
+
+export async function reopen(
+  ctx: AuthContext,
+  params: { id: string },
+): Promise<Annotation> {
+  return edit(ctx, { id: params.id, status: 'draft' });
+}
+
+// ─── delete ───────────────────────────────────────────────────────────────────
+
+export async function del(
+  _ctx: AuthContext,
+  params: { id: string },
+): Promise<void> {
+  const { id } = params;
+  const db = getDb();
+
+  const existing = db
+    .prepare('SELECT * FROM annotations WHERE id = ?')
+    .get(id) as Annotation | undefined;
+
+  if (!existing) {
+    throw new NotFoundError('Annotation not found');
+  }
+
+  // Cascade delete child replies first
+  db.prepare('DELETE FROM annotations WHERE parent_id = ?').run(id);
+  db.prepare('DELETE FROM annotations WHERE id = ?').run(id);
+
+  // Orphan-review cleanup — if deleting the last annotation on a review, nuke the review.
+  if (existing.review_id) {
+    const remaining = db
+      .prepare('SELECT COUNT(*) as count FROM annotations WHERE review_id = ?')
+      .get(existing.review_id) as { count: number };
+
+    if (remaining.count === 0) {
+      db.prepare('DELETE FROM reviews WHERE id = ?').run(existing.review_id);
+    }
+  }
+}

--- a/packages/api/src/services/context.ts
+++ b/packages/api/src/services/context.ts
@@ -1,0 +1,34 @@
+/**
+ * Shared context type for transport-agnostic service functions.
+ *
+ * Every service function takes an AuthContext as its first argument. The
+ * caller (Express route handler, MCP tool handler, test) is responsible
+ * for populating user/client — services never touch Express types.
+ *
+ * Both fields are optional because /api/search serves anonymous traffic
+ * (softAuth) and a few HTTP flows fall through without auth populated
+ * (dev mode). Services that require identity should check for undefined
+ * and throw an appropriate domain error (or just fall back to the
+ * documented 'anonymous' user_id, as existing HTTP handlers already do).
+ *
+ * The shape matches the Express Request augmentation in
+ * `types/express.d.ts` so `{ user: req.user, client: req.client }` is a
+ * valid AuthContext.
+ */
+
+export interface ServiceAuthUser {
+  id: string;
+  github_login: string;
+  scopes: string[];
+}
+
+export interface ServiceAuthClient {
+  id: string;
+  name: string;
+  client_type: 'interactive' | 'autonomous';
+}
+
+export interface AuthContext {
+  user?: ServiceAuthUser;
+  client?: ServiceAuthClient;
+}

--- a/packages/api/src/services/docs.ts
+++ b/packages/api/src/services/docs.ts
@@ -1,0 +1,523 @@
+/**
+ * Docs service — write operations on the markdown corpus.
+ *
+ * Each function:
+ *   - Accepts AuthContext + a typed params shape.
+ *   - Performs the file / docs_meta / annotations mutation.
+ *   - Invalidates caches + triggers reindex (via invalidateContent()).
+ *
+ * Throws NotFoundError / ValidationError / ConflictError from
+ * services/errors.ts — the route layer maps to HTTP. The MCP tool layer
+ * (S10b) will surface the error message directly.
+ *
+ * GitHub sync lives here too (`syncToGithub`) because it's document
+ * corpus–adjacent: a cross-cutting write that touches the filesystem +
+ * pushes the result.
+ */
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync, unlinkSync } from 'fs';
+import { join, dirname } from 'path';
+import { getDocsPath } from '../config.js';
+import { getDb } from '../db.js';
+import { getAccessLevel } from '../access.js';
+import { normalizeDocPath } from '../utils/normalize-doc-path.js';
+import { contentHash } from '../utils/hash.js';
+import {
+  parseSections,
+  findSection,
+  findDuplicateHeadings,
+} from '../utils/section-parser.js';
+import { syncToGithub as syncGithubLib } from '../sync.js';
+import type { AuthContext } from './context.js';
+import {
+  NotFoundError,
+  ValidationError,
+  ConflictError,
+} from './errors.js';
+
+// Valid templates for document creation
+const VALID_TEMPLATES = ['epic', 'subsystem', 'project', 'workflow', 'blank'] as const;
+type TemplateName = (typeof VALID_TEMPLATES)[number];
+
+// Map template names to file paths (relative to content dir)
+const TEMPLATE_FILES: Record<Exclude<TemplateName, 'blank'>, string> = {
+  epic: 'methodology/templates/epic-design-template.md',
+  subsystem: 'methodology/templates/subsystem-design-template.md',
+  project: 'methodology/templates/project-design-template.md',
+  workflow: 'methodology/templates/workflow-template.md',
+};
+
+function titleFromPath(docPath: string): string {
+  const slug = docPath.split('/').pop() || docPath;
+  return slug
+    .replace(/[-_]/g, ' ')
+    .replace(/\b\w/g, c => c.toUpperCase());
+}
+
+function readDocLines(filePath: string): string[] | null {
+  if (!existsSync(filePath)) return null;
+  return readFileSync(filePath, 'utf-8').split('\n');
+}
+
+function writeDocAndUpdateMeta(filePath: string, lines: string[], docPath: string): void {
+  const content = lines.join('\n');
+  writeFileSync(filePath, content, 'utf-8');
+
+  const hash = contentHash(content);
+  const now = new Date().toISOString();
+  const db = getDb();
+
+  db.prepare(
+    `UPDATE docs_meta SET content_hash = ?, modified_at = ? WHERE path = ?`,
+  ).run(hash, now, docPath);
+}
+
+/**
+ * Lazy-imported cache invalidation hook. The caller (index.ts)
+ * re-exports `invalidateContent` from its module root; importing it
+ * statically here would be fine in prod but creates a circular import
+ * in tests that mock '../index.js'. We wrap it in a getter so tests can
+ * mock the index module and still import this service file.
+ */
+async function invalidate(changedFiles?: string[]): Promise<void> {
+  const mod = await import('../index.js');
+  return mod.invalidateContent(changedFiles);
+}
+
+// ─── createDoc ────────────────────────────────────────────────────────────────
+
+export interface CreateDocParams {
+  path: string;
+  template: string;
+  title?: string;
+  content?: string;
+}
+
+export interface CreateDocResult {
+  path: string;
+  title: string;
+  template: string;
+  created: true;
+}
+
+export async function createDoc(
+  _ctx: AuthContext,
+  params: CreateDocParams,
+): Promise<CreateDocResult> {
+  const { path: rawPath, template, title: userTitle, content: userContent } = params;
+
+  if (!rawPath || typeof rawPath !== 'string') {
+    throw new ValidationError('path is required and must be a string');
+  }
+  if (!template || typeof template !== 'string') {
+    throw new ValidationError('template is required and must be a string');
+  }
+  if (!VALID_TEMPLATES.includes(template as TemplateName)) {
+    throw new ValidationError(
+      `Invalid template "${template}". Must be one of: ${VALID_TEMPLATES.join(', ')}`,
+    );
+  }
+
+  const docPath = normalizeDocPath(rawPath);
+  const contentDir = getDocsPath();
+  const filePath = join(contentDir, `${docPath}.md`);
+
+  if (existsSync(filePath)) {
+    throw new ConflictError(`Document already exists at "${docPath}"`);
+  }
+
+  const title = userTitle || titleFromPath(docPath);
+
+  let content: string;
+  if (userContent && typeof userContent === 'string') {
+    content = userContent;
+  } else if (template === 'blank') {
+    content = `# ${title}\n`;
+  } else {
+    const templateKey = template as Exclude<TemplateName, 'blank'>;
+    const templatePath = join(contentDir, TEMPLATE_FILES[templateKey]);
+    if (!existsSync(templatePath)) {
+      throw new ValidationError(
+        `Template file not found: ${TEMPLATE_FILES[templateKey]}`,
+      );
+    }
+    content = readFileSync(templatePath, 'utf-8');
+  }
+
+  mkdirSync(dirname(filePath), { recursive: true });
+  writeFileSync(filePath, content, 'utf-8');
+
+  const hash = contentHash(content);
+  const now = new Date().toISOString();
+  const access = getAccessLevel(docPath);
+  const db = getDb();
+
+  db.prepare(
+    `INSERT INTO docs_meta (path, title, access, content_hash, modified_at, modified_by, created_at)
+     VALUES (?, ?, ?, ?, ?, 'system', ?)`,
+  ).run(docPath, title, access, hash, now, now);
+
+  await invalidate();
+
+  return { path: docPath, title, template, created: true };
+}
+
+// ─── updateSection ────────────────────────────────────────────────────────────
+
+export interface UpdateSectionParams {
+  path: string;
+  headingPath: string;
+  content: string;
+}
+
+export async function updateSection(
+  _ctx: AuthContext,
+  params: UpdateSectionParams,
+): Promise<{ path: string; heading: string; updated: true }> {
+  const docPath = normalizeDocPath(params.path);
+  const headingPath = params.headingPath;
+  const { content } = params;
+
+  if (content === undefined || typeof content !== 'string') {
+    throw new ValidationError('content is required and must be a string');
+  }
+
+  const contentDir = getDocsPath();
+  const filePath = join(contentDir, `${docPath}.md`);
+  const lines = readDocLines(filePath);
+
+  if (!lines) {
+    throw new NotFoundError(`Document not found: "${docPath}"`);
+  }
+
+  const dupes = findDuplicateHeadings(lines);
+  if (dupes.has(headingPath)) {
+    throw new ValidationError(
+      `Ambiguous heading path "${headingPath}" appears ${dupes.get(headingPath)} times in the document. Cannot update.`,
+    );
+  }
+
+  let section;
+  try {
+    section = findSection(lines, headingPath);
+  } catch (err: any) {
+    if (err?.message?.includes('Ambiguous heading path')) {
+      throw new ValidationError(err.message);
+    }
+    throw err;
+  }
+
+  if (!section) {
+    throw new NotFoundError(`Section not found: "${headingPath}"`, {
+      available_headings: parseSections(lines).map(s => s.headingPath),
+    });
+  }
+
+  const newBodyLines = content.length > 0 ? content.split('\n') : [];
+  const updatedLines = [
+    ...lines.slice(0, section.bodyStart),
+    ...newBodyLines,
+    ...lines.slice(section.subtreeEnd),
+  ];
+
+  writeDocAndUpdateMeta(filePath, updatedLines, docPath);
+  await invalidate([`${docPath}.md`]);
+
+  return { path: docPath, heading: headingPath, updated: true };
+}
+
+// ─── insertSection ────────────────────────────────────────────────────────────
+
+export interface InsertSectionParams {
+  path: string;
+  after_heading: string;
+  heading: string;
+  level: number;
+  content: string;
+}
+
+export async function insertSection(
+  _ctx: AuthContext,
+  params: InsertSectionParams,
+): Promise<{ path: string; heading: string; inserted: true }> {
+  const docPath = normalizeDocPath(params.path);
+  const { after_heading, heading, level, content } = params;
+
+  if (!after_heading || typeof after_heading !== 'string') {
+    throw new ValidationError('after_heading is required and must be a string');
+  }
+  if (!heading || typeof heading !== 'string') {
+    throw new ValidationError('heading is required and must be a string');
+  }
+  if (!level || typeof level !== 'number' || level < 1 || level > 6) {
+    throw new ValidationError('level is required and must be a number between 1 and 6');
+  }
+  if (content === undefined || typeof content !== 'string') {
+    throw new ValidationError('content is required and must be a string');
+  }
+
+  const contentDir = getDocsPath();
+  const filePath = join(contentDir, `${docPath}.md`);
+  const lines = readDocLines(filePath);
+
+  if (!lines) {
+    throw new NotFoundError(`Document not found: "${docPath}"`);
+  }
+
+  const dupes = findDuplicateHeadings(lines);
+  if (dupes.has(after_heading)) {
+    throw new ValidationError(
+      `Ambiguous heading path "${after_heading}" appears ${dupes.get(after_heading)} times. Cannot determine insertion point.`,
+    );
+  }
+
+  let afterSection;
+  try {
+    afterSection = findSection(lines, after_heading);
+  } catch (err: any) {
+    if (err?.message?.includes('Ambiguous heading path')) {
+      throw new ValidationError(err.message);
+    }
+    throw err;
+  }
+
+  if (!afterSection) {
+    throw new NotFoundError(`Section not found: "${after_heading}"`, {
+      available_headings: parseSections(lines).map(s => s.headingPath),
+    });
+  }
+
+  const insertAt = afterSection.subtreeEnd;
+  const prefix = '#'.repeat(level);
+  const newHeadingLine = `${prefix} ${heading}`;
+  const newBodyLines = content.length > 0 ? content.split('\n') : [];
+  const insertLines = ['', newHeadingLine, ...newBodyLines];
+
+  const updatedLines = [
+    ...lines.slice(0, insertAt),
+    ...insertLines,
+    ...lines.slice(insertAt),
+  ];
+
+  writeDocAndUpdateMeta(filePath, updatedLines, docPath);
+  await invalidate([`${docPath}.md`]);
+
+  return { path: docPath, heading, inserted: true };
+}
+
+// ─── moveSection ──────────────────────────────────────────────────────────────
+
+export interface MoveSectionParams {
+  path: string;
+  heading: string;
+  after_heading: string;
+}
+
+export async function moveSection(
+  _ctx: AuthContext,
+  params: MoveSectionParams,
+): Promise<{ path: string; heading: string; after_heading: string; moved: true }> {
+  const docPath = normalizeDocPath(params.path);
+  const { heading, after_heading } = params;
+
+  if (!heading || typeof heading !== 'string') {
+    throw new ValidationError('heading is required and must be a string');
+  }
+  if (!after_heading || typeof after_heading !== 'string') {
+    throw new ValidationError('after_heading is required and must be a string');
+  }
+
+  const contentDir = getDocsPath();
+  const filePath = join(contentDir, `${docPath}.md`);
+  const lines = readDocLines(filePath);
+
+  if (!lines) {
+    throw new NotFoundError(`Document not found: "${docPath}"`);
+  }
+
+  const dupes = findDuplicateHeadings(lines);
+  if (dupes.has(heading)) {
+    throw new ValidationError(
+      `Ambiguous heading path "${heading}" appears ${dupes.get(heading)} times. Cannot determine which section to move.`,
+    );
+  }
+  if (dupes.has(after_heading)) {
+    throw new ValidationError(
+      `Ambiguous heading path "${after_heading}" appears ${dupes.get(after_heading)} times. Cannot determine target position.`,
+    );
+  }
+
+  const sourceSection = findSection(lines, heading);
+  if (!sourceSection) {
+    throw new NotFoundError(`Source section not found: "${heading}"`, {
+      available_headings: parseSections(lines).map(s => s.headingPath),
+    });
+  }
+
+  const targetSection = findSection(lines, after_heading);
+  if (!targetSection) {
+    throw new NotFoundError(`Target section not found: "${after_heading}"`, {
+      available_headings: parseSections(lines).map(s => s.headingPath),
+    });
+  }
+
+  if (sourceSection.headingLine === targetSection.headingLine) {
+    throw new ValidationError('Cannot move a section after itself');
+  }
+
+  const sourceLines = lines.slice(sourceSection.headingLine, sourceSection.subtreeEnd);
+
+  const withoutSource = [
+    ...lines.slice(0, sourceSection.headingLine),
+    ...lines.slice(sourceSection.subtreeEnd),
+  ];
+
+  const targetInModified = findSection(withoutSource, after_heading);
+  if (!targetInModified) {
+    throw new ValidationError(
+      `Target section "${after_heading}" is a descendant of source section "${heading}". Cannot move a section after its own descendant.`,
+    );
+  }
+
+  const insertAt = targetInModified.subtreeEnd;
+  const updatedLines = [
+    ...withoutSource.slice(0, insertAt),
+    ...sourceLines,
+    ...withoutSource.slice(insertAt),
+  ];
+
+  writeDocAndUpdateMeta(filePath, updatedLines, docPath);
+  await invalidate([`${docPath}.md`]);
+
+  return { path: docPath, heading, after_heading, moved: true };
+}
+
+// ─── deleteSection ────────────────────────────────────────────────────────────
+
+export interface DeleteSectionParams {
+  path: string;
+  headingPath: string;
+}
+
+export async function deleteSection(
+  _ctx: AuthContext,
+  params: DeleteSectionParams,
+): Promise<{ path: string; heading: string; deleted: true }> {
+  const docPath = normalizeDocPath(params.path);
+  const headingPath = params.headingPath;
+
+  const contentDir = getDocsPath();
+  const filePath = join(contentDir, `${docPath}.md`);
+  const lines = readDocLines(filePath);
+
+  if (!lines) {
+    throw new NotFoundError(`Document not found: "${docPath}"`);
+  }
+
+  const dupes = findDuplicateHeadings(lines);
+  if (dupes.has(headingPath)) {
+    throw new ValidationError(
+      `Ambiguous heading path "${headingPath}" appears ${dupes.get(headingPath)} times. Cannot determine which section to delete.`,
+    );
+  }
+
+  let section;
+  try {
+    section = findSection(lines, headingPath);
+  } catch (err: any) {
+    if (err?.message?.includes('Ambiguous heading path')) {
+      throw new ValidationError(err.message);
+    }
+    throw err;
+  }
+
+  if (!section) {
+    throw new NotFoundError(`Section not found: "${headingPath}"`, {
+      available_headings: parseSections(lines).map(s => s.headingPath),
+    });
+  }
+
+  if (section.level === 1) {
+    throw new ValidationError(
+      'Cannot delete the H1 heading of a document. Use delete_doc to remove the entire document.',
+    );
+  }
+
+  const updatedLines = [
+    ...lines.slice(0, section.headingLine),
+    ...lines.slice(section.subtreeEnd),
+  ];
+
+  writeDocAndUpdateMeta(filePath, updatedLines, docPath);
+  await invalidate([`${docPath}.md`]);
+
+  return { path: docPath, heading: headingPath, deleted: true };
+}
+
+// ─── deleteDoc ────────────────────────────────────────────────────────────────
+
+export interface DeleteDocResult {
+  path: string;
+  deleted: true;
+  annotations_deleted: number;
+}
+
+export async function deleteDoc(
+  _ctx: AuthContext,
+  params: { path: string },
+): Promise<DeleteDocResult> {
+  const docPath = normalizeDocPath(params.path);
+  const contentDir = getDocsPath();
+  const filePath = join(contentDir, `${docPath}.md`);
+
+  const db = getDb();
+  const metaRow = db.prepare('SELECT path FROM docs_meta WHERE path = ?').get(docPath);
+
+  if (!existsSync(filePath) || !metaRow) {
+    throw new NotFoundError(`Document not found: "${docPath}"`);
+  }
+
+  const deleteAnnotationsStmt = db.prepare('DELETE FROM annotations WHERE doc_path = ?');
+  const annotationsResult = deleteAnnotationsStmt.run(docPath);
+  const annotationsDeleted = annotationsResult.changes;
+
+  db.prepare('DELETE FROM docs_meta WHERE path = ?').run(docPath);
+
+  try {
+    unlinkSync(filePath);
+  } catch (err) {
+    console.error('[docs.deleteDoc] Failed to unlink file:', err);
+    // File may be gone already — DB rows removed, continue.
+  }
+
+  await invalidate([`${docPath}.md`]);
+
+  return { path: docPath, deleted: true, annotations_deleted: annotationsDeleted };
+}
+
+// ─── syncToGithub ─────────────────────────────────────────────────────────────
+
+export interface SyncToGithubParams {
+  remote?: string;
+  branch?: string;
+}
+
+export async function syncToGithub(
+  _ctx: AuthContext,
+  params: SyncToGithubParams,
+): Promise<{ filesSync: number; commitHash: string; duration_ms: number }> {
+  const remoteUrl = params.remote || process.env.SYNC_REMOTE_URL;
+  if (!remoteUrl || typeof remoteUrl !== 'string') {
+    throw new ValidationError(
+      'remote is required — provide in body or set SYNC_REMOTE_URL env var',
+    );
+  }
+
+  const contentDir = getDocsPath();
+  return await syncGithubLib({
+    contentDir,
+    remoteUrl,
+    branch: params.branch || 'main',
+    deployKeyPath: process.env.DEPLOY_KEY_PATH || undefined,
+  });
+}

--- a/packages/api/src/services/errors.ts
+++ b/packages/api/src/services/errors.ts
@@ -1,0 +1,58 @@
+/**
+ * Domain errors thrown by the service layer.
+ *
+ * Services throw these for business-logic failures; transport layers
+ * (routes, MCP tool handlers) catch and map them to the appropriate
+ * protocol response. Each class carries a `status` code the route-level
+ * error mapping uses for HTTP status; MCP handlers surface the message
+ * directly.
+ *
+ * We keep these lightweight (no stack-trace hygiene, no i18n) because
+ * the existing HTTP contract just returns `{ error: string }` bodies.
+ */
+
+export class ServiceError extends Error {
+  status: number;
+  /**
+   * Optional extra payload fields that get merged into the HTTP error
+   * response (e.g. `available_headings` on a 404 from findSection).
+   */
+  extra?: Record<string, unknown>;
+
+  constructor(message: string, status: number, extra?: Record<string, unknown>) {
+    super(message);
+    this.name = 'ServiceError';
+    this.status = status;
+    this.extra = extra;
+  }
+}
+
+export class NotFoundError extends ServiceError {
+  constructor(message: string, extra?: Record<string, unknown>) {
+    super(message, 404, extra);
+    this.name = 'NotFoundError';
+  }
+}
+
+export class ValidationError extends ServiceError {
+  constructor(message: string, extra?: Record<string, unknown>) {
+    super(message, 400, extra);
+    this.name = 'ValidationError';
+  }
+}
+
+export class ConflictError extends ServiceError {
+  constructor(message: string, extra?: Record<string, unknown>) {
+    super(message, 409, extra);
+    this.name = 'ConflictError';
+  }
+}
+
+export class ServiceUnavailableError extends ServiceError {
+  retryAfter?: number;
+  constructor(message: string, retryAfter?: number) {
+    super(message, 503);
+    this.name = 'ServiceUnavailableError';
+    this.retryAfter = retryAfter;
+  }
+}

--- a/packages/api/src/services/mgmt.ts
+++ b/packages/api/src/services/mgmt.ts
@@ -1,0 +1,132 @@
+/**
+ * Management service — reindex, status/health, import-repo.
+ *
+ * These are admin / operational actions that live outside the doc CRUD
+ * pipeline proper. Grouped here rather than each getting its own module
+ * because they're all short.
+ */
+
+import { getDocsPath } from '../config.js';
+import { importFromRepo } from '../import.js';
+import type { AnvilInstance } from '../anvil-loader.js';
+import type { AnvilHolder } from '../anvil-holder.js';
+import type { AuthContext } from './context.js';
+import { ValidationError, ServiceUnavailableError } from './errors.js';
+
+// ─── reindex ──────────────────────────────────────────────────────────────────
+
+export interface ReindexResult {
+  status: 'complete';
+  [key: string]: unknown;
+}
+
+/**
+ * Trigger a full Anvil reindex. Caller passes in the already-resolved
+ * AnvilInstance; the route layer handles the 503-on-not-ready path.
+ */
+export async function reindex(
+  _ctx: AuthContext,
+  anvil: AnvilInstance,
+): Promise<ReindexResult> {
+  const result = await anvil.index();
+  return { status: 'complete', ...result };
+}
+
+// ─── getStatus ────────────────────────────────────────────────────────────────
+
+export interface StatusResult {
+  status: 'ok';
+  version: string;
+  anvil: {
+    status: string;
+    totalPages?: number;
+    totalChunks?: number;
+    lastIndexed?: string | null;
+    error?: string;
+  };
+}
+
+/**
+ * Health / status probe. Returns the full shape the HTTP handler needs,
+ * including the Anvil sub-status. Accepts the AnvilHolder directly since
+ * the payload reflects whether Anvil is loading / errored / ready.
+ */
+export async function getStatus(
+  _ctx: AuthContext,
+  holder: AnvilHolder,
+): Promise<StatusResult> {
+  const anvil = holder.get();
+
+  if (anvil) {
+    try {
+      const status = await anvil.getStatus();
+      return {
+        status: 'ok',
+        version: '0.2.0',
+        anvil: {
+          status: 'ready',
+          totalPages: status.total_pages,
+          totalChunks: status.total_chunks,
+          lastIndexed: status.last_indexed,
+        },
+      };
+    } catch (error) {
+      console.warn('Anvil status error:', error);
+      return {
+        status: 'ok',
+        version: '0.2.0',
+        anvil: {
+          status: 'ready',
+          totalPages: 0,
+          totalChunks: 0,
+          lastIndexed: null,
+        },
+      };
+    }
+  }
+
+  return {
+    status: 'ok',
+    version: '0.2.0',
+    anvil: {
+      status: holder.status === 'error' ? 'error' : holder.status,
+      ...(holder.error ? { error: holder.error } : {}),
+    },
+  };
+}
+
+// ─── importRepo ───────────────────────────────────────────────────────────────
+
+export interface ImportRepoParams {
+  repo: string;
+  branch?: string;
+  prefix?: string;
+}
+
+export async function importRepo(
+  _ctx: AuthContext,
+  params: ImportRepoParams,
+): Promise<{ filesImported: number; docsMetaUpdated: number; duration_ms: number }> {
+  const { repo, branch, prefix } = params;
+
+  if (!repo || typeof repo !== 'string') {
+    throw new ValidationError('repo is required and must be a string');
+  }
+
+  const contentDir = getDocsPath();
+  const result = await importFromRepo({
+    repoUrl: repo,
+    branch: branch || 'main',
+    prefix: prefix || 'docs/',
+    contentDir,
+  });
+
+  // Trigger full Anvil reindex + cache invalidation after import.
+  const mod = await import('../index.js');
+  await mod.invalidateContent();
+
+  return result;
+}
+
+// Re-export helper so route layer can build 503 payloads consistently.
+export { ServiceUnavailableError };

--- a/packages/api/src/services/pages.ts
+++ b/packages/api/src/services/pages.ts
@@ -1,0 +1,208 @@
+/**
+ * Pages / doc-read service — listing pages, getting a page (with
+ * sections) and fetching an individual section by heading path.
+ *
+ * Private-doc gating:
+ *  - `listPages` takes `includePrivate: boolean` as a plain param. The
+ *    route layer decides whether the caller is allowed to set it (auth +
+ *    docs:read:private scope check); the service just filters.
+ *  - `getPage` needs a `canReadPrivate` hint so it can enforce the
+ *    private-doc gate for /docs/:path. The route layer passes
+ *    `ctx.user?.scopes?.includes('docs:read:private') ?? false`; it
+ *    intentionally does NOT use legacy-token bypass because the route
+ *    today wraps requireAuth inline.
+ */
+
+import { readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+import { getDocsPath } from '../config.js';
+import { generateNavPages } from '../utils/nav-generator.js';
+import { getAccessLevel } from '../access.js';
+import { normalizeDocPath } from '../utils/normalize-doc-path.js';
+import { parseSections, findSection } from '../utils/section-parser.js';
+import type { AnvilInstance } from '../anvil-loader.js';
+import type { AuthContext } from './context.js';
+import { NotFoundError, ValidationError } from './errors.js';
+
+// ─── listPages ────────────────────────────────────────────────────────────────
+
+export interface ListPagesParams {
+  includePrivate: boolean;
+}
+
+export interface NavPage {
+  title: string;
+  path: string;
+  access: string;
+}
+
+export async function listPages(
+  _ctx: AuthContext,
+  params: ListPagesParams,
+): Promise<NavPage[]> {
+  const docsPath = getDocsPath();
+  const allPages = generateNavPages(docsPath);
+
+  return params.includePrivate
+    ? allPages
+    : allPages.filter(p => p.access === 'public');
+}
+
+// ─── getPage ──────────────────────────────────────────────────────────────────
+
+export interface GetPageParams {
+  path: string;
+  /**
+   * Whether the caller is allowed to read private docs. Derived by the
+   * route layer from ctx.user.scopes / legacy token.
+   */
+  canReadPrivate: boolean;
+}
+
+export interface DocumentSection {
+  heading: string;
+  level: number;
+  charCount: number;
+  content: string;
+}
+
+export interface DocumentDetail {
+  path: string;
+  title: string;
+  lastModified: string;
+  sections: DocumentSection[];
+}
+
+/**
+ * Anvil-backed page fetch. Caller passes in the resolved AnvilInstance.
+ * Returns 401-worthy ValidationError when the target is private and the
+ * caller lacks read:private (route maps to 401 to preserve existing contract).
+ */
+export async function getPage(
+  _ctx: AuthContext,
+  anvil: AnvilInstance,
+  params: GetPageParams,
+): Promise<DocumentDetail> {
+  const rawPath = params.path;
+  const path = rawPath.endsWith('.md') ? rawPath : `${rawPath}.md`;
+
+  const level = getAccessLevel(path);
+  if (level === 'private' && !params.canReadPrivate) {
+    throw new ValidationError('Authentication required for private content');
+  }
+
+  const page = await anvil.getPage(path);
+  if (!page) {
+    throw new NotFoundError('Document not found');
+  }
+
+  // Aggregate chunks into per-heading sections
+  const sectionMap = new Map<string, DocumentSection>();
+  const sortedChunks = [...page.chunks].sort((a, b) => a.ordinal - b.ordinal);
+
+  for (const chunk of sortedChunks) {
+    if (!chunk.heading_path) continue;
+    const existing = sectionMap.get(chunk.heading_path);
+    if (existing) {
+      existing.content += '\n' + chunk.content;
+      existing.charCount += chunk.char_count;
+    } else {
+      sectionMap.set(chunk.heading_path, {
+        heading: chunk.heading_path,
+        level: chunk.heading_level,
+        charCount: chunk.char_count,
+        content: chunk.content,
+      });
+    }
+  }
+
+  return {
+    path: page.file_path,
+    title: page.title,
+    lastModified: page.last_modified,
+    sections: Array.from(sectionMap.values()),
+  };
+}
+
+// ─── getSection ───────────────────────────────────────────────────────────────
+
+export interface GetSectionParams {
+  path: string;
+  headingPath: string;
+}
+
+export interface SectionDetail {
+  path: string;
+  heading: string;
+  headingPath: string;
+  level: number;
+  content: string;
+  charCount: number;
+}
+
+export async function getSection(
+  _ctx: AuthContext,
+  params: GetSectionParams,
+): Promise<SectionDetail> {
+  const docPath = normalizeDocPath(params.path);
+  const headingPath = params.headingPath;
+
+  const contentDir = getDocsPath();
+  const filePath = join(contentDir, `${docPath}.md`);
+
+  if (!existsSync(filePath)) {
+    throw new NotFoundError(`Document not found: "${docPath}"`);
+  }
+
+  const lines = readFileSync(filePath, 'utf-8').split('\n');
+
+  let section;
+  try {
+    section = findSection(lines, headingPath);
+  } catch (err: any) {
+    // findSection throws on ambiguous paths. Surface as ValidationError.
+    if (err?.message?.includes('Ambiguous')) {
+      throw new ValidationError(err.message);
+    }
+    throw err;
+  }
+
+  if (!section) {
+    throw new NotFoundError(`Section not found: "${headingPath}"`, {
+      available_headings: parseSections(lines).map(s => s.headingPath),
+    });
+  }
+
+  const content = lines.slice(section.headingLine, section.subtreeEnd).join('\n');
+
+  return {
+    path: docPath,
+    heading: section.headingText,
+    headingPath: section.headingPath,
+    level: section.level,
+    content,
+    charCount: content.length,
+  };
+}
+
+// ─── listDocs (existing /docs endpoint) ───────────────────────────────────────
+
+export interface DocumentListItem {
+  path: string;
+  title: string;
+  lastModified: string;
+  chunkCount: number;
+}
+
+export async function listDocs(
+  _ctx: AuthContext,
+  anvil: AnvilInstance,
+): Promise<DocumentListItem[]> {
+  const { pages } = await anvil.listPages();
+  return pages.map(page => ({
+    path: page.file_path,
+    title: page.title,
+    lastModified: page.last_modified,
+    chunkCount: page.chunk_count,
+  }));
+}

--- a/packages/api/src/services/reviews.ts
+++ b/packages/api/src/services/reviews.ts
@@ -1,0 +1,265 @@
+/**
+ * Reviews service — transport-agnostic business logic for reviews.
+ *
+ * Identity propagation: user_id on `create` comes from ctx.user; any
+ * user_id in user-supplied params is ignored. Dev-mode passthrough
+ * (no ctx.user) falls back to 'anonymous'.
+ *
+ * `submit` composes list-annotations + patch-annotation + patch-review
+ * into the aggregate review-submit flow that the MCP `submit_review`
+ * tool needs today (currently implemented as three HTTP calls in
+ * http-client.ts — S10b will replace that with this service).
+ */
+
+import { createId } from '@paralleldrive/cuid2';
+import { getDb } from '../db.js';
+import { normalizeDocPath } from '../utils/normalize-doc-path.js';
+import type {
+  Annotation,
+  Review,
+  ReviewStatus,
+} from '../types/annotations.js';
+import type { AuthContext } from './context.js';
+import { NotFoundError, ValidationError } from './errors.js';
+import * as annotationsService from './annotations.js';
+
+// ─── list ─────────────────────────────────────────────────────────────────────
+
+export interface ListReviewsParams {
+  doc_path: string;
+  status?: string;
+}
+
+export async function list(
+  _ctx: AuthContext,
+  params: ListReviewsParams,
+): Promise<Review[]> {
+  const { doc_path, status } = params;
+
+  if (!doc_path) {
+    throw new ValidationError('doc_path query parameter is required');
+  }
+
+  const db = getDb();
+  const normalized = normalizeDocPath(doc_path);
+  let query = `SELECT * FROM reviews WHERE doc_path = ?`;
+  const queryParams: unknown[] = [normalized];
+
+  if (status) {
+    query += ' AND status = ?';
+    queryParams.push(status);
+  }
+
+  query += ' ORDER BY created_at DESC';
+
+  return db.prepare(query).all(...queryParams) as Review[];
+}
+
+// ─── get ──────────────────────────────────────────────────────────────────────
+
+export interface GetReviewResult {
+  review: Review;
+  annotations: Annotation[];
+}
+
+export async function get(
+  _ctx: AuthContext,
+  params: { id: string },
+): Promise<GetReviewResult> {
+  const { id } = params;
+  const db = getDb();
+
+  const review = db
+    .prepare('SELECT * FROM reviews WHERE id = ?')
+    .get(id) as Review | undefined;
+
+  if (!review) {
+    throw new NotFoundError('Review not found');
+  }
+
+  const annotations = db
+    .prepare('SELECT * FROM annotations WHERE review_id = ? ORDER BY created_at ASC')
+    .all(id) as Annotation[];
+
+  return { review, annotations };
+}
+
+// ─── create ───────────────────────────────────────────────────────────────────
+
+export async function create(
+  ctx: AuthContext,
+  params: { doc_path: string },
+): Promise<Review> {
+  const { doc_path } = params;
+
+  if (!doc_path) {
+    throw new ValidationError('doc_path is required');
+  }
+
+  // Identity is server-authoritative.
+  const effectiveUserId = ctx.user?.id ?? 'anonymous';
+
+  const db = getDb();
+  const id = createId();
+  const now = new Date().toISOString();
+  const normalizedDocPath = normalizeDocPath(doc_path);
+
+  const review: Review = {
+    id,
+    doc_path: normalizedDocPath,
+    user_id: effectiveUserId,
+    status: 'draft',
+    submitted_at: null,
+    completed_at: null,
+    created_at: now,
+    updated_at: now,
+  };
+
+  db.prepare(
+    `INSERT INTO reviews (
+      id, doc_path, user_id, status, submitted_at, completed_at, created_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    review.id,
+    review.doc_path,
+    review.user_id,
+    review.status,
+    review.submitted_at,
+    review.completed_at,
+    review.created_at,
+    review.updated_at,
+  );
+
+  return review;
+}
+
+// ─── edit / patch ─────────────────────────────────────────────────────────────
+
+export interface EditReviewParams {
+  id: string;
+  status?: ReviewStatus;
+  submitted_at?: string | null;
+  completed_at?: string | null;
+}
+
+export async function edit(
+  _ctx: AuthContext,
+  params: EditReviewParams,
+): Promise<Review> {
+  const { id, status, submitted_at, completed_at } = params;
+
+  if (!status && !submitted_at && !completed_at) {
+    throw new ValidationError('status, submitted_at, or completed_at must be provided');
+  }
+
+  const db = getDb();
+  const existingStmt = db.prepare('SELECT * FROM reviews WHERE id = ?');
+  const existing = existingStmt.get(id) as Review | undefined;
+
+  if (!existing) {
+    throw new NotFoundError('Review not found');
+  }
+
+  const now = new Date().toISOString();
+  const updates: string[] = [];
+  const queryParams: unknown[] = [];
+
+  if (status !== undefined) {
+    updates.push('status = ?');
+    queryParams.push(status);
+  }
+  if (submitted_at !== undefined) {
+    updates.push('submitted_at = ?');
+    queryParams.push(submitted_at);
+  }
+  if (completed_at !== undefined) {
+    updates.push('completed_at = ?');
+    queryParams.push(completed_at);
+  }
+
+  updates.push('updated_at = ?');
+  queryParams.push(now);
+  queryParams.push(id);
+
+  db.prepare(`UPDATE reviews SET ${updates.join(', ')} WHERE id = ?`).run(...queryParams);
+
+  return existingStmt.get(id) as Review;
+}
+
+// ─── submit ───────────────────────────────────────────────────────────────────
+
+export interface SubmitReviewParams {
+  doc_path: string;
+  annotation_ids?: string[];
+}
+
+export interface SubmitReviewResult {
+  status: 'review_submitted';
+  review_id: string;
+  doc_path: string;
+  submitted_at: string;
+  comment_count: number;
+  comments: Array<{
+    id: string;
+    heading_path: string;
+    quoted_text: string | null;
+    content: string;
+  }>;
+}
+
+/**
+ * Aggregate submit-review flow used by the MCP `submit_review` tool.
+ * Composes: create review → patch each annotation with review_id +
+ * status='submitted' → patch review to status='submitted'.
+ *
+ * When annotation_ids is omitted, picks up all draft + submitted
+ * annotations on the doc.
+ */
+export async function submit(
+  ctx: AuthContext,
+  params: SubmitReviewParams,
+): Promise<SubmitReviewResult> {
+  const { doc_path, annotation_ids } = params;
+
+  const review = await create(ctx, { doc_path });
+
+  let annotations: Annotation[];
+  if (annotation_ids && annotation_ids.length > 0) {
+    const all = await annotationsService.list(ctx, { doc_path });
+    annotations = all.filter(a => annotation_ids.includes(a.id));
+  } else {
+    const drafts = await annotationsService.list(ctx, { doc_path, status: 'draft' });
+    const submitted = await annotationsService.list(ctx, { doc_path, status: 'submitted' });
+    annotations = [...drafts, ...submitted];
+  }
+
+  const now = new Date().toISOString();
+
+  for (const ann of annotations) {
+    await annotationsService.edit(ctx, {
+      id: ann.id,
+      review_id: review.id,
+      status: 'submitted',
+    });
+  }
+
+  await edit(ctx, {
+    id: review.id,
+    status: 'submitted',
+    submitted_at: now,
+  });
+
+  return {
+    status: 'review_submitted',
+    review_id: review.id,
+    doc_path,
+    submitted_at: now,
+    comment_count: annotations.length,
+    comments: annotations.map(a => ({
+      id: a.id,
+      heading_path: a.heading_path,
+      quoted_text: a.quoted_text,
+      content: a.content,
+    })),
+  };
+}

--- a/packages/api/src/services/search.ts
+++ b/packages/api/src/services/search.ts
@@ -1,0 +1,101 @@
+/**
+ * Search service — transport-agnostic semantic-search business logic.
+ *
+ * This is the one service that's auth-aware at the domain layer:
+ * private-doc filtering depends on the caller's scopes (D-S8-5 / S9).
+ * When ctx.user is undefined OR lacks `docs:read:private`, results are
+ * filtered to public-only.
+ *
+ * Anvil readiness is the caller's responsibility — they pass in the
+ * already-resolved AnvilInstance. The route layer handles the 503 / init
+ * path; the service expects anvil to be ready by the time it runs.
+ */
+
+import type { AnvilInstance } from '../anvil-loader.js';
+import { getAccessLevel } from '../access.js';
+import type { AuthContext } from './context.js';
+import { ValidationError, ServiceUnavailableError } from './errors.js';
+
+export interface SearchParams {
+  query: string;
+  topK?: number;
+}
+
+export interface SearchResultItem {
+  path: string;
+  heading: string;
+  snippet: string;
+  score: number;
+  charCount: number;
+}
+
+export interface SearchResult {
+  results: SearchResultItem[];
+  query: string;
+  totalResults: number;
+  warning?: string;
+}
+
+const MIN_RELEVANCE_SCORE = 0.5;
+
+export async function search(
+  ctx: AuthContext,
+  anvil: AnvilInstance,
+  params: SearchParams,
+): Promise<SearchResult> {
+  const { query, topK = 10 } = params;
+
+  if (typeof query !== 'string') {
+    throw new ValidationError('Missing or invalid "query" field. Expected a non-empty string.');
+  }
+
+  if (query.trim() === '') {
+    throw new ValidationError('Query cannot be an empty string.');
+  }
+
+  // Empty index short-circuit (FAISS crashes on empty vss queries).
+  const status = await anvil.getStatus();
+  if (status.total_chunks === 0) {
+    return {
+      results: [],
+      query,
+      totalResults: 0,
+      warning: 'Anvil index is empty. Run anvil index to populate.',
+    };
+  }
+
+  const searchResults = await anvil.search(query, topK);
+
+  const mapped: SearchResultItem[] = searchResults.map(result => ({
+    path: result.metadata.file_path,
+    heading: result.metadata.heading_path,
+    snippet: result.content.slice(0, 200),
+    score: result.score,
+    charCount: result.metadata.char_count,
+  }));
+
+  // Scope-aware access filter. Missing/invalid tokens → ctx.user undefined
+  // → public-only. Legacy FOUNDRY_WRITE_TOKEN carries all docs:read:* scopes
+  // (see middleware/auth.ts LEGACY_SCOPES) and passes this check.
+  const canReadPrivate = ctx.user?.scopes?.includes('docs:read:private') ?? false;
+  const accessFiltered = canReadPrivate
+    ? mapped
+    : mapped.filter(r => getAccessLevel(r.path) !== 'private');
+
+  const filteredResults = accessFiltered.filter(r => r.score >= MIN_RELEVANCE_SCORE);
+
+  const result: SearchResult = {
+    results: filteredResults,
+    query,
+    totalResults: filteredResults.length,
+  };
+
+  if (filteredResults.length === 0 && topK !== 0) {
+    result.warning = 'No results matched your query.';
+  }
+
+  return result;
+}
+
+// Re-export so tests don't have to reach into errors.ts for this.
+export { ServiceUnavailableError };


### PR DESCRIPTION
## Story
FND-E12-S10a — Extract service layer (W7 solo; unblocks S10b MCP cutover)

## What changed
- `packages/api/src/services/` (NEW) — 6 domain modules + `context.ts` + `errors.ts`, pure `(ctx, params)` functions
- `packages/api/src/routes/*.ts` — thin handlers (≤15 lines each) delegating to services
- `packages/api/src/services/__tests__/` (NEW) — service-level unit tests, 52 new tests

## AC-to-diff mapping
- AC1 (existing HTTP tests unchanged) → `git diff main -- packages/api/src/routes/__tests__/` shows zero test-file edits; the 421 pre-existing tests still pass unmodified.
- AC2 (services/ populated) → annotations.ts, reviews.ts, search.ts, pages.ts, docs.ts, mgmt.ts + context.ts + errors.ts
- AC3 (pure functions, no Express types) → `grep -rn "from.*'express'" packages/api/src/services` returns zero hits
- AC4 (thin handlers) → largest route handler body is `GET /docs/:path(*)` at ~10 LOC; most are 5–8 LOC
- AC5 (new service tests) → 6 test files (annotations/reviews/search/pages/docs/mgmt), 52 new tests total
- AC6 (all tests green) → 473 passed (421 main + 52 new service tests)
- AC7 (tsc clean) → `npm run build` exits 0
- AC8 (MCP untouched) → diff touches only `routes/*.ts` + new `services/`; `mcp/`, `oauth*`, `middleware/`, `oauth/`, `db.ts`, schema all unchanged

## QA notes
- Backend-only refactor. No visual surface.
- HTTP contract is identical — existing integration tests are the contract guard.
- S10b will consume these services from MCP tool handlers.
- Smoke post-merge:
  - POST /api/annotations with legacy Bearer → 201 (identity propagation still works end-to-end)
  - POST /api/search anonymous → 200 (soft-auth path intact)
  - GET /api/pages?include_private=true no auth → 401 (scope gate intact)

## Test plan
- [x] npm test green (473 tests)
- [x] tsc clean
- [x] grep confirms services/ has no express imports
- [ ] Post-merge: orchestrator smokes the three representative routes above