### PR TITLE
fix(tests): eliminate HMAC-tamper flake + env-var leak between files

### DIFF
--- a/packages/api/src/routes/__tests__/oauth-github.test.ts
+++ b/packages/api/src/routes/__tests__/oauth-github.test.ts
@@ -74,8 +74,18 @@ describe('signCookie / verifyCookie', () => {
   it('returns null when HMAC is tampered', () => {
     const payload = { state: 'abc123', exp: Math.floor(Date.now() / 1000) + 300 };
     const raw = signCookie(payload);
-    // Tamper: flip last char of HMAC part
-    const tampered = raw.slice(0, -1) + (raw.endsWith('a') ? 'b' : 'a');
+    const dotIndex = raw.lastIndexOf('.');
+    // Flip the first char of the HMAC part. That char always carries 6 bits of
+    // real data, so any substitution changes the decoded bytes. (The last
+    // base64url char of a 32-byte HMAC only carries 4 bits — the low 2 bits are
+    // padding and get discarded on decode, so flipping only those yields an
+    // identical HMAC ~1/16 of the time.)
+    const hmacStart = dotIndex + 1;
+    const firstHmacChar = raw[hmacStart];
+    const tampered =
+      raw.slice(0, hmacStart) +
+      (firstHmacChar === 'A' ? 'B' : 'A') +
+      raw.slice(hmacStart + 1);
     expect(verifyCookie(tampered)).toBeNull();
   });
 
@@ -189,7 +199,13 @@ describe('GET /oauth/github/callback', () => {
 
   it('returns 400 when state cookie has been tampered (HMAC check)', async () => {
     const rawCookie = makeStateCookie('good-state');
-    const tampered = rawCookie.slice(0, -1) + (rawCookie.endsWith('a') ? 'b' : 'a');
+    const dotIndex = rawCookie.lastIndexOf('.');
+    const hmacStart = dotIndex + 1;
+    const firstHmacChar = rawCookie[hmacStart];
+    const tampered =
+      rawCookie.slice(0, hmacStart) +
+      (firstHmacChar === 'A' ? 'B' : 'A') +
+      rawCookie.slice(hmacStart + 1);
     const res = await request(app)
       .get('/oauth/github/callback?code=abc&state=good-state')
       .set('Cookie', `foundry_oauth_state=${encodeURIComponent(tampered)}`)

--- a/packages/api/vitest.config.ts
+++ b/packages/api/vitest.config.ts
@@ -7,9 +7,17 @@ import { defineConfig } from 'vitest/config';
  * provides safe defaults for env vars the middleware / OAuth code
  * expects. Individual test files can override these with module-top
  * `process.env.X = '...'` assignments.
+ *
+ * `pool: 'forks'` runs each test file in a child_process.fork so that
+ * `process.env` is not shared between files. The default `threads`
+ * pool uses worker_threads, which share the process-global `process.env`
+ * — test files that mutate env vars (e.g. oauth-register deletes
+ * FOUNDRY_DCR_TOKEN in an afterEach) were leaking state into other
+ * files' concurrent tests, producing rare cross-file flakes.
  */
 export default defineConfig({
   test: {
     setupFiles: ['./vitest.setup.ts'],
+    pool: 'forks',
   },
 });


### PR DESCRIPTION
## Summary

Two independent root causes behind the intermittent OAuth test flakes flagged in `next.md`:

- **HMAC tamper bug** in `oauth-github.test.ts` — the test flipped the *last* base64url char of a 32-byte HMAC. That char only carries 4 bits of real data; the low 2 bits are padding and get discarded on decode. When the original last char was `Y` (binary `011000`), replacing it with `a` (binary `011010`) decoded to identical bytes — HMAC verified and the test failed. Reproduced at 591/10000 collisions (~5.9%). Fix: tamper the first HMAC char instead (full 6 bits of real data). 0/10000 collisions after.
- **Cross-file env-var leak** — vitest's default `threads` pool shares `process.env` across worker threads. Files that mutate env vars in before/afterEach (e.g. oauth-register deletes `FOUNDRY_DCR_TOKEN`) were leaking state into concurrent files, causing sparse one-off failures in unrelated suites (annotations, oauth-register bot test, softAuth). Switching to `pool: 'forks'` isolates `process.env` per file per next.md's suggestion.

Full-suite flake rate measured over 65 runs: **8% → 2.5%**. Residual rare failures look like supertest socket timing under heavy fork parallelism — filed as follow-up, not blocking S12.

## Test plan

- [x] `npm run test -- src/routes/__tests__/oauth-github.test.ts` (26/26 pass)
- [x] 40 consecutive full-suite runs (`npx vitest run`) — 39/40 pass; one residual failure unrelated to the fixes
- [x] 10k-iteration HMAC tamper simulation — 0 collisions with new logic vs 591 with old

🤖 Generated with [Claude Code](https://claude.com/claude-code)