### PR TITLE
docs(mcp): remove stdio refs + add HTTP migration runbook (FND-E12-S10c)

### DIFF
--- a/CICD.md
+++ b/CICD.md
@@ -115,8 +115,12 @@ Beyond tests, every PR should pass:
 # Type check (no emit)
 cd packages/api && npx tsc --noEmit
 
-# Full build (produces dist/ for the MCP stdio server)
+# Full build (produces dist/ for the Express server + MCP mount)
 npm run build -w @foundry/api
 ```
 
-The MCP stdio server (`dist/mcp/stdio.js`) is what Claude Code and other MCP clients spawn as a local child process. It reads from `dist/`, so **a rebuild is required** for local MCP tool schema changes to take effect in a running session. After rebuilding, reconnect the Foundry MCP client to pick up new tools.
+MCP runs in-process behind the Express mount at `POST /mcp` (Streamable
+HTTP transport). There is no separate child-process bridge to rebuild —
+when the deployed API restarts, clients reconnect and pick up the new tool
+schemas. In local dev, restart `packages/api` after changing tool
+definitions and your MCP client will see the update on its next request.

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -2,21 +2,31 @@
 
 ## Architecture
 
-Foundry runs as a single Docker container serving the static site + API + MCP server on one port.
+Foundry runs as a single Docker container serving the static site + API + OAuth AS + MCP server on one port.
 
 ```
-┌─────────────────────────────┐
-│  Foundry Container (:3001)  │
-│  ├── /*       → static site │
-│  ├── /api/*   → REST API    │
-│  └── /mcp/*   → MCP server  │
-│  SQLite → /data/foundry.db  │
-└─────────────────────────────┘
+┌─────────────────────────────────────┐
+│  Foundry Container (:3001)          │
+│  ├── /*              → static site  │
+│  ├── /api/*          → REST API     │
+│  ├── /oauth/*        → OAuth AS+DCR │
+│  ├── /.well-known/*  → AS metadata  │
+│  └── /mcp            → MCP (HTTP)   │
+│  SQLite → /data/foundry.db          │
+└─────────────────────────────────────┘
 ```
 
 ## Authentication
 
-Foundry uses bearer token authentication to protect write operations (annotations, reviews) and annotation read access. Static docs and search remain public.
+Foundry has two auth paths:
+
+1. **OAuth 2.0** — the primary path. Used by MCP clients (Claude Code,
+   Claude.ai, Cowork) and by first-party site sessions. Clients register via
+   DCR (RFC 7591), authorize against GitHub for identity, then call `/mcp`
+   with the resulting Bearer access token.
+2. **Legacy static token** (`FOUNDRY_WRITE_TOKEN`) — 30-day break-glass path
+   for the REST annotation/review endpoints. Not used by MCP. Will be
+   retired after operators have migrated.
 
 ### Security Model
 
@@ -28,10 +38,19 @@ Foundry uses bearer token authentication to protect write operations (annotation
 | GET /api/health | ❌ | Monitoring |
 | GET/POST/PATCH/DELETE /api/annotations* | ✅ | Review content is sensitive |
 | GET/POST/PATCH /api/reviews* | ✅ | Review metadata is sensitive |
-| MCP doc tools (search_docs, etc.) | 🟨 | Access-controlled — accepts optional auth_token |
-| MCP annotation tools | ✅ | Same as API annotations |
+| POST /mcp | ✅ (OAuth) | MCP Streamable HTTP — always requires a Bearer token |
+| GET /.well-known/oauth-* | ❌ | Discovery — must be public per RFC 8414 / 9728 |
+| GET /oauth/authorize | ❌ | OAuth user-facing entry |
+| POST /oauth/token | Client auth | Standard OAuth token endpoint |
+| POST /oauth/register | DCR token | Dynamic Client Registration, gated by `FOUNDRY_DCR_TOKEN` |
 
-### Token Setup
+### Legacy Token Setup (REST writes only)
+
+`FOUNDRY_WRITE_TOKEN` is the break-glass bearer for the REST annotation and
+review endpoints. MCP does **not** consult it — MCP always requires an
+OAuth access token. This token is kept for 30 days past the HTTP-MCP
+cutover to give operators room to migrate legacy scripts. See
+[docs/mcp-migration.md](mcp-migration.md) for the MCP path.
 
 1. **Generate a token:**
    ```bash
@@ -43,7 +62,8 @@ Foundry uses bearer token authentication to protect write operations (annotation
    cp .env.example .env
    # Edit .env and set FOUNDRY_WRITE_TOKEN=<your-token>
    ```
-   Without the token, auth is disabled (dev mode — all requests allowed).
+   Without the token, REST annotation/review writes fall open (dev mode).
+   MCP still requires OAuth regardless.
 
 3. **Fly.io production:**
    ```bash
@@ -68,9 +88,13 @@ Foundry uses bearer token authentication to protect write operations (annotation
 
 ### MCP Client Auth
 
-MCP annotation tools accept an `auth_token` parameter. Configure in your MCP client:
-- In-process (same container): uses `FOUNDRY_WRITE_TOKEN` env var directly
-- Remote clients: pass token as tool parameter
+MCP clients authenticate with an OAuth 2.0 Bearer token. Supported clients
+(Claude Code 2.1.64+, Claude.ai Connectors, Cowork-Claude) perform DCR +
+PKCE automatically — the operator only needs to paste the `/mcp` URL and
+complete the in-browser GitHub consent step.
+
+Operators configuring a new client: see
+[docs/mcp-migration.md](docs/mcp-migration.md) for the runbook.
 
 ## Public/Private Doc Access Control
 
@@ -112,7 +136,7 @@ The build script generates `.access.json` mapping path prefixes to access levels
 4. **API endpoints:** `/api/docs/*` checks access level before serving
 5. **Search:** Results filtered server-side — private content never reaches unauthenticated clients
 6. **Nav sidebar:** Client-side filtering hides private sections when no token present
-7. **MCP tools:** `search_docs` accepts optional `auth_token` for private results
+7. **MCP tools:** Identity is threaded from the OAuth Bearer token on `POST /mcp` directly into service calls — private results are returned when the caller's scopes include `docs:read:private`
 
 ### Adding New Content
 
@@ -147,8 +171,20 @@ To add a new source with access control:
    fly volumes create foundry_data --region iad --size 1
    ```
 
-5. **Set secrets** (if using private source repos):
+5. **Set secrets:**
    ```bash
+   # OAuth AS — required for MCP
+   fly secrets set FOUNDRY_OAUTH_ISSUER=https://foundry-claymore.fly.dev
+   fly secrets set FOUNDRY_DCR_TOKEN=$(openssl rand -hex 32)
+
+   # GitHub identity provider for OAuth consent
+   fly secrets set FOUNDRY_GITHUB_CLIENT_ID=<your-github-oauth-app-client-id>
+   fly secrets set FOUNDRY_GITHUB_CLIENT_SECRET=<your-github-oauth-app-secret>
+
+   # Legacy break-glass token for REST writes (annotations/reviews)
+   fly secrets set FOUNDRY_WRITE_TOKEN=$(openssl rand -hex 32)
+
+   # Only if pulling private source repos
    fly secrets set GITHUB_TOKEN=ghp_your_token_here
    ```
 
@@ -208,7 +244,11 @@ docker run -p 3001:3001 -v foundry-data:/data foundry
 | `PORT` | `3001` | Server port |
 | `FOUNDRY_DB_PATH` | `/data/foundry.db` | SQLite database path |
 | `FOUNDRY_STATIC_PATH` | `../../site/dist` | Path to Astro build output |
-| `FOUNDRY_WRITE_TOKEN` | (none) | Bearer token for API write protection; if unset, auth disabled (dev mode) |
+| `FOUNDRY_OAUTH_ISSUER` | (none) | Required in prod. Public origin advertised as the OAuth issuer (e.g. `https://foundry-claymore.fly.dev`) |
+| `FOUNDRY_DCR_TOKEN` | (none) | Required in prod. Bearer token that gates `POST /oauth/register` so only trusted clients can dynamically register |
+| `FOUNDRY_GITHUB_CLIENT_ID` | (none) | GitHub OAuth app client id — used as the identity provider during consent |
+| `FOUNDRY_GITHUB_CLIENT_SECRET` | (none) | GitHub OAuth app client secret |
+| `FOUNDRY_WRITE_TOKEN` | (none) | Legacy break-glass bearer for REST annotation/review writes. MCP no longer consults this. If unset, REST writes fall open in dev mode |
 | `GITHUB_TOKEN` | (none) | GitHub token for private source repos |
 | `NODE_ENV` | `production` | Node environment |
 

--- a/README.md
+++ b/README.md
@@ -21,9 +21,11 @@ Foundry runs two processes behind a single port:
 
 ```
 Port 4321 (proxy)
-├── /api/*  → Express API (port 3001, internal)
-├── /mcp/*  → Express API (MCP endpoints)
-└── /*      → Astro SSR (dynamic page rendering)
+├── /api/*    → Express API (port 3001, internal)
+├── /oauth/*  → Express API (OAuth AS + DCR)
+├── /.well-known/oauth-* → Express API (RFC 8414 / 9728 discovery)
+├── /mcp      → Express API (MCP Streamable HTTP)
+└── /*        → Astro SSR (dynamic page rendering)
 ```
 
 On startup:
@@ -62,11 +64,20 @@ CONTENT_BRANCH=main
 # GitHub webhook secret (for auto-updates on push)
 WEBHOOK_SECRET=<openssl rand -hex 32>
 
-# API write protection (annotations/reviews) AND the MCP transport (/mcp/sse,
-# /mcp/message). Required in production — without it, the MCP transport is
-# open and anyone on the internet can call tools like create_doc,
-# update_section, delete_section, etc. In dev mode (unset), auth is bypassed.
+# Legacy break-glass bearer token for REST writes (annotations/reviews).
+# Optional — if unset, REST write endpoints fall open in dev mode. MCP no
+# longer uses this token; MCP authenticates exclusively via OAuth 2.0
+# Bearer tokens (see "MCP server" below).
 FOUNDRY_WRITE_TOKEN=<openssl rand -hex 32>
+
+# OAuth issuer URL — required in production. MCP discovery advertises this
+# as the authorization server. Use your public Foundry URL.
+FOUNDRY_OAUTH_ISSUER=https://foundry-claymore.fly.dev
+
+# DCR admin token — required in production. Gates POST /oauth/register so
+# only trusted clients (Claude Code, Claude.ai, Cowork) can dynamically
+# register. Give clients this token via their own secret config.
+FOUNDRY_DCR_TOKEN=<openssl rand -hex 32>
 ```
 
 **Private repo setup** — see [Deploy Key Setup](#deploy-key-setup-private-repos) below.
@@ -119,6 +130,8 @@ fly secrets set CONTENT_BRANCH=main
 fly secrets set DEPLOY_KEY_B64=$(cat ~/.ssh/foundry_deploy_key | base64 -w0)
 fly secrets set WEBHOOK_SECRET=$(openssl rand -hex 32)
 fly secrets set FOUNDRY_WRITE_TOKEN=$(openssl rand -hex 32)
+fly secrets set FOUNDRY_OAUTH_ISSUER=https://foundry-claymore.fly.dev
+fly secrets set FOUNDRY_DCR_TOKEN=$(openssl rand -hex 32)
 fly deploy --remote-only
 ```
 
@@ -203,9 +216,11 @@ foundry/
 │   │   └── content/          # Docs cloned here at runtime
 │   └── api/                  # Express API server
 │       └── src/
-│           ├── routes/       # REST endpoints (docs, search, webhook, etc.)
-│           ├── middleware/    # Auth middleware
-│           ├── mcp/          # MCP server + tools
+│           ├── routes/       # REST + OAuth endpoints (docs, search, webhook, oauth/*)
+│           ├── middleware/   # Auth middleware (OAuth Bearer + legacy token)
+│           ├── mcp/          # MCP server + tools (Streamable HTTP)
+│           ├── oauth/        # OAuth AS + DCR storage + GitHub identity
+│           ├── services/     # Shared business logic (REST + MCP reuse)
 │           └── content-fetcher.ts  # Git clone/pull manager
 ├── scripts/
 │   ├── start.sh              # Container entrypoint (API + proxy)
@@ -230,16 +245,39 @@ foundry/
 | `PATCH /api/annotations/:id` | Yes | Update annotation status/content |
 | `POST /api/reviews` | Yes | Create review |
 | `PATCH /api/reviews/:id` | Yes | Update review status |
-| `GET /mcp/sse` | Yes | MCP SSE transport (connect) |
-| `POST /mcp/message` | Yes | MCP SSE transport (messages) |
+| `POST /mcp` | OAuth | MCP Streamable HTTP transport |
+| `GET /.well-known/oauth-protected-resource` | No | RFC 9728 resource metadata |
+| `GET /.well-known/oauth-authorization-server` | No | RFC 8414 AS metadata |
+| `POST /oauth/register` | DCR token | Dynamic Client Registration (RFC 7591) |
+| `GET /oauth/authorize` | No | OAuth authorize endpoint (PKCE) |
+| `POST /oauth/token` | Client | OAuth token endpoint |
 
-Auth: `Authorization: Bearer <FOUNDRY_WRITE_TOKEN>`
+REST write auth: `Authorization: Bearer <FOUNDRY_WRITE_TOKEN>` (legacy
+break-glass path; still honored for `/api/annotations` and `/api/reviews`).
 
-The `/mcp/*` transport endpoints require the same Bearer token as `/api/*`
-writes. MCP SSE clients that use `fetch`-based transports (including the
-official `@modelcontextprotocol/sdk` `SSEClientTransport`) can set the
-`Authorization` header; browser `EventSource` cannot and is not a supported
-client. In dev mode (`FOUNDRY_WRITE_TOKEN` unset), the transport is open.
+MCP auth: `Authorization: Bearer <oauth-access-token>` — issued by the
+`/oauth/authorize` + `/oauth/token` flow. See **MCP server** below.
+
+## MCP server
+
+Foundry exposes MCP over **Streamable HTTP** at a single endpoint:
+
+- Production: `https://foundry-claymore.fly.dev/mcp`
+- Local dev: `http://localhost:4321/mcp` (or whichever `PORT` you bound)
+
+All requests are gated by OAuth 2.0 Bearer token auth. Supported clients:
+
+- **Claude Code** (v2.1.64 or newer) — `claude mcp add --transport http foundry https://foundry-claymore.fly.dev/mcp`
+- **Claude.ai Connectors** — Settings → Connectors → Add custom connector, paste the URL
+- **Cowork-Claude** — configured on the Cowork side; point at the same URL
+
+All three clients handle **DCR** (Dynamic Client Registration) and **PKCE**
+automatically. The browser-based authorize flow prompts the user to grant
+scopes (`docs:read`, `docs:write`, `docs:read:private`) once, then the client
+caches the resulting access + refresh tokens.
+
+Migrating from the old stdio bridge? See
+[docs/mcp-migration.md](docs/mcp-migration.md).
 
 ## Tech Stack
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,8 +18,20 @@ services:
       - DEPLOY_KEY_PATH=/root/.ssh/deploy_key
       # GitHub remote URL for sync (git@github.com:user/repo.git or https URL)
       - SYNC_REMOTE_URL=${SYNC_REMOTE_URL:-}
-      # Bearer token for API write protection (annotations/reviews)
-      # If unset, auth is disabled (dev mode)
+      # OAuth AS — required in production. MCP discovery advertises this
+      # origin as the authorization server. In local docker dev you can
+      # leave FOUNDRY_OAUTH_ISSUER set to http://localhost:4321 or unset
+      # (falls back to dev mode).
+      - FOUNDRY_OAUTH_ISSUER=${FOUNDRY_OAUTH_ISSUER:-}
+      # DCR admin token — required in production. Gates POST /oauth/register
+      # so only trusted clients can dynamically register.
+      - FOUNDRY_DCR_TOKEN=${FOUNDRY_DCR_TOKEN:-}
+      # GitHub OAuth app used as the identity provider during consent.
+      - FOUNDRY_GITHUB_CLIENT_ID=${FOUNDRY_GITHUB_CLIENT_ID:-}
+      - FOUNDRY_GITHUB_CLIENT_SECRET=${FOUNDRY_GITHUB_CLIENT_SECRET:-}
+      # Legacy break-glass bearer for REST writes (annotations/reviews).
+      # MCP no longer uses this token. If unset, REST writes fall open
+      # (dev mode). Will be retired after operators have migrated.
       - FOUNDRY_WRITE_TOKEN=${FOUNDRY_WRITE_TOKEN:-}
       - FOUNDRY_READ_TOKEN=${FOUNDRY_READ_TOKEN:-}
     restart: unless-stopped

--- a/docs/mcp-migration.md
+++ b/docs/mcp-migration.md
@@ -1,0 +1,103 @@
+# MCP Migration — stdio bridge to HTTP
+
+Foundry's MCP server moved from a local stdio subprocess to a single
+Streamable HTTP endpoint at `POST /mcp`. All callers authenticate with an
+OAuth 2.0 Bearer token. This page is the runbook for switching your client
+over.
+
+Production endpoint: `https://foundry-claymore.fly.dev/mcp`
+Local dev endpoint: `http://localhost:4321/mcp`
+
+## Claude Code CLI
+
+The supported client is Claude Code **v2.1.64 or newer**. Older versions
+cannot complete DCR + PKCE against Foundry.
+
+### Quick path — `claude mcp add`
+
+```bash
+claude mcp add --transport http foundry https://foundry-claymore.fly.dev/mcp
+```
+
+Claude Code will open a browser tab the first time you invoke a Foundry
+tool. Sign in to GitHub, grant the scopes, and you're done — tokens are
+cached in `~/.claude.json`.
+
+### Manual path — edit `~/.claude.json`
+
+If you're migrating a hand-edited config, swap the stdio entry for an HTTP
+entry:
+
+```jsonc
+// BEFORE (stdio bridge — no longer works)
+{
+  "mcpServers": {
+    "foundry": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["/path/to/foundry/packages/api/dist/mcp/stdio.js"],
+      "env": { "FOUNDRY_WRITE_TOKEN": "..." }
+    }
+  }
+}
+
+// AFTER (HTTP)
+{
+  "mcpServers": {
+    "foundry": {
+      "type": "http",
+      "url": "https://foundry-claymore.fly.dev/mcp"
+    }
+  }
+}
+```
+
+No token goes in the config — OAuth handles auth transparently.
+
+## Claude.ai Connectors
+
+1. Claude.ai → Settings → Connectors → **Add custom connector**
+2. URL: `https://foundry-claymore.fly.dev/mcp`
+3. Save. Claude.ai kicks off the OAuth flow in-browser; approve the scopes.
+
+No token or secret paste required. If you had an older stdio-style
+connector registered, delete it first — Foundry no longer speaks stdio.
+
+## Cowork-Claude
+
+Cowork-Claude is configured on the Cowork side, not inside Foundry. Point
+the Cowork connector config at `https://foundry-claymore.fly.dev/mcp` and
+let DCR + PKCE complete automatically. See the Cowork repo for the exact
+config file path and reload command.
+
+## Troubleshooting
+
+**`401 Unauthorized` on the first tool call.** Expected on a fresh client
+— the 401 response carries a `WWW-Authenticate: Bearer resource_metadata=...`
+header that kicks off discovery + DCR. If you keep getting 401s, the client
+may not support OAuth 2.0 DCR. Upgrade to Claude Code 2.1.64+ or use
+Claude.ai.
+
+**`POST /oauth/register` returns 403.** Your client couldn't present the
+DCR admin token. Check that the Foundry deployment has `FOUNDRY_DCR_TOKEN`
+set and that your client was provisioned with the same value. First-party
+clients (Claude Code, Claude.ai, Cowork-Claude) are provisioned
+out-of-band.
+
+**Old stdio entry still in the config and you see a "command not found" or
+"ENOENT" error.** That's the stdio bridge the old config still points at.
+Delete the `"command"` / `"args"` / `"env"` keys and replace with the HTTP
+entry shape above.
+
+**Token looks valid but tools return empty private results.** The consent
+page only grants the scopes you approve. Private doc reads require
+`docs:read:private`. Revoke the existing grant on the GitHub OAuth app and
+re-authorize.
+
+## Related
+
+- [README → MCP server](../README.md#mcp-server)
+- [DEPLOY → Security Model](../DEPLOY.md#security-model)
+- RFC 7591 — Dynamic Client Registration
+- RFC 8414 — OAuth 2.0 Authorization Server Metadata
+- RFC 9728 — OAuth 2.0 Protected Resource Metadata

--- a/foundry.config.example.yaml
+++ b/foundry.config.example.yaml
@@ -6,7 +6,9 @@
 # Private repos require GITHUB_TOKEN to be set in your environment.
 #
 # access: public  — visible to anyone
-# access: private — requires bearer token (FOUNDRY_WRITE_TOKEN)
+# access: private — requires a Bearer token. MCP clients authenticate via
+#                   OAuth 2.0 (see README → "MCP server"). Legacy REST
+#                   callers can still present FOUNDRY_WRITE_TOKEN.
 
 sources:
   # Public methodology docs — open to the world


### PR DESCRIPTION
## Story
FND-E12-S10c — Docs + config cleanup (W9, final E12 Phase 3 PR)

## What changed

Modified (5):
- `README.md` — rewrote MCP section for Streamable HTTP + OAuth; updated architecture diagram, API table, env var block, Fly deploy secrets, Project Structure
- `DEPLOY.md` — updated architecture diagram, security model table, authentication intro (OAuth primary + legacy token secondary), Fly secrets checklist, env vars reference, MCP client auth section
- `CICD.md` — removed the `dist/mcp/stdio.js` rebuild note; replaced with in-process HTTP mount semantics
- `docker-compose.yml` — added `FOUNDRY_OAUTH_ISSUER`, `FOUNDRY_DCR_TOKEN`, `FOUNDRY_GITHUB_CLIENT_ID`, `FOUNDRY_GITHUB_CLIENT_SECRET`; reworded `FOUNDRY_WRITE_TOKEN` as legacy break-glass
- `foundry.config.example.yaml` — clarified that private sources accept OAuth tokens primarily; legacy token still honored

New (1):
- `docs/mcp-migration.md` — <100 LOC runbook. Claude Code (CLI + manual edit), Claude.ai Connectors, Cowork-Claude pointer, troubleshooting section

## AC-to-diff mapping

- **AC1 — `FOUNDRY_MCP_REQUIRE_AUTH` refs gone from code+docs.** Zero hits in `*.md`, `*.yaml`, `*.yml`. Remaining hits in `packages/api/src/__tests__/mcp-transport-auth.test.ts` are intentional regression guards (verify the env var no longer provides an escape hatch); non-test `packages/api/src` is clean.
- **AC2 — `dist/mcp/stdio` refs gone from docs.** Only remaining hit is the BEFORE block in `docs/mcp-migration.md` as part of the migration diff.
- **AC3 — README/DEPLOY/CICD updated to HTTP-only MCP.** `README.md:262-280` (new MCP section), `DEPLOY.md:5-16` (arch diagram) + `DEPLOY.md:82-90` (MCP client auth), `CICD.md:110-124` (build section).
- **AC4 — Example config files drop stdio env vars.** `docker-compose.yml:21-33`, `foundry.config.example.yaml:9-12`.
- **AC5 — Runbook exists.** `docs/mcp-migration.md`.

## QA notes

- No code changes — S10a/b did all the code work. `git diff --name-only main` returns only `*.md`, `*.yaml`, `*.yml`.
- Orchestrator will handle `fly secrets unset FOUNDRY_MCP_REQUIRE_AUTH` separately.
- Smoke post-merge: read the new README MCP section + `docs/mcp-migration.md`, confirm URL + `claude mcp add` snippet work against deployed Foundry.

## Test plan

- [x] Three grep sanity checks pass (see AC1-AC2)
- [x] No code files modified (`git diff --name-only main` shows only docs/config)
- [x] Runbook kept under 100 lines
- [x] Read through each modified doc for coherence (not just mechanical deletions)