### PR TITLE
docs(s12): DEPLOY env gaps + DCR rotation runbook + E12 ship log (PR C)

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -175,11 +175,16 @@ To add a new source with access control:
    ```bash
    # OAuth AS — required for MCP
    fly secrets set FOUNDRY_OAUTH_ISSUER=https://foundry-claymore.fly.dev
+   fly secrets set FOUNDRY_OAUTH_SESSION_SECRET=$(openssl rand -hex 32)
    fly secrets set FOUNDRY_DCR_TOKEN=$(openssl rand -hex 32)
 
    # GitHub identity provider for OAuth consent
-   fly secrets set FOUNDRY_GITHUB_CLIENT_ID=<your-github-oauth-app-client-id>
-   fly secrets set FOUNDRY_GITHUB_CLIENT_SECRET=<your-github-oauth-app-secret>
+   fly secrets set GITHUB_OAUTH_CLIENT_ID=<your-github-oauth-app-client-id>
+   fly secrets set GITHUB_OAUTH_CLIENT_SECRET=<your-github-oauth-app-secret>
+
+   # Comma-separated GitHub logins granted the docs:read:private scope.
+   # Any user outside this list gets docs:read + docs:write only.
+   fly secrets set FOUNDRY_PRIVATE_DOC_USERS=danhannah94,other-admin
 
    # Legacy break-glass token for REST writes (annotations/reviews)
    fly secrets set FOUNDRY_WRITE_TOKEN=$(openssl rand -hex 32)
@@ -197,6 +202,25 @@ To add a new source with access control:
    ```bash
    curl https://foundry-claymore.fly.dev/api/health
    ```
+
+### Pre-deploy OAuth conformance check
+
+Before any deploy that touches the OAuth surface, run the conformance
+probe against staging (or prod if there is no staging environment):
+
+```bash
+FOUNDRY_BASE_URL=https://foundry-claymore.fly.dev \
+FOUNDRY_DCR_TOKEN=<value> \
+node scripts/oauth-conformance.mjs
+```
+
+All checks must pass (exit code 0) before merging the deploy. The
+probe validates AS metadata shape (RFC 8414), DCR bearer gate (RFC 7591),
+PKCE enforcement (RFC 7636), token endpoint error contract (RFC 6749),
+and `WWW-Authenticate` shape (RFC 6750) against the live instance.
+
+For threat-model coverage and accepted risks, see
+[docs/security-review.md](docs/security-review.md).
 
 ### Continuous Deployment
 
@@ -244,10 +268,12 @@ docker run -p 3001:3001 -v foundry-data:/data foundry
 | `PORT` | `3001` | Server port |
 | `FOUNDRY_DB_PATH` | `/data/foundry.db` | SQLite database path |
 | `FOUNDRY_STATIC_PATH` | `../../site/dist` | Path to Astro build output |
-| `FOUNDRY_OAUTH_ISSUER` | (none) | Required in prod. Public origin advertised as the OAuth issuer (e.g. `https://foundry-claymore.fly.dev`) |
-| `FOUNDRY_DCR_TOKEN` | (none) | Required in prod. Bearer token that gates `POST /oauth/register` so only trusted clients can dynamically register |
-| `FOUNDRY_GITHUB_CLIENT_ID` | (none) | GitHub OAuth app client id — used as the identity provider during consent |
-| `FOUNDRY_GITHUB_CLIENT_SECRET` | (none) | GitHub OAuth app client secret |
+| `FOUNDRY_OAUTH_ISSUER` | (none) | Required in prod. Public origin advertised as the OAuth issuer (e.g. `https://foundry-claymore.fly.dev`). Sourced only from this env — never from the `Host` header |
+| `FOUNDRY_OAUTH_SESSION_SECRET` | (none) | Required in prod. HMAC-SHA256 key used to sign the `foundry_oauth_session` and `foundry_oauth_pending` cookies. Rotating invalidates in-flight auth flows; users just retry |
+| `FOUNDRY_DCR_TOKEN` | (none) | Required in prod. Bearer token that gates `POST /oauth/register` so only trusted clients can dynamically register. See [docs/dcr-rotation.md](docs/dcr-rotation.md) for rotation |
+| `GITHUB_OAUTH_CLIENT_ID` | (none) | GitHub OAuth app client id — used as the identity provider during consent |
+| `GITHUB_OAUTH_CLIENT_SECRET` | (none) | GitHub OAuth app client secret |
+| `FOUNDRY_PRIVATE_DOC_USERS` | (empty) | Comma-separated GitHub logins that receive the `docs:read:private` scope at token mint. Users not in this list get `docs:read` + `docs:write` only |
 | `FOUNDRY_WRITE_TOKEN` | (none) | Legacy break-glass bearer for REST annotation/review writes. MCP no longer consults this. If unset, REST writes fall open in dev mode |
 | `GITHUB_TOKEN` | (none) | GitHub token for private source repos |
 | `NODE_ENV` | `production` | Node environment |

--- a/NEXT.md
+++ b/NEXT.md
@@ -1,0 +1,125 @@
+# Foundry — Ship Log
+
+Rolling record of shipped epics. Newest first. For per-change detail,
+see `git log` or the linked PRs; this file captures the "what did this
+epic deliver and why it mattered" layer that would otherwise get lost.
+
+---
+
+## E12 — MCP Authorization (OAuth 2.0 + GitHub IdP) — 2026-04-20
+
+**Headline.** Foundry's MCP surface now authenticates callers via the
+standard OAuth 2.0 authorization code flow with PKCE, backed by GitHub
+as the identity provider. The stdio bridge is gone; every MCP client —
+Claude Code, Claude.ai Connectors, Cowork-Claude — talks to
+`https://foundry-claymore.fly.dev/mcp` over Streamable HTTP with an
+OAuth Bearer token.
+
+### Why this mattered
+
+Pre-E12, Foundry identified MCP callers by looking up an environment
+variable (`FOUNDRY_MCP_USER`). Every agent action was attributed to
+whatever string was configured at container boot. This was fine when
+there was exactly one operator running exactly one MCP client, but it
+failed the core Foundry contract — that annotations and reviews are
+attributed to the human or agent that actually wrote them. E12 replaces
+the env-var lie with real identity:
+
+- Each MCP client registers dynamically and gets a `client_type`
+  (`interactive` / `autonomous`).
+- Each human authenticates against GitHub once per ~30-day refresh
+  window.
+- Every write lands with the right `user_id` (GitHub) + `author_type`
+  (derived from the client_type, not the user account).
+
+This is also what unlocks Claude.ai Connectors talking to Foundry at
+all — they require the MCP Authorization spec as of 2025-06-18.
+
+### What shipped
+
+| Story | PR | Delivers |
+|---|---|---|
+| S1 | — | OAuth schema + DAOs (`users`, `oauth_clients`, `oauth_authorization_codes`, `oauth_tokens`) |
+| S2 | — | GitHub OAuth callback — `GET /oauth/github/callback`, mints signed session cookie |
+| S3 | — | `.well-known/oauth-authorization-server` + `.well-known/oauth-protected-resource` (RFC 8414 / 9728) |
+| S4 | — | Dynamic Client Registration — `POST /oauth/register` gated by `FOUNDRY_DCR_TOKEN` (RFC 7591) |
+| S5 | [#146](https://github.com/danhannah94/foundry/pull/146) | `/oauth/authorize` + consent page + auth-code mint; S5 hotfix `GET /oauth/consent` handler |
+| S6 | [#147](https://github.com/danhannah94/foundry/pull/147) | Token endpoint + refresh rotation + confused-deputy check (RFC 6749 §4.1.3) |
+| S7 | [#148](https://github.com/danhannah94/foundry/pull/148) | `requireAuth` / `requireScope` / `softAuth` middleware + RFC 6750 `WWW-Authenticate` |
+| S8 | [#150](https://github.com/danhannah94/foundry/pull/150) | Identity propagation — `user_id` from `req.user.id`, `author_type` from `req.client.client_type` |
+| S9 | [#149](https://github.com/danhannah94/foundry/pull/149) | Per-user `docs:read:private` on `/api/search` + `/api/pages` (closes most of #99) |
+| S10a | [#152](https://github.com/danhannah94/foundry/pull/152) | Service-layer extraction — 6 domain modules, ~1700 LOC, +52 unit tests |
+| S10b | [#153](https://github.com/danhannah94/foundry/pull/153) | MCP Streamable HTTP cutover — direct service calls, stdio + http-client deleted |
+| S10c | [#154](https://github.com/danhannah94/foundry/pull/154) | Docs + config cleanup + `docs/mcp-migration.md` runbook |
+| S12 A | [#158](https://github.com/danhannah94/foundry/pull/158) | In-repo OAuth E2E test suite + security AC gap coverage |
+| S12 B | [#159](https://github.com/danhannah94/foundry/pull/159) | `scripts/oauth-conformance.mjs` probe + `docs/security-review.md` pen-test pass |
+| S12 C | (this PR) | DEPLOY.md env gaps + DCR rotation runbook + this ship log |
+
+Plus two follow-up hotfixes:
+
+- [#155](https://github.com/danhannah94/foundry/pull/155) — `docs:read:private` on `GET /docs/:path` (closes remainder of #99)
+- [#156](https://github.com/danhannah94/foundry/pull/156) — `npm audit fix` clears critical + high vulnerabilities (#140)
+
+And a test-infra fix landed during S12 prep:
+
+- [#157](https://github.com/danhannah94/foundry/pull/157) — fix OAuth test flakes (HMAC-tamper logic bug + cross-file `process.env` leak under vitest's threads pool)
+
+### Issues closed
+
+- [#99](https://github.com/danhannah94/foundry/issues/99) — per-user access control on private docs
+- [#140](https://github.com/danhannah94/foundry/issues/140) — critical + high npm audit findings
+- [#151](https://github.com/danhannah94/foundry/issues/151) — `docs:read:private` on GET `/docs/:path`
+
+### Security posture
+
+- Opaque tokens, SHA-256 at rest. No JWTs.
+- Refresh rotation on every use with reuse detection (single-use refresh).
+- Auth codes one-time-consumable via atomic DB update.
+- PKCE required (S256 only); no `plain` downgrade path.
+- `redirect_uri` exact string match — no query-param stripping.
+- Client secrets bcrypt-hashed at rest.
+- DCR bearer-gated via `FOUNDRY_DCR_TOKEN` — see [dcr-rotation.md](docs/dcr-rotation.md).
+- Issuer URL sourced from `FOUNDRY_OAUTH_ISSUER`, never from `Host` header.
+- Token material never appears in log output (intercept-tested).
+
+Full threat matrix + accepted risks: [docs/security-review.md](docs/security-review.md).
+
+### Non-obvious decisions
+
+Captured at ship time because they're expensive to reverse and won't be
+obvious from the code alone:
+
+- **S10 was split into S10a/b/c mid-flight.** A pre-implementation grep
+  discovered `mcp/http-client.ts` was consumed by both stdio AND the
+  old `/mcp/sse` path — deleting the bridge directly would have broken
+  the HTTP MCP endpoint mid-migration. Splitting into extract →
+  Streamable HTTP cutover → cleanup let each step ship independently.
+- **Chose Streamable HTTP over keeping SSE.** Research confirmed both
+  Claude Code and Claude.ai Connectors prefer Streamable today; SSE is
+  `@deprecated` in the MCP SDK. Near-zero incremental cost to cut over
+  in the same epic.
+- **Session cookies, not database sessions.** Signed HMAC-SHA256
+  cookies keep the happy path DB-hit-free for a single-node deploy.
+  Revisit if Foundry goes multi-node.
+- **`author_type` derived from client, not user.** An agent using a
+  human's OAuth session still writes as `ai` because the client
+  registered as `autonomous`. Accurate audit trail.
+- **Consent shown on every fresh auth flow in v1.** No
+  `oauth_consents` table. At refresh-token lifetimes of ~30 days, a
+  single human sees consent ~monthly — acceptable UX, ~zero
+  implementation cost, deferred to v2 if a second human joins.
+
+### Follow-ups outside E12
+
+- **`FOUNDRY_WRITE_TOKEN` legacy path removal** — 30-day break-glass
+  window opened at S10b ship (~2026-04-20). Earliest removal
+  ~2026-05-20 in a follow-up PR.
+- **Vitest residual flake rate ~2.5%** — tracked as a follow-up after
+  #157 brought it down from ~8%. Not CI-blocking.
+- **OAuth test-flake follow-up** — `oauth_consents` skip-consent,
+  audit log for DCR use, multi-tenant rate limiting. All v2 concerns.
+
+### Upstream dependencies
+
+None introduced. E12 uses only existing deps (`bcryptjs`,
+`better-sqlite3`, `express`, node's built-in `crypto`).

--- a/docs/dcr-rotation.md
+++ b/docs/dcr-rotation.md
@@ -1,0 +1,95 @@
+# DCR Bearer Token Rotation
+
+`FOUNDRY_DCR_TOKEN` gates `POST /oauth/register`. Without it, anyone on
+the internet could register a new OAuth client against Foundry. Treat
+it like a deploy key — rotate on a schedule, rotate immediately if
+leaked.
+
+## When to rotate
+
+- **Leaked / suspected leak** — rotate within the hour. Preceding and
+  subsequent rotations are effectively free; the cost is one shared-secret
+  re-broadcast to each authorized registrant.
+- **Personnel changes** — when someone who had access to the token
+  leaves the project.
+- **Scheduled hygiene** — every 6–12 months. Add a reminder to your
+  calendar tied to the date it was last set.
+
+## Rotation procedure
+
+```bash
+# 1. Generate a new token locally. Don't reuse; always fresh.
+NEW_TOKEN=$(openssl rand -hex 32)
+echo "$NEW_TOKEN"
+# Capture this somewhere transient — you'll need it to test and to
+# hand off to registrants. DO NOT commit, paste into Slack, or email.
+# Use a proper secret channel (1Password share link, signal, etc.).
+
+# 2. Set the new value on Fly. This rolls the machine automatically.
+fly secrets set FOUNDRY_DCR_TOKEN="$NEW_TOKEN" --app foundry-claymore
+
+# 3. Wait for the new machine to be healthy.
+fly status --app foundry-claymore
+# Look for "1/1 passing" under Checks before continuing.
+
+# 4. Verify the new token works against the deployed instance.
+FOUNDRY_BASE_URL=https://foundry-claymore.fly.dev \
+FOUNDRY_DCR_TOKEN="$NEW_TOKEN" \
+node scripts/oauth-conformance.mjs
+# All DCR checks should PASS. If any FAIL, roll back before proceeding
+# (fly secrets set FOUNDRY_DCR_TOKEN=<old-value>) and debug.
+
+# 5. Broadcast the new token out-of-band to each authorized registrant
+# — currently Claude.ai Connectors administrator (Dan) and Cowork-Claude
+# config. Use a proper secret channel.
+
+# 6. Confirm the old token is rejected. The conformance probe's
+# "DCR with wrong bearer → 401" assertion already covers this; verifying
+# with the real old value is belt-and-suspenders.
+```
+
+## Who needs the token
+
+As of E12 ship (2026-04-20):
+
+| Registrant | Mechanism | How to deliver |
+|---|---|---|
+| Claude.ai Connectors (Dan) | Paste into the Connectors admin UI at connection time | 1Password share |
+| Cowork-Claude | Baked into the MCP config at setup time | 1Password share |
+
+If a new client joins the authorized set, document it in this table so
+the next rotation has an accurate distribution list.
+
+## What breaks during rotation
+
+- In-flight `POST /oauth/register` requests that arrive after the new
+  secret has been set but before the requestor has the new token will
+  receive 401. Retry with the new token resolves.
+- Already-registered clients are unaffected. The DCR token gates
+  *registration*, not ongoing auth — existing `client_id` / `client_secret`
+  pairs continue to work against `/oauth/token` regardless of DCR state.
+- No user-facing disruption. Consent flows, MCP calls, token refreshes
+  all continue uninterrupted.
+
+## Rollback
+
+If a rotation is broken (e.g. the new token has shell-escaping issues
+that corrupt the stored value):
+
+```bash
+fly secrets set FOUNDRY_DCR_TOKEN=<previous-value> --app foundry-claymore
+```
+
+Fly keeps one prior secret value internally, but do not rely on that —
+always have the old value cached locally for the duration of the
+rotation window. Discard within 1 hour of confirming the new value
+works.
+
+## Audit
+
+There is intentionally no audit log of DCR token use in v1. The token
+is a single shared secret; attributing a registration to a specific
+holder isn't possible without per-registrant tokens (planned for v2,
+not scoped to E12). Treat every `POST /oauth/register` event in the
+server log as "authorized DCR holder or someone with a leaked secret"
+— and rotate on suspicion.


### PR DESCRIPTION
## Summary

Final PR closing FND-E12-S12 and, with it, the E12 epic. Docs-only. Three additions:

### 1. DEPLOY.md fixes + additions

- **Env var name corrections.** The env table listed `FOUNDRY_GITHUB_CLIENT_ID` / `FOUNDRY_GITHUB_CLIENT_SECRET`. The code (`packages/api/src/oauth/github.ts`) actually reads `GITHUB_OAUTH_CLIENT_ID` / `GITHUB_OAUTH_CLIENT_SECRET`. Prod was already set correctly — only the doc was stale, which would have cost time for a future deploy of a fresh Fly instance.
- **Two missing vars added.** `FOUNDRY_OAUTH_SESSION_SECRET` (HMAC key for session / pending cookies — required in prod) and `FOUNDRY_PRIVATE_DOC_USERS` (private-scope allowlist). Both are read by the code and set on prod, just weren't in the reference table.
- **Pre-deploy conformance check section.** Points at `scripts/oauth-conformance.mjs` with a one-liner that runs before any OAuth-surface-touching deploy. Links to `docs/security-review.md`.

### 2. `docs/dcr-rotation.md`

Runbook for rotating `FOUNDRY_DCR_TOKEN`. Covers:

- When to rotate (leaked / personnel change / scheduled hygiene)
- The rotation procedure including conformance verification as step 4
- Who needs the new token (Claude.ai Connectors admin, Cowork-Claude) and how to deliver it
- What breaks during rotation (nothing user-facing — existing clients unaffected)
- Rollback
- The v1 audit limitation (single shared secret, rotate-on-suspicion posture) and its reasoning

### 3. `NEXT.md`

E12 ship log at repo root. Designed as an ongoing release notes file (newest epic first, like a CHANGELOG but more narrative). The E12 entry captures:

- Headline + why it mattered (env-var identity lie → real OAuth identity)
- Full PR map across all 12 stories + S12 A/B/C + hotfixes
- Issues closed: #99, #140, #151
- Security posture summary
- Non-obvious decisions preserved for future-us (S10 mid-flight split, Streamable HTTP vs SSE, session cookies vs DB sessions, client-type-derived `author_type`, per-session consent trade-off)
- Follow-ups that fall outside E12 scope

## With this merged, E12 is formally closed.

The remaining S12 acceptance criteria are operational (not code):

- [ ] Run conformance probe with real DCR token against staging → exit 0
- [ ] Walk all 12 stories' ACs against prod
- [ ] Reindex prod Anvil (templates may have been touched during E12 churn)
- [ ] Confirm `FOUNDRY_MCP_USER` unset from Fly secrets

Those will happen in the session-end wrap.

## Test plan

- [x] `grep -r "FOUNDRY_GITHUB_CLIENT" packages/` — zero matches (all OAuth app env vars now correctly use `GITHUB_OAUTH_*`)
- [x] DEPLOY.md renders cleanly (no broken tables/links)
- [x] All three new internal links resolve (`docs/dcr-rotation.md`, `docs/security-review.md`, `scripts/oauth-conformance.mjs`)

## Follows

- #157 (flake fixes)
- #158 (PR A — E2E test suite)
- #159 (PR B — conformance probe + security review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)