### PR TITLE
fix(cors): allow https://claude.ai in CORS allowlist (E12 smoke-test hotfix)

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -130,10 +130,14 @@ async function startServer(): Promise<void> {
   try {
     const app = express();
 
-    // CORS configuration - allow GitHub Pages and localhost
+    // CORS configuration — allow GitHub Pages (static site), localhost
+    // (dev), and claude.ai (Claude.ai Connectors performs OAuth discovery
+    // + DCR from the browser and requires an origin echo with
+    // credentials: true).
     const corsOptions = {
       origin: [
         'https://danhannah94.github.io',
+        'https://claude.ai',
         /^http:\/\/localhost:\d+$/,  // Allow any localhost port
       ],
       credentials: true,


### PR DESCRIPTION
## Summary

Caught during the E12 smoke test: adding `foundry-claymore.fly.dev/mcp` as a Custom Connector in Claude.ai fails with *"Couldn't reach the MCP server"*, even though every endpoint on the server returns the right status/body when probed directly.

Root cause: `https://claude.ai` wasn't in Express's cors allowlist. The cors middleware saw the claude.ai Origin, didn't find a match, and silently responded **without** an `Access-Control-Allow-Origin` header. The browser then refused to hand the response up to the Claude.ai Connectors UI — so from Claude.ai's perspective the server was unreachable, even though the server log showed nothing wrong (because the failure happens entirely in the browser before the main request is even sent).

## Why nothing caught it earlier

- The in-repo E2E suite (#158) uses `supertest` — same-origin in-process, no preflight, no CORS.
- The conformance probe (#159) uses native `fetch` from node — not a browser, no CORS enforcement.
- Prior clients (Claude Code MCP, Cowork) connect server-to-server, not from a browser.

First actual browser-origin call was the smoke test. We'll want to either add a CORS integration test or wire the conformance probe to optionally send a browser-simulating `Origin: https://claude.ai` preflight before we consider this fully defended. Filing as a follow-up (not in this hotfix — keep the fix minimal).

## Fix

Add `'https://claude.ai'` to the cors allowlist. Specific origin (not wildcard) because `credentials: true` is set and the cors spec forbids `*` with credentials.

```diff
     const corsOptions = {
       origin: [
         'https://danhannah94.github.io',
+        'https://claude.ai',
         /^http:\/\/localhost:\d+$/,
       ],
       credentials: true,
     };
```

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] Existing 446 tests still pass (no CORS behavior was under test, so no regression surface)
- [ ] Post-deploy: `curl -i -X OPTIONS https://foundry-claymore.fly.dev/mcp -H "Origin: https://claude.ai" -H "Access-Control-Request-Method: POST"` should return `Access-Control-Allow-Origin: https://claude.ai`
- [ ] Post-deploy: Claude.ai Connector add flow completes end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)